### PR TITLE
adding a check on event source type on the source stream

### DIFF
--- a/ddb-migration/README.md
+++ b/ddb-migration/README.md
@@ -5,7 +5,7 @@ This sample development project presents the content explained in the [DynamoDB 
 
 ## 🚀 Getting Started
 
-To execute this CDK project, you'll need to provide the `sourceTableArn` and the `destinationTableArn` DynamoDB table ARNs. For the source table you must enable DynamoDB Streams to project Old and New images for this solution to work properly.
+To execute this CDK project, you'll need to provide the `sourceTableArn` and the `destinationTableArn` DynamoDB table ARNs. For the source table you must enable DynamoDB Streams to project [`NEW_AND_OLD_IMAGES`](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_StreamSpecification.html) view type for this solution to work properly.
 
 📋 Before you begin, ensure your shell has credentials for the account you're operating in through your AWS profile or your environment variables.
 

--- a/ddb-migration/lambda/setup-check/index.py
+++ b/ddb-migration/lambda/setup-check/index.py
@@ -20,6 +20,7 @@ def handler(event, context):
         # Check if streams are enabled
         stream_specification = table['Table'].get('StreamSpecification', {})
         streams_enabled = stream_specification.get('StreamEnabled', False)
+        stream_view_type = stream_specification.get('StreamViewType', False)
         
         # Check PITR status
         pitr_description = dynamodb.describe_continuous_backups(TableName=table_name)
@@ -29,6 +30,8 @@ def handler(event, context):
         ex_message = list()
         if not streams_enabled:
             ex_message.append("DynamoDB Streams")
+        elif stream_view_type != "NEW_AND_OLD_IMAGES":
+            ex_message.append("DynamoDB Streams (NEW_AND_OLD_IMAGES view type)")
         if is_large and not pitr_enabled:
             ex_message.append("DynamoDB PITR")
 

--- a/ddb-migration/lib/ddb-migration-stack.ts
+++ b/ddb-migration/lib/ddb-migration-stack.ts
@@ -416,7 +416,7 @@ export class DdbMigrationStack extends cdk.Stack {
     );
 
     // Make and output a RBP for the destination DynamoDB table if this is x-account
-    if (destinationAccountId !== cdk.Aws.ACCOUNT_ID) {
+    if (destinationAccountId !== sourceAccountId) {
       const dynamoDbRbp = {
         Version: "2012-10-17",
         Statement: [


### PR DESCRIPTION
*Issue #, if available:*
#55 
*Description of changes:*
- Modify the setup and check Lambda to look for the correct stream specification, and return an error if it's wrong
- Bugfix: Update the CDK script to only output the RBP if the source and dest accounts are different.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
