### PR TITLE
Improved tear down to delete inline policies as well, ensuring role gets deleted

### DIFF
--- a/bulk_executor/client/src/infrastructure/teardown.py
+++ b/bulk_executor/client/src/infrastructure/teardown.py
@@ -69,7 +69,7 @@ class TeardownInfrastructure:
 
         log.debug(f"Deleting role {role_name}...")
 
-        self._delete_managed_policies(role_name)
+        self._detach_managed_policies(role_name)
         self._delete_inline_policies(role_name)
 
         # Delete the role
@@ -102,7 +102,7 @@ class TeardownInfrastructure:
                 log.error(f"Unexpected error deleting inline policy {policy_name}: {e}")
                 exit(1)
 
-    def _delete_managed_policies(self, role_name):
+    def _detach_managed_policies(self, role_name):
         managed_policies = []
 
         # Verify the Role Exists and Get Attached Policies


### PR DESCRIPTION
*Description of changes:*
When `./bulk teardown` is executed it might fail as there are inline policies associated with the role. Teardown now deletes these inline policies first, allowing the role to be deleted


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
