### PR TITLE
feat: app --region support to metrics collector script

### DIFF
--- a/metrics-collector/README.md
+++ b/metrics-collector/README.md
@@ -29,19 +29,25 @@ This project is built with Poetry for dependency management. To get started:
 3. Alternatively, you can use pip with the provided `requirements.txt`:
 `pip install -r requirements.txt`
 
-The install might take a couple of minutes because of the dependencies. 
+The install might take a couple of minutes because of the dependencies.
 
 ## 🏃‍♂️ Usage
 
 Run the metrics collector with a single command:
 
 ```bash
+# Scan all regions
 python -m metrics_collector.utilization_example --start-time 2025-02-19
+
+# Scan only a specific region
+python -m metrics_collector.utilization_example --start-time 2025-02-19 --region us-east-1
+```
 
 Options:
 
 --start-time: Specify the start time for metric collection (ISO8601 format)
 --end-time: Specify the end time (defaults to current time if not provided)
+--region: AWS region to scan (if not specified, all regions will be scanned)
 --config: Path to a custom configuration file
 --output: Custom name for the output CSV file
 ```
@@ -161,9 +167,9 @@ This configuration flexibility allows you to tailor the metrics collection to yo
 
 There is a companion project in the making where we will simplify metric visualization. Stay tuned for future updates!
 
-Want to turn your CSV data into stunning visualizations? Check out our companion project DynamoDB Metrics Visualizer to create interactive dashboards and charts! 
+Want to turn your CSV data into stunning visualizations? Check out our companion project DynamoDB Metrics Visualizer to create interactive dashboards and charts!
 
-The current report will present data in csv 
+The current report will present data in csv
 
 | Region | Table Name | Read Utilization | Write Utilization |
 |--------|------------|------------------|-------------------|
@@ -196,4 +202,4 @@ We welcome contributions! Please see our Contributing Guide for more details.
 
 This project is licensed under the MIT License - see the [LICENSE](../LICENSE) file for details.
 
-Built with ❤️ by DynamoDB Specialist Solutions Architects. 
+Built with ❤️ by DynamoDB Specialist Solutions Architects.

--- a/metrics-collector/metrics_collector/utilization_example.py
+++ b/metrics-collector/metrics_collector/utilization_example.py
@@ -133,6 +133,11 @@ async def main():
     parser.add_argument("--start-time", type=str, help="Start time in ISO8601 format")
     parser.add_argument("--end-time", type=str, help="End time in ISO8601 format")
     parser.add_argument(
+        "--region",
+        type=str,
+        help="AWS region to scan (if not specified, all regions will be scanned)",
+    )
+    parser.add_argument(
         "--storage",
         choices=["disk", "memory"],
         default="disk",
@@ -170,7 +175,7 @@ async def main():
 
     logger.info(f"Collecting metrics from {start_time} to {end_time}")
 
-    all_metrics, low_utilization_tables = await collector.collect_all_metrics(start_time, end_time)
+    all_metrics, low_utilization_tables = await collector.collect_all_metrics(start_time, end_time, args.region)
 
     logger.info("Metrics collected and stored successfully.")
 


### PR DESCRIPTION
*Issue #, if available:*

Current script defaults to scanning 17 regions which for us fails due to IAM permissions. We noticed it only got as far as 12 regions and then quit so this PR adds a `--region` flag to allow scanning of a single region.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
