### PR TITLE
New copy command. Includes support for cross-account and cross-region…

### DIFF
--- a/tools/bulk_executor/client/src/python_modules/copy.py
+++ b/tools/bulk_executor/client/src/python_modules/copy.py
@@ -1,0 +1,39 @@
+import argparse
+import logging as log
+
+import utils
+from utils.custom_parser import BulkArgumentParser
+
+help_text = f"""
+    Purpose of "copy":
+        Copy items from one DynamoDB table to another (already-existing) table
+        Required --source parameter
+        Required --target parameter
+
+    Examples:
+        bulk copy --source tableOne --target tableTwo
+    """
+
+def run(env_configs):
+    glue_job_parent = utils.glue_job_arguments()
+    environment_parent = utils.environment_arguments()
+
+    # The Bulk Executor Action to be performed.
+    parser = BulkArgumentParser("bulk copy", help_text=help_text, parents=[glue_job_parent, environment_parent])
+    parser.add_argument('verb', help=argparse.SUPPRESS)
+    parser.add_argument('--source', required=True, type=str, help='Source table name')
+    parser.add_argument('--target', required=True, type=str, help='Target table name')
+    args = parser.parse_args()
+
+    #result = {k: v for k, v in vars(args).items() if v is not None}
+    result = args.__dict__
+
+    if result["source"] == result["target"]:
+        parser.error("--source and --target must be different DynamoDB tables")
+
+    utils.validate_tables(env_configs, parser, result['source'], result['target'], pitr_enabled=True, schemas_match=True)
+
+    log.info(f"Running action '{result['verb']}' with arguments: {result}")
+
+    # If all checks pass
+    return True, result

--- a/tools/bulk_executor/server/src/python_modules/copy.py
+++ b/tools/bulk_executor/server/src/python_modules/copy.py
@@ -1,0 +1,152 @@
+import sys
+
+import boto3
+from botocore.config import Config
+from pyspark import AccumulatorParam
+
+
+sys.path.append('/server/src')
+from python_modules.shared.errors import get_error_message
+from python_modules.shared.table_info import (
+    get_and_print_dynamodb_table_info,
+    get_and_print_table_scan_cost,
+    get_and_print_table_copy_write_cost,
+    get_dynamodb_throughput_configs,
+    _region_from_table_ref
+)
+
+from python_modules.shared.rate_limiter import (
+    RateLimiterAggregator,  
+    RateLimiterSharedConfig,
+    RateLimiterWorker
+)
+
+class ListAccumulator(AccumulatorParam):
+    def zero(self, initialValue):
+        return []
+            
+    def addInPlace(self, v1, v2):
+        v1.extend(v2)
+        return v1
+
+def print_dynamodb_table_info(source_table, target_table):
+    source_table_info = get_and_print_dynamodb_table_info(source_table)
+    scan_cost = get_and_print_table_scan_cost(source_table_info)
+
+    target_table_info = get_and_print_dynamodb_table_info(target_table)
+    write_cost = get_and_print_table_copy_write_cost(source_table_info, target_table_info)
+
+    total_cost = scan_cost + write_cost
+    print(f"TOTAL DynamoDB cost for scanning '{source_table}' and writing to '{target_table}' (approx): ${total_cost:,.2f}")
+    print()
+
+def run(job, spark_context, glue_context, parsed_args):
+    source_table = parsed_args.get('source')
+    target_table = parsed_args.get('target')
+
+    # Rate limiter configuration
+    bucket_name = parsed_args.get('s3-bucket-name')
+    job_run_id = parsed_args.get("JOB_RUN_ID")
+
+    print_dynamodb_table_info(source_table, target_table)
+
+    source_rate_limiter_shared_config = RateLimiterSharedConfig(
+        bucket=bucket_name,
+        job_run_id=f"{job_run_id}-source"
+    )
+
+    target_rate_limiter_shared_config = RateLimiterSharedConfig(
+        bucket=bucket_name,
+        job_run_id=f"{job_run_id}-target"
+    )
+
+    source_rate_limiter_aggregator = RateLimiterAggregator(shared_config=source_rate_limiter_shared_config)
+    target_rate_limiter_aggregator = RateLimiterAggregator(shared_config=target_rate_limiter_shared_config)
+
+    # Get monitor options for rate limiting
+    source_monitor_options = get_dynamodb_throughput_configs(parsed_args, source_table, modes=["read"], format="monitor")
+    target_monitor_options = get_dynamodb_throughput_configs(parsed_args, target_table, modes=["write"], format="monitor")
+
+    total_matched_accumulator = spark_context.accumulator(0)
+
+    # Since each task might generate errors, let's accumulate them and report intelligently
+    error_accumulator = spark_context.accumulator([], ListAccumulator())
+
+    # Distribute work among partitions, each knowing what segment it's to handle
+    try:
+        parallelize_count = 400
+        rdd = spark_context.parallelize(range(parallelize_count), parallelize_count)
+        rdd.foreach(lambda worker_id: _copy_data(source_table, target_table, source_monitor_options, target_monitor_options, worker_id, parallelize_count, total_matched_accumulator, error_accumulator, source_rate_limiter_shared_config, target_rate_limiter_shared_config))
+        #rdd.count()
+    except Exception as e:
+        raise Exception(f"Error in parallel execution: {get_error_message(e)}") from None
+    finally:
+        source_rate_limiter_aggregator.shutdown()
+        target_rate_limiter_aggregator.shutdown()
+    if error_accumulator.value:
+        first_error = error_accumulator.value[0]
+        raise Exception(first_error) from None
+
+    print(f"Total records copied: {total_matched_accumulator.value:,}")
+
+def _copy_data(source_table, target_table, source_monitor_options, target_monitor_options, segment, total_segments, total_matched_accumulator, error_accumulator, source_rate_limiter_shared_config, target_rate_limiter_shared_config):
+
+    # Let's hit the gas harder for this verb, at least for now XXX
+    source_rl = RateLimiterWorker(
+        shared_config=source_rate_limiter_shared_config,
+        **source_monitor_options,
+        worker_max_read_rate=2500, # up from 1,500 default
+    )
+    target_rl = RateLimiterWorker(
+        shared_config=target_rate_limiter_shared_config,
+        **target_monitor_options,
+        worker_max_write_rate=800, # up from 500 default
+    )
+
+    source_session = source_rl.get_session()
+    target_session = target_rl.get_session()
+
+    cfg = Config(
+        connect_timeout=4.0,
+        read_timeout=4.0,
+        retries={"mode": "standard", "total_max_attempts": 50},
+    )
+
+    # Talk to the right region if the table name is an ARN to a diff region
+    source_region = _region_from_table_ref(source_table) or source_session.region_name
+    target_region = _region_from_table_ref(target_table) or target_session.region_name
+
+    source_ddb = source_session.resource("dynamodb", config=cfg, region_name=source_region)
+    target_ddb   = target_session.resource("dynamodb", config=cfg, region_name=target_region)
+
+    src = source_ddb.Table(source_table)
+    dst = target_ddb.Table(target_table)
+
+    local_count = 0
+    scan_kwargs = {"Segment": segment, "TotalSegments": total_segments}
+
+    try:
+        with dst.batch_writer() as batch:
+            while True:
+                resp = src.scan(**scan_kwargs)
+
+                items = resp.get("Items", [])
+                for item in items:
+                    # optionally transform item here
+                    batch.put_item(Item=item)
+                local_count += len(items)
+
+                lek = resp.get("LastEvaluatedKey")
+                if not lek:
+                    break
+                scan_kwargs["ExclusiveStartKey"] = lek
+    except Exception as e:
+        error_accumulator.add([f"Error in worker {segment}: {get_error_message(e)}"])
+        # Let control drop down to exit
+    finally:
+        source_rl.shutdown()
+        target_rl.shutdown()
+
+    total_matched_accumulator.add(local_count)
+    print(f"Worker {segment}/{total_segments} copied {local_count} records.")
+    return local_count

--- a/tools/bulk_executor/server/src/python_modules/shared/table_info.py
+++ b/tools/bulk_executor/server/src/python_modules/shared/table_info.py
@@ -9,13 +9,10 @@ sys.path.append('/server/src')
 from python_modules.shared.logger import log
 from python_modules.shared.pricing import PricingUtility
 
-dynamodb = boto3.client('dynamodb')
-service_quotas = boto3.client('service-quotas')
-
 MIN_RECOMMENDED_READ_RATE = 100
 MIN_RECOMMENDED_WRITE_RATE = 100
 
-def get_quota_value(quota_name):
+def get_quota_value(quota_name, region_name):
     """
     Get the value of a specific DynamoDB quota from Service Quotas API.
     Returns None if the quota cannot be found or if there's an error.
@@ -34,6 +31,7 @@ def get_quota_value(quota_name):
         quota_code = quota_codes[quota_name]
 
         # Get the quota value
+        service_quotas = boto3.client('service-quotas', region_name=region_name)
         response = service_quotas.get_service_quota(
             ServiceCode='dynamodb',
             QuotaCode=quota_code
@@ -60,7 +58,12 @@ def get_quota_value(quota_name):
         return None
 
 def get_and_print_dynamodb_table_info(table_name, index_name=None):
-    autoscaling = boto3.client('application-autoscaling')
+    region_name = _region_from_table_ref(table_name) or _default_region()
+    if not region_name:
+        raise ValueError("Unable to determine region_name for DynamoDB call.")
+
+    autoscaling = boto3.client('application-autoscaling', region_name=region_name)
+    dynamodb = boto3.client('dynamodb', region_name=region_name)
 
     # Get table description
     response = dynamodb.describe_table(TableName=table_name)
@@ -182,6 +185,8 @@ def get_and_print_dynamodb_table_info(table_name, index_name=None):
     log.info("")
 
     return {
+        'table_name': table_name,
+        'region_name': region_name,
         'billing_mode': billing_mode,
         'write_pricing_category': write_pricing_category,
         'read_pricing_category': read_pricing_category,
@@ -189,7 +194,13 @@ def get_and_print_dynamodb_table_info(table_name, index_name=None):
         'size_bytes': size_bytes
     }
 
-def get_and_print_table_scan_cost(table_info, region_name, fraction=1.0, numberOfScans=1):
+def get_and_print_table_scan_cost(table_info, region_name=None, fraction=1.0, numberOfScans=1):
+    region_name = (
+        region_name
+        or table_info.get("region_name")
+        or _default_region()
+    )
+
     read_units = math.ceil(int(table_info['size_bytes']) / 8096)
 
     log.info(f"DynamoDB read costs depend on the table size.")
@@ -204,7 +215,7 @@ def get_and_print_table_scan_cost(table_info, region_name, fraction=1.0, numberO
 
     pricing_utility = PricingUtility()
     ondemand_pricing = pricing_utility.get_on_demand_capacity_pricing(region_name)
-    rru_cost = float(ondemand_pricing.get(table_info['read_pricing_category']))
+    rru_cost = float(ondemand_pricing[table_info['read_pricing_category']])
     od_cost = read_units * rru_cost
     prov_cost = od_cost / 1.5  # very rough, look into updating this
     if table_info['billing_mode'] == "PROVISIONED":
@@ -215,7 +226,43 @@ def get_and_print_table_scan_cost(table_info, region_name, fraction=1.0, numberO
         return od_cost
     return 0
 
+def get_and_print_table_copy_write_cost(source_info, target_info):
+    region_name = (
+        target_info.get("region_name") # it's the target we price writes in
+        or _default_region()
+    )
+
+    item_count = source_info['item_count']
+    if item_count == 0:
+        avg_write_units = 0
+        write_units = 0
+    else:
+        item_size = source_info['size_bytes'] / item_count
+        avg_write_units = math.ceil(item_size / 1024)
+        write_units = item_count * avg_write_units
+
+    log.info(f"DynamoDB write costs depend on the number and size of items written.")
+    log.info(f"DynamoDB write units required to write {item_count:,} items of {avg_write_units} average write units (approx): {write_units:,}")
+
+    pricing_utility = PricingUtility()
+    ondemand_pricing = pricing_utility.get_on_demand_capacity_pricing(region_name)
+    wru_cost = float(ondemand_pricing[target_info["write_pricing_category"]])
+    od_cost = write_units * wru_cost
+    prov_cost = od_cost / 1.5  # very rough, look into updating this
+    if target_info['billing_mode'] == "PROVISIONED":
+        log.info(f"Approx DynamoDB cost for provisioned writes consuming {write_units:,} WCUs (using {region_name} prices): ${prov_cost:,.2f}\n")
+        return prov_cost
+    elif target_info['billing_mode'] == "PAY_PER_REQUEST":
+        log.info(f"Approx DynamoDB cost for on-demand writes consuming {write_units:,} WRUs (using {region_name} prices): ${od_cost:,.2f}\n")
+        return od_cost
+    return 0
+
 def get_dynamodb_throughput_configs(args, table_name, modes=None, format="connector"):
+    region_name = _region_from_table_ref(table_name) or _default_region()
+    if not region_name:
+        raise ValueError("Unable to determine region_name for DynamoDB call.")
+    dynamodb = boto3.client('dynamodb', region_name=region_name)
+
     if modes is None:
         modes = ("read", "write")
 
@@ -246,7 +293,7 @@ def get_dynamodb_throughput_configs(args, table_name, modes=None, format="connec
 
             if table_read_limit is None:
                 # Try to get account-level quota
-                quota_read_limit = get_quota_value("Table-level read throughput limit")
+                quota_read_limit = get_quota_value("Table-level read throughput limit", region_name)
                 if quota_read_limit is not None:
                     read_rate = quota_read_limit
                     log.info(f"Max read rate set to account quota limit: {read_rate}")
@@ -279,7 +326,7 @@ def get_dynamodb_throughput_configs(args, table_name, modes=None, format="connec
 
             if table_write_limit is None:
                 # Try to get account-level quota
-                quota_write_limit = get_quota_value("Table-level write throughput limit")
+                quota_write_limit = get_quota_value("Table-level write throughput limit", region_name)
                 if quota_write_limit is not None:
                     write_rate = quota_write_limit
                     log.info(f"Max write rate set to account quota limit: {write_rate}")
@@ -358,4 +405,45 @@ def get_dynamodb_throughput_configs(args, table_name, modes=None, format="connec
 
     else:
         raise ValueError(f"Unrecognized value for 'format': {format}")
+
+# If they pass an ARN we want to read the components out
+
+def _default_region():
+    return (
+        boto3.Session().region_name
+        or os.environ.get("AWS_REGION")
+        or os.environ.get("AWS_DEFAULT_REGION")
+    )
+
+def _parse_arn(arn: str) -> dict:
+    """
+    Minimal ARN parser.
+    Returns dict with: partition, service, region, account, resource.
+    Raises ValueError if malformed.
+    """
+    parts = arn.split(":", 5)
+
+    if len(parts) != 6 or parts[0] != "arn":
+        raise ValueError(f"Invalid ARN: {arn}")
+
+    _, partition, service, region, account, resource = parts
+
+    return {
+        "partition": partition,
+        "service": service,
+        "region": region,
+        "account": account,
+        "resource": resource,
+    }
+
+def _region_from_table_ref(table_ref: str) -> str | None:
+    if not table_ref or not table_ref.startswith("arn:"):
+        return None
+    arn = _parse_arn(table_ref)
+    if arn.get("service") != "dynamodb":
+        return None
+    # Expect resource like "table/MyTable"
+    if not arn.get("resource", "").startswith("table/"):
+        return None
+    return arn.get("region")
 


### PR DESCRIPTION
… reads and writes to help copying tables between accounts and/or regions.

*Issue #, if available:* 
93

*Description of changes:*

New `copy` command that reads from one table and writes to another. Includes special handling for cross-region and cross-account access, just specify the `--source` or `--target` table as an ARN instead of a name. 

Avoids reading the whole table in memory. Instead it runs a tight read-then-write loop in each Glue task. Breaks the table into (for now) 400 segments that can run in parallel. Uses the rate limiter so each thread does max 500 WCUs.

Could easily in the future add a `--filter-expression` to copy only a subset. Or a python function hook to modify the data as it goes.

Could in the future try having way more segments, giving each Glue task a random bunch of segment identifiers, and having each Glue job run parallel threads with one thread for each segment. Avoided that now for the sake of code simplicity.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
