### PR TITLE
Remove XRole, XRegion, XAccount from Glue job DefaultArgs

### DIFF
--- a/tools/bulk_executor/client/src/infrastructure/bootstrap.py
+++ b/tools/bulk_executor/client/src/infrastructure/bootstrap.py
@@ -199,9 +199,12 @@ class BootstrapInfrastructure:
 
         default_arguments = {}
 
-        # Add XEnvironmentArguments to be used by the Glue Job
+        # Add XEnvironmentArguments to be used by the Glue Job.
+        # XRole, XRegion, and XAccount are bootstrap-time / client-side
+        # concerns and are not needed at job runtime, so they are excluded
+        # from DefaultArguments. See issue #85.
         for key, value in args.items():
-            if key.startswith('X'):
+            if key.startswith('X') and key not in ('XRole', 'XRegion', 'XAccount'):
                 default_arguments[f'--{key}'] = str(value)
 
         default_arguments.update({ # Update last intentional.


### PR DESCRIPTION
Closes #85.

`XRole`, `XRegion`, and `XAccount` are read at bootstrap / client-construction time, not at Glue runtime. Persisting them in the Glue job's `DefaultArguments` is dead state — nothing reads them later, server or client.

The chosen role remains visible via `--glue-job-role-name` (canonical key, read by `teardown.py` as source of truth).

Carries forward @parikhsachi's #109; extends to also cover XAccount.

Test coverage for this change lives in #152, alongside the test framework cleanup. The exclusion tests in `tests/client/test_bootstrap.py` (TestXRoleXRegionExclusion, TestXAccountExclusion, TestRoleNameStillPersisted) verify this fix and are part of #152.

Co-authored-by: Sachi Parikh <parikhsachi@users.noreply.github.com>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
