### PR TITLE
Improve help command to match actual command

### DIFF
--- a/tools/bulk_executor/bulk
+++ b/tools/bulk_executor/bulk
@@ -29,7 +29,7 @@ def _show_missing_module(action):
         import os
         files = os.listdir(path)
         modules = [
-            f[:-3] for f in files
+            f[:-3].replace('_', '-') for f in files
             if f.endswith('.py') and not f.startswith('__')
         ]
         for module in sorted(modules):


### PR DESCRIPTION
*Description of changes:*
`./bulk help` now prints the correct command texts replacing `_` with `-` as needed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
