### PR TITLE
ci: GitHub Actions CI pipeline for bulk_executor

### DIFF
--- a/.github/scripts/e2e-bootstrap.sh
+++ b/.github/scripts/e2e-bootstrap.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Bootstrap GitHub Actions e2e infrastructure in a given AWS account.
+# Creates: OIDC identity provider, IAM role, inline policy, GitHub secrets.
+#
+# Prerequisites:
+#   - AWS CLI authenticated to the target account (Admin role)
+#   - gh CLI authenticated with repo admin access
+#   - jq installed
+#
+# Usage:
+#   .github/scripts/e2e-bootstrap.sh \
+#     --account-id 123456789012 \
+#     --region us-east-1 \
+#     --read-table tiny-boat \
+#     --write-table mini-boat \
+#     --repos "awslabs/amazon-dynamodb-tools,relentlesscol/amazon-dynamodb-tools"
+
+ROLE_NAME="github-actions-e2e-runner"
+POLICY_NAME="e2e-test-access"
+
+usage() {
+  echo "Usage: $0 --account-id ID --region REGION --read-table TABLE --write-table TABLE --repos REPO1,REPO2"
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --account-id) ACCOUNT_ID="$2"; shift 2 ;;
+    --region) REGION="$2"; shift 2 ;;
+    --read-table) READ_TABLE="$2"; shift 2 ;;
+    --write-table) WRITE_TABLE="$2"; shift 2 ;;
+    --repos) IFS=',' read -ra REPOS <<< "$2"; shift 2 ;;
+    *) usage ;;
+  esac
+done
+
+[[ -z "${ACCOUNT_ID:-}" || -z "${REGION:-}" || -z "${READ_TABLE:-}" || -z "${WRITE_TABLE:-}" || ${#REPOS[@]} -eq 0 ]] && usage
+
+echo "==> Bootstrapping e2e CI in account ${ACCOUNT_ID} (${REGION})"
+
+# --- OIDC Provider ---
+OIDC_ARN="arn:aws:iam::${ACCOUNT_ID}:oidc-provider/token.actions.githubusercontent.com"
+if aws iam get-open-id-connect-provider --open-id-connect-provider-arn "${OIDC_ARN}" >/dev/null 2>&1; then
+  echo "    OIDC provider already exists, skipping"
+else
+  echo "    Creating OIDC provider..."
+  aws iam create-open-id-connect-provider \
+    --url "https://token.actions.githubusercontent.com" \
+    --client-id-list "sts.amazonaws.com" \
+    --thumbprint-list "6938fd4d98bab03faadb97b34396831e3780aea1" "1c58a3a8518e8759bf075b76b750d4f2df264fcd" \
+    --output text --query 'OpenIDConnectProviderArn'
+fi
+
+# --- Trust Policy ---
+SUB_CONDITIONS=$(printf '"%s"' "repo:${REPOS[0]}:ref:refs/heads/main")
+for repo in "${REPOS[@]:1}"; do
+  SUB_CONDITIONS+=", \"repo:${repo}:ref:refs/heads/main\""
+done
+
+TRUST_POLICY=$(cat <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "${OIDC_ARN}"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+        },
+        "StringLike": {
+          "token.actions.githubusercontent.com:sub": [${SUB_CONDITIONS}]
+        }
+      }
+    }
+  ]
+}
+EOF
+)
+
+# --- IAM Role ---
+ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
+if aws iam get-role --role-name "${ROLE_NAME}" >/dev/null 2>&1; then
+  echo "    Role ${ROLE_NAME} exists, updating trust policy..."
+  aws iam update-assume-role-policy --role-name "${ROLE_NAME}" --policy-document "${TRUST_POLICY}"
+else
+  echo "    Creating role ${ROLE_NAME}..."
+  aws iam create-role \
+    --role-name "${ROLE_NAME}" \
+    --assume-role-policy-document "${TRUST_POLICY}" \
+    --description "GitHub Actions role for bulk_executor e2e tests" \
+    --output text --query 'Role.Arn'
+fi
+
+# --- Inline Policy ---
+echo "    Attaching inline policy ${POLICY_NAME}..."
+PERMISSIONS_POLICY=$(cat <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "DynamoDBNamedTables",
+      "Effect": "Allow",
+      "Action": [
+        "dynamodb:BatchGetItem",
+        "dynamodb:BatchWriteItem",
+        "dynamodb:DeleteItem",
+        "dynamodb:DescribeTable",
+        "dynamodb:GetItem",
+        "dynamodb:PutItem",
+        "dynamodb:Query",
+        "dynamodb:Scan",
+        "dynamodb:UpdateItem",
+        "dynamodb:DescribeExport",
+        "dynamodb:ExportTableToPointInTime",
+        "dynamodb:DescribeContinuousBackups",
+        "dynamodb:UpdateContinuousBackups"
+      ],
+      "Resource": [
+        "arn:aws:dynamodb:${REGION}:${ACCOUNT_ID}:table/${READ_TABLE}",
+        "arn:aws:dynamodb:${REGION}:${ACCOUNT_ID}:table/${READ_TABLE}/*",
+        "arn:aws:dynamodb:${REGION}:${ACCOUNT_ID}:table/${WRITE_TABLE}",
+        "arn:aws:dynamodb:${REGION}:${ACCOUNT_ID}:table/${WRITE_TABLE}/*"
+      ]
+    },
+    {
+      "Sid": "DynamoDBTransientTables",
+      "Effect": "Allow",
+      "Action": [
+        "dynamodb:CreateTable",
+        "dynamodb:DeleteTable",
+        "dynamodb:DescribeTable",
+        "dynamodb:BatchGetItem",
+        "dynamodb:BatchWriteItem",
+        "dynamodb:DeleteItem",
+        "dynamodb:GetItem",
+        "dynamodb:PutItem",
+        "dynamodb:Query",
+        "dynamodb:Scan",
+        "dynamodb:UpdateItem",
+        "dynamodb:UpdateContinuousBackups",
+        "dynamodb:DescribeContinuousBackups",
+        "dynamodb:TagResource"
+      ],
+      "Resource": [
+        "arn:aws:dynamodb:${REGION}:${ACCOUNT_ID}:table/bulk-e2e-*"
+      ]
+    },
+    {
+      "Sid": "GlueJobAccess",
+      "Effect": "Allow",
+      "Action": [
+        "glue:GetJob",
+        "glue:GetJobRun",
+        "glue:GetJobRuns",
+        "glue:StartJobRun",
+        "glue:BatchStopJobRun"
+      ],
+      "Resource": [
+        "arn:aws:glue:${REGION}:${ACCOUNT_ID}:job/bulk_dynamodb"
+      ]
+    },
+    {
+      "Sid": "S3GlueBucket",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:ListBucket",
+        "s3:DeleteObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::aws-glue-bulk-dynamodb-*",
+        "arn:aws:s3:::aws-glue-bulk-dynamodb-*/*"
+      ]
+    },
+    {
+      "Sid": "PassGlueRole",
+      "Effect": "Allow",
+      "Action": "iam:PassRole",
+      "Resource": "arn:aws:iam::${ACCOUNT_ID}:role/AWSGlueServiceRole*",
+      "Condition": {
+        "StringEquals": {
+          "iam:PassedToService": "glue.amazonaws.com"
+        }
+      }
+    },
+    {
+      "Sid": "CloudWatchLogsRead",
+      "Effect": "Allow",
+      "Action": [
+        "logs:DescribeLogGroups",
+        "logs:DescribeLogStreams",
+        "logs:GetLogEvents",
+        "logs:FilterLogEvents",
+        "logs:StartLiveTail"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "STSIdentity",
+      "Effect": "Allow",
+      "Action": "sts:GetCallerIdentity",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+)
+
+aws iam put-role-policy \
+  --role-name "${ROLE_NAME}" \
+  --policy-name "${POLICY_NAME}" \
+  --policy-document "${PERMISSIONS_POLICY}"
+
+# --- GitHub Secrets ---
+echo "    Setting GitHub secrets..."
+for repo in "${REPOS[@]}"; do
+  echo "      ${repo}"
+  gh secret set E2E_AWS_ROLE_ARN   --repo "${repo}" --body "${ROLE_ARN}"
+  gh secret set E2E_AWS_ACCOUNT_ID --repo "${repo}" --body "${ACCOUNT_ID}"
+  gh secret set E2E_AWS_REGION     --repo "${repo}" --body "${REGION}"
+  gh secret set E2E_READ_TABLE     --repo "${repo}" --body "${READ_TABLE}"
+  gh secret set E2E_WRITE_TABLE    --repo "${repo}" --body "${WRITE_TABLE}"
+done
+
+echo ""
+echo "==> Bootstrap complete"
+echo "    OIDC:    ${OIDC_ARN}"
+echo "    Role:    ${ROLE_ARN}"
+echo "    Repos:   ${REPOS[*]}"
+echo "    Region:  ${REGION}"
+echo "    Tables:  ${READ_TABLE} (read), ${WRITE_TABLE} (write)"

--- a/.github/scripts/e2e-switch-account.sh
+++ b/.github/scripts/e2e-switch-account.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Switch e2e CI from one AWS account to another.
+# Tears down the old account, bootstraps the new one.
+#
+# Prerequisites:
+#   - AWS CLI authenticated to the OLD account (for teardown)
+#   - You'll be prompted to switch credentials before bootstrap
+#
+# Usage:
+#   .github/scripts/e2e-switch-account.sh \
+#     --old-account-id 654654401288 \
+#     --new-account-id 111222333444 \
+#     --region us-east-1 \
+#     --read-table tiny-boat \
+#     --write-table mini-boat \
+#     --repos "awslabs/amazon-dynamodb-tools,relentlesscol/amazon-dynamodb-tools"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+usage() {
+  echo "Usage: $0 --old-account-id ID --new-account-id ID --region REGION --read-table TABLE --write-table TABLE --repos REPO1,REPO2"
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --old-account-id) OLD_ACCOUNT="$2"; shift 2 ;;
+    --new-account-id) NEW_ACCOUNT="$2"; shift 2 ;;
+    --region) REGION="$2"; shift 2 ;;
+    --read-table) READ_TABLE="$2"; shift 2 ;;
+    --write-table) WRITE_TABLE="$2"; shift 2 ;;
+    --repos) REPOS="$2"; shift 2 ;;
+    *) usage ;;
+  esac
+done
+
+[[ -z "${OLD_ACCOUNT:-}" || -z "${NEW_ACCOUNT:-}" || -z "${REGION:-}" || -z "${READ_TABLE:-}" || -z "${WRITE_TABLE:-}" || -z "${REPOS:-}" ]] && usage
+
+echo "╔══════════════════════════════════════════════════╗"
+echo "║  E2E Account Switch: ${OLD_ACCOUNT} → ${NEW_ACCOUNT}  ║"
+echo "╚══════════════════════════════════════════════════╝"
+echo ""
+
+# --- Phase 1: Teardown old account ---
+echo "── Phase 1: Teardown (account ${OLD_ACCOUNT}) ──"
+echo ""
+echo "Ensure AWS CLI is authenticated to ${OLD_ACCOUNT}."
+read -rp "Press Enter to continue (or Ctrl+C to abort)..."
+echo ""
+
+"${SCRIPT_DIR}/e2e-teardown.sh" --account-id "${OLD_ACCOUNT}" --repos "${REPOS}"
+
+echo ""
+
+# --- Phase 2: Bootstrap new account ---
+echo "── Phase 2: Bootstrap (account ${NEW_ACCOUNT}) ──"
+echo ""
+echo "Switch AWS CLI credentials to ${NEW_ACCOUNT} now."
+echo "  e.g.: ada credentials update --account ${NEW_ACCOUNT} --provider isengard --role Admin --once"
+echo ""
+read -rp "Press Enter when ready (or Ctrl+C to abort)..."
+echo ""
+
+"${SCRIPT_DIR}/e2e-bootstrap.sh" \
+  --account-id "${NEW_ACCOUNT}" \
+  --region "${REGION}" \
+  --read-table "${READ_TABLE}" \
+  --write-table "${WRITE_TABLE}" \
+  --repos "${REPOS}"
+
+echo ""
+echo "==> Account switch complete: ${OLD_ACCOUNT} → ${NEW_ACCOUNT}"

--- a/.github/scripts/e2e-switch-account.sh
+++ b/.github/scripts/e2e-switch-account.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 #
 # Usage:
 #   .github/scripts/e2e-switch-account.sh \
-#     --old-account-id 654654401288 \
+#     --old-account-id 111111111111 \
 #     --new-account-id 111222333444 \
 #     --region us-east-1 \
 #     --read-table tiny-boat \

--- a/.github/scripts/e2e-teardown.sh
+++ b/.github/scripts/e2e-teardown.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Tear down GitHub Actions e2e infrastructure from a given AWS account.
+# Removes: inline policy, IAM role, OIDC provider, GitHub secrets.
+#
+# Usage:
+#   .github/scripts/e2e-teardown.sh \
+#     --account-id 123456789012 \
+#     --repos "awslabs/amazon-dynamodb-tools,relentlesscol/amazon-dynamodb-tools"
+
+ROLE_NAME="github-actions-e2e-runner"
+POLICY_NAME="e2e-test-access"
+
+usage() {
+  echo "Usage: $0 --account-id ID --repos REPO1,REPO2"
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --account-id) ACCOUNT_ID="$2"; shift 2 ;;
+    --repos) IFS=',' read -ra REPOS <<< "$2"; shift 2 ;;
+    *) usage ;;
+  esac
+done
+
+[[ -z "${ACCOUNT_ID:-}" || ${#REPOS[@]} -eq 0 ]] && usage
+
+echo "==> Tearing down e2e CI from account ${ACCOUNT_ID}"
+
+# --- Inline Policy ---
+if aws iam get-role-policy --role-name "${ROLE_NAME}" --policy-name "${POLICY_NAME}" >/dev/null 2>&1; then
+  echo "    Deleting inline policy ${POLICY_NAME}..."
+  aws iam delete-role-policy --role-name "${ROLE_NAME}" --policy-name "${POLICY_NAME}"
+else
+  echo "    No inline policy found, skipping"
+fi
+
+# --- IAM Role ---
+if aws iam get-role --role-name "${ROLE_NAME}" >/dev/null 2>&1; then
+  echo "    Deleting role ${ROLE_NAME}..."
+  aws iam delete-role --role-name "${ROLE_NAME}"
+else
+  echo "    No role found, skipping"
+fi
+
+# --- OIDC Provider ---
+OIDC_ARN="arn:aws:iam::${ACCOUNT_ID}:oidc-provider/token.actions.githubusercontent.com"
+if aws iam get-open-id-connect-provider --open-id-connect-provider-arn "${OIDC_ARN}" >/dev/null 2>&1; then
+  echo "    Deleting OIDC provider..."
+  aws iam delete-open-id-connect-provider --open-id-connect-provider-arn "${OIDC_ARN}"
+else
+  echo "    No OIDC provider found, skipping"
+fi
+
+# --- GitHub Secrets ---
+echo "    Removing GitHub secrets..."
+for repo in "${REPOS[@]}"; do
+  echo "      ${repo}"
+  gh secret delete E2E_AWS_ROLE_ARN   --repo "${repo}" 2>/dev/null || true
+  gh secret delete E2E_AWS_ACCOUNT_ID --repo "${repo}" 2>/dev/null || true
+  gh secret delete E2E_AWS_REGION     --repo "${repo}" 2>/dev/null || true
+  gh secret delete E2E_READ_TABLE     --repo "${repo}" 2>/dev/null || true
+  gh secret delete E2E_WRITE_TABLE    --repo "${repo}" 2>/dev/null || true
+done
+
+echo ""
+echo "==> Teardown complete for account ${ACCOUNT_ID}"

--- a/.github/workflows/bulk-executor-connector-smoke.yml
+++ b/.github/workflows/bulk-executor-connector-smoke.yml
@@ -1,0 +1,58 @@
+name: "bulk_executor: connector smoke"
+
+on:
+  workflow_run:
+    workflows: ["bulk_executor: unit tests"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  connector-smoke:
+    runs-on: ubuntu-latest
+    if: >
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       (github.repository == 'awslabs/amazon-dynamodb-tools' || github.repository == 'relentlesscol/amazon-dynamodb-tools'))
+    defaults:
+      run:
+        working-directory: tools/bulk_executor
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m venv .venv
+          .venv/bin/pip install --upgrade pip
+          .venv/bin/pip install -r requirements.txt
+          .venv/bin/pip install -r tests/requirements-test.txt
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.E2E_AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.E2E_AWS_REGION }}
+
+      - name: Write e2e config
+        env:
+          E2E_ACCOUNT: ${{ secrets.E2E_AWS_ACCOUNT_ID }}
+          E2E_REGION: ${{ secrets.E2E_AWS_REGION }}
+          E2E_READ: ${{ secrets.E2E_READ_TABLE }}
+          E2E_WRITE: ${{ secrets.E2E_WRITE_TABLE }}
+        run: |
+          printf '{"aws_account_id":"%s","aws_region":"%s","read_table":"%s","write_table":"%s","bootstrap_confirmed":true}\n' \
+            "$E2E_ACCOUNT" "$E2E_REGION" "$E2E_READ" "$E2E_WRITE" > tests/e2e/.e2e-config
+
+      - name: Run connector smoke
+        run: |
+          .venv/bin/pytest tests/e2e/connector/ -m e2e -v --tb=short --e2e-suite "connector smoke"

--- a/.github/workflows/bulk-executor-e2e-copy.yml
+++ b/.github/workflows/bulk-executor-e2e-copy.yml
@@ -1,0 +1,58 @@
+name: "bulk_executor: e2e copy"
+
+on:
+  workflow_run:
+    workflows: ["bulk_executor: connector smoke"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  e2e-copy:
+    runs-on: ubuntu-latest
+    if: >
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       (github.repository == 'awslabs/amazon-dynamodb-tools' || github.repository == 'relentlesscol/amazon-dynamodb-tools'))
+    defaults:
+      run:
+        working-directory: tools/bulk_executor
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m venv .venv
+          .venv/bin/pip install --upgrade pip
+          .venv/bin/pip install -r requirements.txt
+          .venv/bin/pip install -r tests/requirements-test.txt
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.E2E_AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.E2E_AWS_REGION }}
+
+      - name: Write e2e config
+        env:
+          E2E_ACCOUNT: ${{ secrets.E2E_AWS_ACCOUNT_ID }}
+          E2E_REGION: ${{ secrets.E2E_AWS_REGION }}
+          E2E_READ: ${{ secrets.E2E_READ_TABLE }}
+          E2E_WRITE: ${{ secrets.E2E_WRITE_TABLE }}
+        run: |
+          printf '{"aws_account_id":"%s","aws_region":"%s","read_table":"%s","write_table":"%s","bootstrap_confirmed":true}\n' \
+            "$E2E_ACCOUNT" "$E2E_REGION" "$E2E_READ" "$E2E_WRITE" > tests/e2e/.e2e-config
+
+      - name: Run e2e copy
+        run: |
+          .venv/bin/pytest tests/e2e/commands/test_copy_smoke.py -m e2e -v --tb=short --e2e-suite "e2e copy"

--- a/.github/workflows/bulk-executor-e2e-delete.yml
+++ b/.github/workflows/bulk-executor-e2e-delete.yml
@@ -1,0 +1,58 @@
+name: "bulk_executor: e2e delete"
+
+on:
+  workflow_run:
+    workflows: ["bulk_executor: connector smoke"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  e2e-delete:
+    runs-on: ubuntu-latest
+    if: >
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       (github.repository == 'awslabs/amazon-dynamodb-tools' || github.repository == 'relentlesscol/amazon-dynamodb-tools'))
+    defaults:
+      run:
+        working-directory: tools/bulk_executor
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m venv .venv
+          .venv/bin/pip install --upgrade pip
+          .venv/bin/pip install -r requirements.txt
+          .venv/bin/pip install -r tests/requirements-test.txt
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.E2E_AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.E2E_AWS_REGION }}
+
+      - name: Write e2e config
+        env:
+          E2E_ACCOUNT: ${{ secrets.E2E_AWS_ACCOUNT_ID }}
+          E2E_REGION: ${{ secrets.E2E_AWS_REGION }}
+          E2E_READ: ${{ secrets.E2E_READ_TABLE }}
+          E2E_WRITE: ${{ secrets.E2E_WRITE_TABLE }}
+        run: |
+          printf '{"aws_account_id":"%s","aws_region":"%s","read_table":"%s","write_table":"%s","bootstrap_confirmed":true}\n' \
+            "$E2E_ACCOUNT" "$E2E_REGION" "$E2E_READ" "$E2E_WRITE" > tests/e2e/.e2e-config
+
+      - name: Run e2e delete
+        run: |
+          .venv/bin/pytest tests/e2e/commands/test_delete_smoke.py -m e2e -v --tb=short --e2e-suite "e2e delete"

--- a/.github/workflows/bulk-executor-e2e-diff.yml
+++ b/.github/workflows/bulk-executor-e2e-diff.yml
@@ -1,0 +1,58 @@
+name: "bulk_executor: e2e diff"
+
+on:
+  workflow_run:
+    workflows: ["bulk_executor: connector smoke"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  e2e-diff:
+    runs-on: ubuntu-latest
+    if: >
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       (github.repository == 'awslabs/amazon-dynamodb-tools' || github.repository == 'relentlesscol/amazon-dynamodb-tools'))
+    defaults:
+      run:
+        working-directory: tools/bulk_executor
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m venv .venv
+          .venv/bin/pip install --upgrade pip
+          .venv/bin/pip install -r requirements.txt
+          .venv/bin/pip install -r tests/requirements-test.txt
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.E2E_AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.E2E_AWS_REGION }}
+
+      - name: Write e2e config
+        env:
+          E2E_ACCOUNT: ${{ secrets.E2E_AWS_ACCOUNT_ID }}
+          E2E_REGION: ${{ secrets.E2E_AWS_REGION }}
+          E2E_READ: ${{ secrets.E2E_READ_TABLE }}
+          E2E_WRITE: ${{ secrets.E2E_WRITE_TABLE }}
+        run: |
+          printf '{"aws_account_id":"%s","aws_region":"%s","read_table":"%s","write_table":"%s","bootstrap_confirmed":true}\n' \
+            "$E2E_ACCOUNT" "$E2E_REGION" "$E2E_READ" "$E2E_WRITE" > tests/e2e/.e2e-config
+
+      - name: Run e2e diff
+        run: |
+          .venv/bin/pytest tests/e2e/commands/test_diff_smoke.py -m e2e -v --tb=short --e2e-suite "e2e diff"

--- a/.github/workflows/bulk-executor-e2e-fill.yml
+++ b/.github/workflows/bulk-executor-e2e-fill.yml
@@ -1,0 +1,58 @@
+name: "bulk_executor: e2e fill"
+
+on:
+  workflow_run:
+    workflows: ["bulk_executor: connector smoke"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  e2e-fill:
+    runs-on: ubuntu-latest
+    if: >
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       (github.repository == 'awslabs/amazon-dynamodb-tools' || github.repository == 'relentlesscol/amazon-dynamodb-tools'))
+    defaults:
+      run:
+        working-directory: tools/bulk_executor
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m venv .venv
+          .venv/bin/pip install --upgrade pip
+          .venv/bin/pip install -r requirements.txt
+          .venv/bin/pip install -r tests/requirements-test.txt
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.E2E_AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.E2E_AWS_REGION }}
+
+      - name: Write e2e config
+        env:
+          E2E_ACCOUNT: ${{ secrets.E2E_AWS_ACCOUNT_ID }}
+          E2E_REGION: ${{ secrets.E2E_AWS_REGION }}
+          E2E_READ: ${{ secrets.E2E_READ_TABLE }}
+          E2E_WRITE: ${{ secrets.E2E_WRITE_TABLE }}
+        run: |
+          printf '{"aws_account_id":"%s","aws_region":"%s","read_table":"%s","write_table":"%s","bootstrap_confirmed":true}\n' \
+            "$E2E_ACCOUNT" "$E2E_REGION" "$E2E_READ" "$E2E_WRITE" > tests/e2e/.e2e-config
+
+      - name: Run e2e fill
+        run: |
+          .venv/bin/pytest tests/e2e/commands/test_fill_smoke.py -m e2e -v --tb=short --e2e-suite "e2e fill"

--- a/.github/workflows/bulk-executor-e2e-update.yml
+++ b/.github/workflows/bulk-executor-e2e-update.yml
@@ -1,0 +1,58 @@
+name: "bulk_executor: e2e update"
+
+on:
+  workflow_run:
+    workflows: ["bulk_executor: connector smoke"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  e2e-update:
+    runs-on: ubuntu-latest
+    if: >
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       (github.repository == 'awslabs/amazon-dynamodb-tools' || github.repository == 'relentlesscol/amazon-dynamodb-tools'))
+    defaults:
+      run:
+        working-directory: tools/bulk_executor
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m venv .venv
+          .venv/bin/pip install --upgrade pip
+          .venv/bin/pip install -r requirements.txt
+          .venv/bin/pip install -r tests/requirements-test.txt
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.E2E_AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.E2E_AWS_REGION }}
+
+      - name: Write e2e config
+        env:
+          E2E_ACCOUNT: ${{ secrets.E2E_AWS_ACCOUNT_ID }}
+          E2E_REGION: ${{ secrets.E2E_AWS_REGION }}
+          E2E_READ: ${{ secrets.E2E_READ_TABLE }}
+          E2E_WRITE: ${{ secrets.E2E_WRITE_TABLE }}
+        run: |
+          printf '{"aws_account_id":"%s","aws_region":"%s","read_table":"%s","write_table":"%s","bootstrap_confirmed":true}\n' \
+            "$E2E_ACCOUNT" "$E2E_REGION" "$E2E_READ" "$E2E_WRITE" > tests/e2e/.e2e-config
+
+      - name: Run e2e update
+        run: |
+          .venv/bin/pytest tests/e2e/commands/test_update_smoke.py -m e2e -v --tb=short --e2e-suite "e2e update"

--- a/.github/workflows/bulk-executor-flake-retry.yml
+++ b/.github/workflows/bulk-executor-flake-retry.yml
@@ -1,0 +1,64 @@
+name: "bulk_executor: flake retry"
+
+on:
+  workflow_run:
+    workflows:
+      - "bulk_executor: e2e fill"
+      - "bulk_executor: e2e copy"
+      - "bulk_executor: e2e update"
+      - "bulk_executor: e2e delete"
+      - "bulk_executor: e2e diff"
+      - "bulk_executor: connector smoke"
+    types: [completed]
+    branches: [main]
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  retry-on-failure:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'failure'
+
+    steps:
+      - name: Check if this is already a retry
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          # Count recent failed runs for this workflow + commit
+          FAILED_COUNT=$(gh api \
+            "repos/${{ github.repository }}/actions/runs?event=workflow_run&status=failure&head_sha=${HEAD_SHA}" \
+            --jq "[.workflow_runs[] | select(.name == \"${WORKFLOW_NAME}\")] | length" \
+            2>/dev/null || echo "0")
+
+          echo "failed_count=${FAILED_COUNT}" >> "$GITHUB_OUTPUT"
+          echo "Workflow '${WORKFLOW_NAME}' has ${FAILED_COUNT} failure(s) on commit ${HEAD_SHA:0:7}"
+
+      - name: Retry if first failure
+        if: steps.check.outputs.failed_count == '1'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WORKFLOW_ID: ${{ github.event.workflow_run.workflow_id }}
+        run: |
+          echo "First failure — triggering retry..."
+          gh workflow run "${WORKFLOW_ID}" \
+            --repo "${{ github.repository }}" \
+            --ref "${{ github.event.workflow_run.head_branch }}"
+
+      - name: Alert if repeated failure
+        if: steps.check.outputs.failed_count != '1'
+        env:
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+        run: |
+          echo "::error::REAL FAILURE (not a flake): '${WORKFLOW_NAME}' failed twice on ${HEAD_SHA:0:7}"
+          echo ""
+          echo "Run: ${RUN_URL}"
+          echo ""
+          echo "This is likely a genuine regression, not a transient Glue hiccup."
+          exit 1

--- a/.github/workflows/bulk-executor-unit-tests.yml
+++ b/.github/workflows/bulk-executor-unit-tests.yml
@@ -1,0 +1,43 @@
+name: "bulk_executor: unit tests"
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'tools/bulk_executor/**'
+      - '.github/workflows/bulk-executor-unit-tests.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'tools/bulk_executor/**'
+      - '.github/workflows/bulk-executor-unit-tests.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: tools/bulk_executor
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m venv .venv
+          .venv/bin/pip install --upgrade pip
+          .venv/bin/pip install -r requirements.txt
+          .venv/bin/pip install -r tests/requirements-test.txt
+
+      - name: Run unit tests
+        run: |
+          .venv/bin/pytest tests/ --ignore=tests/e2e -v --tb=short --cov=server/src --cov=client/src --cov-branch --cov-report=term-missing


### PR DESCRIPTION
## Summary

Add a full CI pipeline that runs on every push to main and on PRs.

### Workflow chain (sequential via `workflow_run` triggers)

```
unit tests (push+PR)
    ↓ (on success)
connector smoke (read-path)
    ↓ (on success, fan out in parallel)
e2e fill │ e2e copy │ e2e update │ e2e delete │ e2e diff
```

Each workflow has its own status badge and failure notification — you can see exactly which command broke and re-run just that one.

### Flake retry

A watcher workflow auto-reruns any failed e2e once. Only alerts on the 2nd consecutive failure for the same commit (separates Glue cold-start hiccups from real regressions).

### Infrastructure scripts

| Script | Purpose |
|--------|---------|
| `e2e-bootstrap.sh` | Create OIDC provider + IAM role + GitHub secrets in one command |
| `e2e-teardown.sh` | Clean removal of all CI infra from an account |
| `e2e-switch-account.sh` | Interactive teardown-old + bootstrap-new |

### Security

- All AWS creds via OIDC federation (zero long-lived keys)
- Account ID / table names in GitHub Secrets (never in code)
- OIDC trust scoped to specific repos + `main` branch only
- Security suite excluded from CI (requires admin privileges)

### Tested

Full pipeline green on fork (relentlesscol/amazon-dynamodb-tools) including all 5 e2e command tests against real Glue jobs in us-east-1.

---

**To enable on awslabs:** run `.github/scripts/e2e-bootstrap.sh` with the target account credentials + set secrets on the repo.