### PR TITLE
Fix _jsonify_message extracting wrong regex group in bulk_executor

### DIFF
--- a/tools/bulk_executor/client/src/runner.py
+++ b/tools/bulk_executor/client/src/runner.py
@@ -73,7 +73,7 @@ class BulkDynamoDbRunner:
         if json_match:
             try:
                 # Get the JSON part
-                json_str = json_match.group(1)
+                json_str = json_match.group(3)
                 parsed_json = json.loads(json_str)
 
                 # Print the prefix (non-JSON part)

--- a/tools/bulk_executor/tests/client/test_runner.py
+++ b/tools/bulk_executor/tests/client/test_runner.py
@@ -201,14 +201,11 @@ class TestJsonifyMessage:
         # Falls through to fix_newlines (no escapes → identity).
         assert result == 'INFO log message {"a":1}'
 
-    def test_message_matching_error_pattern_falls_back_on_decode_error(self, bulk_runner):
-        # Even a message that matches the regex falls back to _fix_newlines
-        # because the implementation parses group(1) which is the prefix,
-        # not the JSON. This is a known quirk; tests pin current behavior.
+    def test_message_matching_error_pattern_pretty_prints_json(self, bulk_runner):
         msg = 'ERROR something bad {"key": "value"}'
         result = bulk_runner._jsonify_message(msg)
-        # Whatever the result, it should equal _fix_newlines(msg) on fallback.
-        assert result == msg.replace('\\n', '\n').replace('\\t', '\t')
+        expected = 'ERROR something bad \n{\n  "key": "value"\n}'
+        assert result == expected
 
 
 # --- _pretty_print_log_event ------------------------------------------------


### PR DESCRIPTION
## Summary
Fix a regex capture-group bug in `bulk_executor`'s `_jsonify_message` that made embedded-JSON pretty-printing dead code.

In `client/src/runner.py`, `_jsonify_message` extracted `json_match.group(1)` (the log prefix) instead of `group(3)` (the JSON payload). The regex `^(.*\b(ERROR|WARN|EXCEPTION)\b.*?)({...}|[...])$` has: group(1)=prefix, group(2)=severity, group(3)=JSON. Parsing group(1) always raised `JSONDecodeError`, so the `except` branch always fired and JSON was never pretty-printed.

## Changes
- `runner.py:76`: `group(1)` → `group(3)`
- `tests/client/test_runner.py`: the existing test pinned the buggy fallback behavior (commented as a "known quirk"). Updated it to assert JSON is now pretty-printed.

## Testing
`make test` → 1273 passed, line coverage 99.7%, branch coverage 96.8% (baseline held).

---
🤖 This change was identified and authored by an experimental automated code-quality agent ("dark factory") and is being submitted for human review. Flagging the provenance for transparency.