### PR TITLE
Bulk Executor load - S3 directory support

### DIFF
--- a/tools/bulk_executor/server/src/python_modules/load/__init__.py
+++ b/tools/bulk_executor/server/src/python_modules/load/__init__.py
@@ -145,7 +145,9 @@ def check_s3_file_exists(s3_uri):
         return True
     except ClientError as e:
         if e.response['Error']['Code'] == '404':
-            return False
+            # Check if it's a prefix containing objects
+            resp = s3.list_objects_v2(Bucket=bucket_name, Prefix=key, MaxKeys=1)
+            return resp.get('KeyCount', 0) > 0
         else:
             # Something else went wrong
             raise


### PR DESCRIPTION
Modified check_s3_file_exists() to allow S3 paths that contain objects, not just objects directly, to allow load to ingest multiple files in a single execution.