### PR TITLE
Remove XRole/XRegion in Glue job DefaultArgs

### DIFF
--- a/bulk_executor/client/src/infrastructure/bootstrap.py
+++ b/bulk_executor/client/src/infrastructure/bootstrap.py
@@ -199,7 +199,7 @@ class BootstrapInfrastructure:
 
         # Add XEnvironmentArguments to be used by the Glue Job
         for key, value in args.items():
-            if key.startswith('X'):
+            if key.startswith('X') and key not in ('XRole', 'XRegion'):
                 default_arguments[f'--{key}'] = str(value)
 
         default_arguments.update({ # Update last intentional.


### PR DESCRIPTION
*Issue #, if available:* #85 

*Description of changes:*
Removes parameters `XRole` and `XRegion` into Glue job's `DefaultArguments` during bootstrap. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
