### PR TITLE
Typo fixing table1 to be table2 in monitor options

### DIFF
--- a/tools/bulk_executor/server/src/python_modules/diff.py
+++ b/tools/bulk_executor/server/src/python_modules/diff.py
@@ -344,7 +344,7 @@ def run(job, spark_context, glue_context, parsed_args):
     rate_limiter_aggregator = RateLimiterAggregator(shared_config=rate_limiter_shared_config)
 
     monitor_options_1 = get_dynamodb_throughput_configs(parsed_args, table1, modes=("read"), format="monitor")
-    monitor_options_2 = get_dynamodb_throughput_configs(parsed_args, table1, modes=("read"), format="monitor")
+    monitor_options_2 = get_dynamodb_throughput_configs(parsed_args, table2, modes=("read"), format="monitor")
 
     try:
         rdd2 = rdd.map(lambda worker_id: diff_segment(table1, table2, monitor_options_1, monitor_options_2, worker_id, splits, False, diff_type == 'keys', job_id, use_s3, bucket, broadcast_schema, rate_limiter_shared_config)).collect()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Noticed a typo in the diff monitoring logic where it looked at table1 metrics for rate limiting the second table when it should of course be looking at table2.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
