### PR TITLE
Optima readme install steps still had beta/ instead of tools/ for the path.

### DIFF
--- a/tools/dynamodb-optima/README.md
+++ b/tools/dynamodb-optima/README.md
@@ -88,7 +88,7 @@ DynamoDB Optima provides three types of cost optimization analysis for DynamoDB:
 ## 🚀 Installation
 
 ```bash
-cd beta/dynamodb-optima
+cd tools/dynamodb-optima
 
 # Install with development dependencies
 pip install -e ".[dev]"


### PR DESCRIPTION
*Description of changes:*
The readme install steps for optima were still referencing the beta directory for where the tools live, but it has been moved to tools/ instead, so this is just updating the readme to reflect the correct directory.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
