### PR TITLE
Docs/clarify size is returned in bytes

### DIFF
--- a/item_size_calculator/README.md
+++ b/item_size_calculator/README.md
@@ -1,13 +1,13 @@
 # DynamoDB-ItemSizeCalculator
 
-> Utility tool to calculate the size of a DynamoDB items.
+> Utility tool to calculate the size of DynamoDB items.
 
 [![NPM Version][npm-image]][npm-url]
 [![Downloads Stats][npm-downloads]][npm-url]
 
-Utility tool to gain item size information for DynamoDB JSON items to understand capacity consumption and ensure items are under the 400KB DynamoDB limit.
+Utility tool to gain item size information in Bytes for DynamoDB JSON items. This allows us to understand capacity consumption and ensure items are under the 400KB DynamoDB item size limit.
 
-DynamoDB SDKs cater for both DDB-JSON or Native JSON. This package can be used to calculate both. By default, it uses DDB-JSON but you can alter the methods to take Native JSON by passing a bool `true` value as a parameter to the method:
+DynamoDB SDKs cater for both DDB-JSON and Native JSON. This package can be used to calculate both. By default, it uses DDB-JSON but you can alter methods to take Native JSON by passing boolean value `true` as a parameter to the method:
 
 ```js
 CalculateSize(item, true)
@@ -79,11 +79,11 @@ const size = CALC.CalculateSize(item);
 { 
     rcu: 1, 
     wcu: 1, 
-    size: 137 
+    size: 137 // in Bytes
 }
 ```
 
-### **Understand if an item is under the 400Kb limit**
+### **Understand if an item is under the 400KB limit**
 
 ```js
 const isValid = CALC.IsUnderLimit(item);
@@ -117,11 +117,11 @@ const size =  CALC.CalculateSize(item, true);
 { 
     rcu: 1, 
     wcu: 1, 
-    size: 137 
+    size: 137 // in Bytes
 }
 ```
 
-### **Understand if an item is under the 400Kb limit**
+### **Understand if an item is under the 400KB limit**
 
 ```js
 const isValid = CALC.IsUnderLimit(item, true);

--- a/item_size_calculator/README.md
+++ b/item_size_calculator/README.md
@@ -1,4 +1,5 @@
 # DynamoDB-ItemSizeCalculator
+
 > Utility tool to calculate the size of a DynamoDB items.
 
 [![NPM Version][npm-image]][npm-url]
@@ -6,10 +7,13 @@
 
 Utility tool to gain item size information for DynamoDB JSON items to understand capacity consumption and ensure items are under the 400KB DynamoDB limit.
 
-DynamoDB SDK's can cater for both DDB-JSON or Native JSON. This package can be used to calculate both. By default it uses DDB-JSON but you can alter the methods to take Native JSON by passing a bool `true` value as a parameter to the method:
-`CalculateSize(item, true)`
+DynamoDB SDKs cater for both DDB-JSON or Native JSON. This package can be used to calculate both. By default, it uses DDB-JSON but you can alter the methods to take Native JSON by passing a bool `true` value as a parameter to the method:
 
-![](https://www.cdata.com/blog/articles/20191018-dynamodb-performance-0.png)
+```js
+CalculateSize(item, true)
+```
+
+![DynamoDB Icon](https://www.cdata.com/blog/articles/20191018-dynamodb-performance-0.png)
 
 ## Installation
 
@@ -19,16 +23,17 @@ OS X & Linux:
 npm install ddb-calc --save
 ```
 
-
 ## Usage example  
   
 ### **Require**
- ```
+
+```js
 const CALC = require('ddb-calc')
- ```
+```
 
 ### **Sample DynamoDB JSON item**
-```
+
+```js
 const item = {
         "Id": {
             "N": "101"
@@ -62,14 +67,15 @@ const item = {
             "S": "Book"
         }
     }
-
 ```
 
 ### **Calculate Size**
+
+```js
+const size = CALC.CalculateSize(item);
 ```
-const size =  CALC.CalculateSize(item);
-```
-```
+
+```js
 { 
     rcu: 1, 
     wcu: 1, 
@@ -78,15 +84,14 @@ const size =  CALC.CalculateSize(item);
 ```
 
 ### **Understand if an item is under the 400Kb limit**
-```
+
+```js
 const isValid = CALC.IsUnderLimit(item);
-```
-```
-true
 ```
 
 ### **Sample Native JSON item**
-```
+
+```js
 const item = {
     "Id": 101,
     "Title": "Book 101 Title",
@@ -103,11 +108,12 @@ const item = {
 ```
 
 ### **Calculate Size**
-```
+
+```js
 const size =  CALC.CalculateSize(item, true);
 ```
 
-```
+```js
 { 
     rcu: 1, 
     wcu: 1, 
@@ -116,26 +122,24 @@ const size =  CALC.CalculateSize(item, true);
 ```
 
 ### **Understand if an item is under the 400Kb limit**
-```
+
+```js
 const isValid = CALC.IsUnderLimit(item, true);
-```
-```
-true
 ```
 
 ## Release History
-* 0.0.4
-    * Alter: Native JSON now supported by bool value: `CalculateSizeJson(item, true)`
-* 0.0.3
-    * ADD: Added native JSON functions `CalculateSizeJson()` and `IsUnderLimitJson()`
-* 0.0.2
-    * ADD: Added `marshalling` capability for native JSON
-* 0.0.1
-    * The first proper release
-    * ADD: Added `isUnderLimit()` function
-* 0.0.0
-    * Work in progress
 
+* 0.0.4
+  * Alter: Native JSON now supported by bool value: `CalculateSizeJson(item, true)`
+* 0.0.3
+  * ADD: Added native JSON functions `CalculateSizeJson()` and `IsUnderLimitJson()`
+* 0.0.2
+  * ADD: Added `marshalling` capability for native JSON
+* 0.0.1
+  * The first proper release
+  * ADD: Added `isUnderLimit()` function
+* 0.0.0
+  * Work in progress
 
 ## Contributing
 


### PR DESCRIPTION
Closes #26 

Changes exclusive to  Item Size Calculator README:

1. Clarifying unit of measure is Bytes for item size calculations.
2. Minor formatting and phrasing improvements elsewhere.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
