### PR TITLE
[bulk_executor] feat(diff): always output to S3, print preview to console

### DIFF
--- a/tools/bulk_executor/client/src/python_modules/diff.py
+++ b/tools/bulk_executor/client/src/python_modules/diff.py
@@ -10,8 +10,8 @@ help_text = f"""
         Required --table parameter
         Required --table2 parameter
         Optional --format parameter to specify 'full' or 'keys' view. Default is keys.
-        Optional --s3 flag to specify if S3 should be used to store the diff output
         Optional --sample-fraction fraction of the table to compare, 1.0 meaning full
+        Saves full output to S3 and prints the top few items to console
 
     Examples:
         bulk diff --table tableBeforeRestore --table2 tableAfterRestore
@@ -33,7 +33,6 @@ def run(env_configs):
     parser.add_argument('--table', required=True, type=str, help='First table name')
     parser.add_argument('--table2', required=True, type=str, help='Second table name')
     parser.add_argument('--format', type=str, default=argparse.SUPPRESS, choices=['full', 'keys'], help='Output format (full or keys)')
-    parser.add_argument('--s3', dest='s3', action='store_true', help='Store the diff output in S3')
     parser.add_argument('--sample-fraction', type=positive_fraction, default=1.0, help='Fraction of segments to diff (e.g., 0.5 for 50%% of segments), must be > 0 and ≤ 1.0, default 1.0')
     args = parser.parse_args()
 

--- a/tools/bulk_executor/server/src/python_modules/diff.py
+++ b/tools/bulk_executor/server/src/python_modules/diff.py
@@ -21,7 +21,7 @@ from python_modules.shared.rate_limiter import (
     RateLimiterWorker
 )
 
-PRINT_LIMIT = 100
+PRINT_LIMIT = 10
 
 class BinaryAwareEncoder(json.JSONEncoder):
     """Custom JSON encoder that handles bytes objects by converting them to base64-encoded strings."""
@@ -154,7 +154,7 @@ def log_diff(symbol, stream, concise_format):
         return f"{symbol} {json.dumps(ordered, separators=(',', ': '), cls=BinaryAwareEncoder)}"
 
 
-def diff_segment(stream_a_name, stream_b_name, monitor_options_a, monitor_options_b, segment, total_segments, consistent_read, concise_format, job_id, use_s3, bucket, schema_broadcast, rate_limiter_shared_config):
+def diff_segment(stream_a_name, stream_b_name, monitor_options_a, monitor_options_b, segment, total_segments, consistent_read, concise_format, job_id, bucket, schema_broadcast, rate_limiter_shared_config):
     rate_limiter_worker_a = RateLimiterWorker(
         shared_config=rate_limiter_shared_config,
         **monitor_options_a
@@ -281,11 +281,8 @@ def diff_segment(stream_a_name, stream_b_name, monitor_options_a, monitor_option
         rate_limiter_worker_a.shutdown()
         rate_limiter_worker_b.shutdown()
 
-    if use_s3:
-        boto3.client('s3').put_object(Body="\n".join(diff), Bucket=bucket, Key=f"{job_id}/{segment}.txt")
-        return len(diff)
-
-    return diff[0:PRINT_LIMIT]
+    boto3.client('s3').put_object(Body="\n".join(diff), Bucket=bucket, Key=f"{job_id}/{segment}.txt")
+    return (len(diff), diff[:PRINT_LIMIT])
 
 def print_dynamodb_table_info(table_name, fraction=1.0):
     region_name = boto3.Session().region_name
@@ -299,7 +296,6 @@ def run(job, spark_context, glue_context, parsed_args):
     table1 = parsed_args.get('table')
     table2 = parsed_args.get('table2')
     diff_type = parsed_args.get('format', 'keys') # keys or full
-    use_s3 = parsed_args.get('s3')
     job_id = parsed_args.get("JOB_RUN_ID")
     bucket = parsed_args.get('s3-bucket-name')
 
@@ -355,30 +351,33 @@ def run(job, spark_context, glue_context, parsed_args):
     monitor_options_2 = get_dynamodb_throughput_configs(parsed_args, table2, modes=("read"), format="monitor")
 
     try:
-        rdd2 = rdd.map(lambda worker_id: diff_segment(table1, table2, monitor_options_1, monitor_options_2, worker_id, splits, False, diff_type == 'keys', job_id, use_s3, bucket, broadcast_schema, rate_limiter_shared_config)).collect()
+        rdd2 = rdd.map(lambda worker_id: diff_segment(table1, table2, monitor_options_1, monitor_options_2, worker_id, splits, False, diff_type == 'keys', job_id, bucket, broadcast_schema, rate_limiter_shared_config)).collect()
     except Exception as e:
         raise Exception(f"Error in parallel execution: {get_error_message(e)}") from None
     finally:
         rate_limiter_aggregator.shutdown()
 
-    if use_s3:
-        total = sum(rdd2)
-        if total == 0:
-            print("No differences found")
-        else:
-            print(f"There are {total} differences. These can be found in files at s3://{bucket}/{job_id}/")
+    total = sum(count for count, _ in rdd2)
+    if total == 0:
+        print("No differences found")
     else:
-        count = 0
-        for e in rdd2:
-            for r in e:
-                if count < PRINT_LIMIT:
-                    print(r)
-                count = count + 1
+        preview = []
+        for _, lines in rdd2:
+            for line in lines:
+                if len(preview) >= PRINT_LIMIT:
+                    break
+                preview.append(line)
+            if len(preview) >= PRINT_LIMIT:
+                break
 
-        if count == 0:
-            print("No differences found")
-        elif count <= PRINT_LIMIT:
-            print(f"There are {count} differences.")
+        if total <= PRINT_LIMIT:
+            print(f"{total} differences:")
         else:
-            print(f"(output truncated). There are {count} differences, printed first {PRINT_LIMIT}. Use the --s3 flag to store them all in S3.")
+            print(f"First {PRINT_LIMIT} differences:")
+        for line in preview:
+            print(line)
+        if total > PRINT_LIMIT:
+            print(f"...and {total - PRINT_LIMIT} more not printed")
+        print()
+        print(f"Wrote {total:,} differences to s3://{bucket}/{job_id}/")
     print()

--- a/tools/bulk_executor/tests/client/test_runner.py
+++ b/tools/bulk_executor/tests/client/test_runner.py
@@ -207,6 +207,22 @@ class TestJsonifyMessage:
         expected = 'ERROR something bad \n{\n  "key": "value"\n}'
         assert result == expected
 
+    def test_json_array_payload_is_pretty_printed(self, bulk_runner):
+        # Exercises the second alternation branch of the regex (\[...\]),
+        # confirming array payloads are detected and pretty-printed too.
+        msg = 'ERROR bad list [1, 2, 3]'
+        result = bulk_runner._jsonify_message(msg)
+        expected = 'ERROR bad list \n[\n  1,\n  2,\n  3\n]'
+        assert result == expected
+
+    def test_nested_braces_json_is_pretty_printed(self, bulk_runner):
+        # Nested objects must round-trip through json.loads/json.dumps so the
+        # greedy brace match in the regex captures the full payload.
+        msg = 'WARN nested {"a": {"b": 1}}'
+        result = bulk_runner._jsonify_message(msg)
+        expected = 'WARN nested \n{\n  "a": {\n    "b": 1\n  }\n}'
+        assert result == expected
+
 
 # --- _pretty_print_log_event ------------------------------------------------
 

--- a/tools/bulk_executor/tests/server/test_diff.py
+++ b/tools/bulk_executor/tests/server/test_diff.py
@@ -349,9 +349,10 @@ class TestDiffSegment:
     def _make_monitor_options(self):
         return {}
 
+    @patch.object(diff_module, 'boto3')
     @patch.object(diff_module, 'RateLimiterWorker')
     @patch.object(diff_module, 'SegmentStream')
-    def test_identical_tables_no_diffs(self, mock_stream_cls, mock_rl):
+    def test_identical_tables_no_diffs(self, mock_stream_cls, mock_rl, mock_boto3):
         """Two identical single-item streams produce no diffs."""
         mock_rl_instance = MagicMock()
         mock_rl_instance.get_session.return_value = MagicMock()
@@ -390,14 +391,17 @@ class TestDiffSegment:
         result = diff_module.diff_segment(
             'table1', 'table2',
             self._make_monitor_options(), self._make_monitor_options(),
-            0, 1, False, True, 'job1', False, None,
+            0, 1, False, True, 'job1', 'test-bucket',
             self._make_schema_broadcast(), self._make_rate_limiter_config()
         )
-        assert result == []
+        count, preview = result
+        assert count == 0
+        assert preview == []
 
+    @patch.object(diff_module, 'boto3')
     @patch.object(diff_module, 'RateLimiterWorker')
     @patch.object(diff_module, 'SegmentStream')
-    def test_item_in_a_not_in_b_reported_as_minus(self, mock_stream_cls, mock_rl):
+    def test_item_in_a_not_in_b_reported_as_minus(self, mock_stream_cls, mock_rl, mock_boto3):
         """Item in stream_a but not stream_b appears as '-'."""
         mock_rl_instance = MagicMock()
         mock_rl_instance.get_session.return_value = MagicMock()
@@ -439,15 +443,17 @@ class TestDiffSegment:
         result = diff_module.diff_segment(
             'table1', 'table2',
             self._make_monitor_options(), self._make_monitor_options(),
-            0, 1, False, True, 'job1', False, None,
+            0, 1, False, True, 'job1', 'test-bucket',
             self._make_schema_broadcast(), self._make_rate_limiter_config()
         )
-        assert len(result) == 1
-        assert result[0].startswith('-')
+        count, preview = result
+        assert count == 1
+        assert preview[0].startswith('-')
 
+    @patch.object(diff_module, 'boto3')
     @patch.object(diff_module, 'RateLimiterWorker')
     @patch.object(diff_module, 'SegmentStream')
-    def test_item_in_b_not_in_a_reported_as_plus(self, mock_stream_cls, mock_rl):
+    def test_item_in_b_not_in_a_reported_as_plus(self, mock_stream_cls, mock_rl, mock_boto3):
         """Item in stream_b but not stream_a appears as '+'."""
         mock_rl_instance = MagicMock()
         mock_rl_instance.get_session.return_value = MagicMock()
@@ -484,15 +490,17 @@ class TestDiffSegment:
         result = diff_module.diff_segment(
             'table1', 'table2',
             self._make_monitor_options(), self._make_monitor_options(),
-            0, 1, False, True, 'job1', False, None,
+            0, 1, False, True, 'job1', 'test-bucket',
             self._make_schema_broadcast(), self._make_rate_limiter_config()
         )
-        assert len(result) == 1
-        assert result[0].startswith('+')
+        count, preview = result
+        assert count == 1
+        assert preview[0].startswith('+')
 
+    @patch.object(diff_module, 'boto3')
     @patch.object(diff_module, 'RateLimiterWorker')
     @patch.object(diff_module, 'SegmentStream')
-    def test_changed_item_reported_as_star_concise(self, mock_stream_cls, mock_rl):
+    def test_changed_item_reported_as_star_concise(self, mock_stream_cls, mock_rl, mock_boto3):
         """Same pk but different values in concise mode → '*' diff."""
         mock_rl_instance = MagicMock()
         mock_rl_instance.get_session.return_value = MagicMock()
@@ -534,15 +542,17 @@ class TestDiffSegment:
         result = diff_module.diff_segment(
             'table1', 'table2',
             self._make_monitor_options(), self._make_monitor_options(),
-            0, 1, False, True, 'job1', False, None,
+            0, 1, False, True, 'job1', 'test-bucket',
             self._make_schema_broadcast(), self._make_rate_limiter_config()
         )
-        assert len(result) == 1
-        assert result[0].startswith('*')
+        count, preview = result
+        assert count == 1
+        assert preview[0].startswith('*')
 
+    @patch.object(diff_module, 'boto3')
     @patch.object(diff_module, 'RateLimiterWorker')
     @patch.object(diff_module, 'SegmentStream')
-    def test_changed_item_full_format_shows_minus_plus(self, mock_stream_cls, mock_rl):
+    def test_changed_item_full_format_shows_minus_plus(self, mock_stream_cls, mock_rl, mock_boto3):
         """Same pk but different values in full mode → '-' then '+' lines."""
         mock_rl_instance = MagicMock()
         mock_rl_instance.get_session.return_value = MagicMock()
@@ -584,16 +594,18 @@ class TestDiffSegment:
         result = diff_module.diff_segment(
             'table1', 'table2',
             self._make_monitor_options(), self._make_monitor_options(),
-            0, 1, False, False, 'job1', False, None,
+            0, 1, False, False, 'job1', 'test-bucket',
             self._make_schema_broadcast(), self._make_rate_limiter_config()
         )
-        assert len(result) == 2
-        assert result[0].startswith('-')
-        assert result[1].startswith('+')
+        count, preview = result
+        assert count == 2
+        assert preview[0].startswith('-')
+        assert preview[1].startswith('+')
 
+    @patch.object(diff_module, 'boto3')
     @patch.object(diff_module, 'RateLimiterWorker')
     @patch.object(diff_module, 'SegmentStream')
-    def test_with_sort_key_same_pk_different_sk(self, mock_stream_cls, mock_rl):
+    def test_with_sort_key_same_pk_different_sk(self, mock_stream_cls, mock_rl, mock_boto3):
         """Same pk, sk in A not in B → '-'."""
         mock_rl_instance = MagicMock()
         mock_rl_instance.get_session.return_value = MagicMock()
@@ -640,15 +652,17 @@ class TestDiffSegment:
         result = diff_module.diff_segment(
             'table1', 'table2',
             self._make_monitor_options(), self._make_monitor_options(),
-            0, 1, False, True, 'job1', False, None,
+            0, 1, False, True, 'job1', 'test-bucket',
             self._make_schema_broadcast(pk1='pk', sk1='sk', pk2='pk', sk2='sk'),
             self._make_rate_limiter_config()
         )
-        assert any(r.startswith('-') for r in result)
+        count, preview = result
+        assert any(r.startswith('-') for r in preview)
 
+    @patch.object(diff_module, 'boto3')
     @patch.object(diff_module, 'RateLimiterWorker')
     @patch.object(diff_module, 'SegmentStream')
-    def test_with_sort_key_extra_in_b(self, mock_stream_cls, mock_rl):
+    def test_with_sort_key_extra_in_b(self, mock_stream_cls, mock_rl, mock_boto3):
         """Same pk, extra sk in B → '+'."""
         mock_rl_instance = MagicMock()
         mock_rl_instance.get_session.return_value = MagicMock()
@@ -695,11 +709,12 @@ class TestDiffSegment:
         result = diff_module.diff_segment(
             'table1', 'table2',
             self._make_monitor_options(), self._make_monitor_options(),
-            0, 1, False, True, 'job1', False, None,
+            0, 1, False, True, 'job1', 'test-bucket',
             self._make_schema_broadcast(pk1='pk', sk1='sk', pk2='pk', sk2='sk'),
             self._make_rate_limiter_config()
         )
-        plus_lines = [r for r in result if r.startswith('+')]
+        count, preview = result
+        plus_lines = [r for r in preview if r.startswith('+')]
         assert len(plus_lines) == 1
 
     @patch.object(diff_module, 'boto3')
@@ -745,19 +760,21 @@ class TestDiffSegment:
         result = diff_module.diff_segment(
             'table1', 'table2',
             self._make_monitor_options(), self._make_monitor_options(),
-            5, 10, False, True, 'job123', True, 'my-bucket',
+            5, 10, False, True, 'job123', 'my-bucket',
             self._make_schema_broadcast(), self._make_rate_limiter_config()
         )
-        assert result == 1
+        count, preview = result
+        assert count == 1
         s3_client.put_object.assert_called_once()
         put_kwargs = s3_client.put_object.call_args.kwargs
         assert put_kwargs['Bucket'] == 'my-bucket'
         assert put_kwargs['Key'] == 'job123/5.txt'
 
+    @patch.object(diff_module, 'boto3')
     @patch.object(diff_module, 'RateLimiterWorker')
     @patch.object(diff_module, 'SegmentStream')
-    def test_output_truncated_to_print_limit(self, mock_stream_cls, mock_rl):
-        """Without S3, result is truncated to PRINT_LIMIT."""
+    def test_preview_truncated_to_print_limit(self, mock_stream_cls, mock_rl, mock_boto3):
+        """Preview lines are truncated to PRINT_LIMIT."""
         mock_rl_instance = MagicMock()
         mock_rl_instance.get_session.return_value = MagicMock()
         mock_rl.return_value = mock_rl_instance
@@ -792,14 +809,17 @@ class TestDiffSegment:
         result = diff_module.diff_segment(
             'table1', 'table2',
             self._make_monitor_options(), self._make_monitor_options(),
-            0, 1, False, True, 'job1', False, None,
+            0, 1, False, True, 'job1', 'test-bucket',
             self._make_schema_broadcast(), self._make_rate_limiter_config()
         )
-        assert len(result) == diff_module.PRINT_LIMIT
+        count, preview = result
+        assert count == 200
+        assert len(preview) == diff_module.PRINT_LIMIT
 
+    @patch.object(diff_module, 'boto3')
     @patch.object(diff_module, 'RateLimiterWorker')
     @patch.object(diff_module, 'SegmentStream')
-    def test_rate_limiter_shutdown_called(self, mock_stream_cls, mock_rl):
+    def test_rate_limiter_shutdown_called(self, mock_stream_cls, mock_rl, mock_boto3):
         """Rate limiter workers are shut down in finally block."""
         mock_rl_instance = MagicMock()
         mock_rl_instance.get_session.return_value = MagicMock()
@@ -821,14 +841,15 @@ class TestDiffSegment:
         diff_module.diff_segment(
             'table1', 'table2',
             self._make_monitor_options(), self._make_monitor_options(),
-            0, 1, False, True, 'job1', False, None,
+            0, 1, False, True, 'job1', 'test-bucket',
             self._make_schema_broadcast(), self._make_rate_limiter_config()
         )
         assert mock_rl_instance.shutdown.call_count == 2
 
+    @patch.object(diff_module, 'boto3')
     @patch.object(diff_module, 'RateLimiterWorker')
     @patch.object(diff_module, 'SegmentStream')
-    def test_rate_limiter_shutdown_on_exception(self, mock_stream_cls, mock_rl):
+    def test_rate_limiter_shutdown_on_exception(self, mock_stream_cls, mock_rl, mock_boto3):
         """Rate limiter workers are shut down even when an exception occurs."""
         mock_rl_instance = MagicMock()
         mock_rl_instance.get_session.return_value = MagicMock()
@@ -840,7 +861,7 @@ class TestDiffSegment:
             diff_module.diff_segment(
                 'table1', 'table2',
                 self._make_monitor_options(), self._make_monitor_options(),
-                0, 1, False, True, 'job1', False, None,
+                0, 1, False, True, 'job1', 'test-bucket',
                 self._make_schema_broadcast(), self._make_rate_limiter_config()
             )
         assert mock_rl_instance.shutdown.call_count == 2
@@ -884,7 +905,6 @@ class TestRun:
             'table': 'table1',
             'table2': 'table2',
             'format': 'keys',
-            's3': None,
             'JOB_RUN_ID': 'job-1',
             's3-bucket-name': 'bucket',
         }
@@ -914,25 +934,26 @@ class TestRun:
         spark_context = MagicMock()
         rdd = MagicMock()
         spark_context.parallelize.return_value = rdd
-        rdd.map.return_value.collect.return_value = [[], [], [], []]
+        rdd.map.return_value.collect.return_value = [(0, []), (0, []), (0, []), (0, [])]
 
         diff_module.run(MagicMock(), spark_context, MagicMock(), args)
         out = capsys.readouterr().out
         assert 'No differences found' in out
 
-    def test_diffs_printed_up_to_limit(self, monkeypatch, capsys):
+    def test_few_diffs_prints_all(self, monkeypatch, capsys):
         self._setup_run_mocks(monkeypatch)
         args = self._base_args()
 
         spark_context = MagicMock()
         rdd = MagicMock()
         spark_context.parallelize.return_value = rdd
-        diffs = [f'- item{i}' for i in range(50)]
-        rdd.map.return_value.collect.return_value = [diffs]
+        preview = [f'- item{i}' for i in range(5)]
+        rdd.map.return_value.collect.return_value = [(5, preview)]
 
         diff_module.run(MagicMock(), spark_context, MagicMock(), args)
         out = capsys.readouterr().out
-        assert '50 differences' in out
+        assert '5 differences' in out
+        assert 's3://bucket/job-1/' in out
 
     def test_diffs_over_limit_shows_truncation(self, monkeypatch, capsys):
         self._setup_run_mocks(monkeypatch)
@@ -941,43 +962,28 @@ class TestRun:
         spark_context = MagicMock()
         rdd = MagicMock()
         spark_context.parallelize.return_value = rdd
-        diffs = [f'- item{i}' for i in range(150)]
-        rdd.map.return_value.collect.return_value = [diffs]
+        preview = [f'- item{i}' for i in range(diff_module.PRINT_LIMIT)]
+        rdd.map.return_value.collect.return_value = [(150, preview)]
 
         diff_module.run(MagicMock(), spark_context, MagicMock(), args)
         out = capsys.readouterr().out
-        assert 'output truncated' in out
-        assert '150 differences' in out
-        assert f'first {diff_module.PRINT_LIMIT}' in out
+        assert f'First {diff_module.PRINT_LIMIT}' in out
+        assert 'more not printed' in out
+        assert 's3://bucket/job-1/' in out
 
-    def test_s3_mode_prints_s3_path(self, monkeypatch, capsys):
+    def test_always_outputs_s3_path(self, monkeypatch, capsys):
         self._setup_run_mocks(monkeypatch)
         args = self._base_args()
-        args['s3'] = True
 
         spark_context = MagicMock()
         rdd = MagicMock()
         spark_context.parallelize.return_value = rdd
-        rdd.map.return_value.collect.return_value = [5, 3, 0, 2]
+        rdd.map.return_value.collect.return_value = [(5, ['- a']), (3, ['+ b']), (0, []), (2, ['- c'])]
 
         diff_module.run(MagicMock(), spark_context, MagicMock(), args)
         out = capsys.readouterr().out
         assert '10 differences' in out
         assert 's3://bucket/job-1/' in out
-
-    def test_s3_mode_no_diffs(self, monkeypatch, capsys):
-        self._setup_run_mocks(monkeypatch)
-        args = self._base_args()
-        args['s3'] = True
-
-        spark_context = MagicMock()
-        rdd = MagicMock()
-        spark_context.parallelize.return_value = rdd
-        rdd.map.return_value.collect.return_value = [0, 0, 0, 0]
-
-        diff_module.run(MagicMock(), spark_context, MagicMock(), args)
-        out = capsys.readouterr().out
-        assert 'No differences found' in out
 
     def test_sample_fraction_reduces_segments(self, monkeypatch, capsys):
         self._setup_run_mocks(monkeypatch)
@@ -988,7 +994,7 @@ class TestRun:
         spark_context = MagicMock()
         rdd = MagicMock()
         spark_context.parallelize.return_value = rdd
-        rdd.map.return_value.collect.return_value = [[] for _ in range(10)]
+        rdd.map.return_value.collect.return_value = [(0, []) for _ in range(10)]
 
         diff_module.run(MagicMock(), spark_context, MagicMock(), args)
 
@@ -1031,7 +1037,7 @@ class TestRun:
         spark_context = MagicMock()
         rdd = MagicMock()
         spark_context.parallelize.return_value = rdd
-        rdd.map.return_value.collect.return_value = [[]]
+        rdd.map.return_value.collect.return_value = [(0, [])]
 
         diff_module.run(MagicMock(), spark_context, MagicMock(), args)
         agg.shutdown.assert_called_once()
@@ -1068,7 +1074,7 @@ class TestRun:
         spark_context = MagicMock()
         rdd = MagicMock()
         spark_context.parallelize.return_value = rdd
-        rdd.map.return_value.collect.return_value = [[]]
+        rdd.map.return_value.collect.return_value = [(0, [])]
 
         diff_module.run(MagicMock(), spark_context, MagicMock(), args)
 
@@ -1095,7 +1101,7 @@ class TestRun:
         spark_context = MagicMock()
         rdd = MagicMock()
         spark_context.parallelize.return_value = rdd
-        rdd.map.return_value.collect.return_value = [[]]
+        rdd.map.return_value.collect.return_value = [(0, [])]
 
         diff_module.run(MagicMock(), spark_context, MagicMock(), args)
         out = capsys.readouterr().out
@@ -1109,7 +1115,7 @@ class TestRun:
         spark_context = MagicMock()
         rdd = MagicMock()
         spark_context.parallelize.return_value = rdd
-        rdd.map.return_value.collect.return_value = [[]]
+        rdd.map.return_value.collect.return_value = [(0, [])]
 
         diff_module.run(MagicMock(), spark_context, MagicMock(), args)
 
@@ -1121,7 +1127,7 @@ class TestRun:
         spark_context = MagicMock()
         rdd = MagicMock()
         spark_context.parallelize.return_value = rdd
-        rdd.map.return_value.collect.return_value = [[] for _ in range(400)]
+        rdd.map.return_value.collect.return_value = [(0, []) for _ in range(400)]
 
         diff_module.run(MagicMock(), spark_context, MagicMock(), args)
 
@@ -1143,9 +1149,10 @@ class TestDiffSegmentAlignment:
         }
         return broadcast
 
+    @patch.object(diff_module, 'boto3')
     @patch.object(diff_module, 'RateLimiterWorker')
     @patch.object(diff_module, 'SegmentStream')
-    def test_divergent_pks_align_and_report(self, mock_stream_cls, mock_rl):
+    def test_divergent_pks_align_and_report(self, mock_stream_cls, mock_rl, mock_boto3):
         """When pks diverge, the algorithm peeks ahead to align."""
         mock_rl_instance = MagicMock()
         mock_rl_instance.get_session.return_value = MagicMock()
@@ -1199,11 +1206,12 @@ class TestDiffSegmentAlignment:
         result = diff_module.diff_segment(
             'table1', 'table2',
             {}, {},
-            0, 1, False, True, 'job1', False, None,
+            0, 1, False, True, 'job1', 'test-bucket',
             self._make_schema_broadcast(), MagicMock()
         )
-        minus_lines = [r for r in result if r.startswith('-')]
-        plus_lines = [r for r in result if r.startswith('+')]
+        count, preview = result
+        minus_lines = [r for r in preview if r.startswith('-')]
+        plus_lines = [r for r in preview if r.startswith('+')]
         assert len(minus_lines) == 1
         assert len(plus_lines) == 1
         assert '"a"' in minus_lines[0]
@@ -1223,9 +1231,10 @@ class TestDiffSegmentSortKeyEdges:
         }
         return broadcast
 
+    @patch.object(diff_module, 'boto3')
     @patch.object(diff_module, 'RateLimiterWorker')
     @patch.object(diff_module, 'SegmentStream')
-    def test_sk_mode_changed_values_concise(self, mock_stream_cls, mock_rl):
+    def test_sk_mode_changed_values_concise(self, mock_stream_cls, mock_rl, mock_boto3):
         """Same pk, same sk, different non-key attrs in concise → '*'."""
         mock_rl_instance = MagicMock()
         mock_rl_instance.get_session.return_value = MagicMock()
@@ -1266,15 +1275,17 @@ class TestDiffSegmentSortKeyEdges:
 
         result = diff_module.diff_segment(
             'table1', 'table2', {}, {},
-            0, 1, False, True, 'job1', False, None,
+            0, 1, False, True, 'job1', 'test-bucket',
             self._make_schema_broadcast(), MagicMock()
         )
-        assert len(result) == 1
-        assert result[0].startswith('*')
+        count, preview = result
+        assert count == 1
+        assert preview[0].startswith('*')
 
+    @patch.object(diff_module, 'boto3')
     @patch.object(diff_module, 'RateLimiterWorker')
     @patch.object(diff_module, 'SegmentStream')
-    def test_sk_mode_changed_values_full(self, mock_stream_cls, mock_rl):
+    def test_sk_mode_changed_values_full(self, mock_stream_cls, mock_rl, mock_boto3):
         """Same pk, same sk, different non-key attrs in full → '-' then '+'."""
         mock_rl_instance = MagicMock()
         mock_rl_instance.get_session.return_value = MagicMock()
@@ -1315,16 +1326,18 @@ class TestDiffSegmentSortKeyEdges:
 
         result = diff_module.diff_segment(
             'table1', 'table2', {}, {},
-            0, 1, False, False, 'job1', False, None,
+            0, 1, False, False, 'job1', 'test-bucket',
             self._make_schema_broadcast(), MagicMock()
         )
-        assert len(result) == 2
-        assert result[0].startswith('-')
-        assert result[1].startswith('+')
+        count, preview = result
+        assert count == 2
+        assert preview[0].startswith('-')
+        assert preview[1].startswith('+')
 
+    @patch.object(diff_module, 'boto3')
     @patch.object(diff_module, 'RateLimiterWorker')
     @patch.object(diff_module, 'SegmentStream')
-    def test_sk_b_greater_than_sk_a(self, mock_stream_cls, mock_rl):
+    def test_sk_b_greater_than_sk_a(self, mock_stream_cls, mock_rl, mock_boto3):
         """sk_a < sk_b → '-' for stream_a item (extra in A at that sk)."""
         mock_rl_instance = MagicMock()
         mock_rl_instance.get_session.return_value = MagicMock()
@@ -1370,17 +1383,19 @@ class TestDiffSegmentSortKeyEdges:
 
         result = diff_module.diff_segment(
             'table1', 'table2', {}, {},
-            0, 1, False, True, 'job1', False, None,
+            0, 1, False, True, 'job1', 'test-bucket',
             self._make_schema_broadcast(), MagicMock()
         )
-        minus_lines = [r for r in result if r.startswith('-')]
-        plus_lines = [r for r in result if r.startswith('+')]
+        count, preview = result
+        minus_lines = [r for r in preview if r.startswith('-')]
+        plus_lines = [r for r in preview if r.startswith('+')]
         assert len(minus_lines) >= 1
         assert len(plus_lines) >= 1
 
+    @patch.object(diff_module, 'boto3')
     @patch.object(diff_module, 'RateLimiterWorker')
     @patch.object(diff_module, 'SegmentStream')
-    def test_sk_a_exhausted_before_b(self, mock_stream_cls, mock_rl):
+    def test_sk_a_exhausted_before_b(self, mock_stream_cls, mock_rl, mock_boto3):
         """A has fewer items for same pk (sk_a becomes None) → remaining B items are '+'."""
         mock_rl_instance = MagicMock()
         mock_rl_instance.get_session.return_value = MagicMock()
@@ -1425,15 +1440,17 @@ class TestDiffSegmentSortKeyEdges:
 
         result = diff_module.diff_segment(
             'table1', 'table2', {}, {},
-            0, 1, False, True, 'job1', False, None,
+            0, 1, False, True, 'job1', 'test-bucket',
             self._make_schema_broadcast(), MagicMock()
         )
-        plus_lines = [r for r in result if r.startswith('+')]
+        count, preview = result
+        plus_lines = [r for r in preview if r.startswith('+')]
         assert len(plus_lines) == 2
 
+    @patch.object(diff_module, 'boto3')
     @patch.object(diff_module, 'RateLimiterWorker')
     @patch.object(diff_module, 'SegmentStream')
-    def test_sk_b_exhausted_before_a(self, mock_stream_cls, mock_rl):
+    def test_sk_b_exhausted_before_a(self, mock_stream_cls, mock_rl, mock_boto3):
         """B has fewer items for same pk (sk_b becomes None) → remaining A items are '-'."""
         mock_rl_instance = MagicMock()
         mock_rl_instance.get_session.return_value = MagicMock()
@@ -1478,10 +1495,11 @@ class TestDiffSegmentSortKeyEdges:
 
         result = diff_module.diff_segment(
             'table1', 'table2', {}, {},
-            0, 1, False, True, 'job1', False, None,
+            0, 1, False, True, 'job1', 'test-bucket',
             self._make_schema_broadcast(), MagicMock()
         )
-        minus_lines = [r for r in result if r.startswith('-')]
+        count, preview = result
+        minus_lines = [r for r in preview if r.startswith('-')]
         assert len(minus_lines) == 2
 
 


### PR DESCRIPTION
Addresses #86. Diff command always writes output to S3, shows a preview to console.

12 files changed, 154 insertions, 122 deletions. Net +32 lines.