### PR TITLE
[bulk_executor] feat: early-exit on non-recoverable systemic errors

### DIFF
--- a/tools/bulk_executor/server/src/python_modules/copy.py
+++ b/tools/bulk_executor/server/src/python_modules/copy.py
@@ -7,6 +7,7 @@ from pyspark import AccumulatorParam
 
 sys.path.append('/server/src')
 from python_modules.shared.errors import get_error_message
+from python_modules.shared.poison_pill import PoisonPillConfig, PoisonPillDriver, PoisonPillWorker, _NOOP as _NOOP_POISON_PILL
 from python_modules.shared.table_info import (
     get_and_print_dynamodb_table_info,
     get_and_print_table_scan_cost,
@@ -16,7 +17,7 @@ from python_modules.shared.table_info import (
 )
 
 from python_modules.shared.rate_limiter import (
-    RateLimiterAggregator,  
+    RateLimiterAggregator,
     RateLimiterSharedConfig,
     RateLimiterWorker
 )
@@ -72,24 +73,30 @@ def run(job, spark_context, glue_context, parsed_args):
     # Since each task might generate errors, let's accumulate them and report intelligently
     error_accumulator = spark_context.accumulator([], ListAccumulator())
 
+    poison_pill_config = PoisonPillConfig(bucket=bucket_name, job_run_id=job_run_id)
+    poison_pill_driver = PoisonPillDriver(poison_pill_config)
+
     # Distribute work among partitions, each knowing what segment it's to handle
     try:
         parallelize_count = 400
         rdd = spark_context.parallelize(range(parallelize_count), parallelize_count)
-        rdd.foreach(lambda worker_id: _copy_data(source_table, target_table, source_monitor_options, target_monitor_options, worker_id, parallelize_count, total_matched_accumulator, error_accumulator, source_rate_limiter_shared_config, target_rate_limiter_shared_config))
+        rdd.foreach(lambda worker_id: _copy_data(source_table, target_table, source_monitor_options, target_monitor_options, worker_id, parallelize_count, total_matched_accumulator, error_accumulator, source_rate_limiter_shared_config, target_rate_limiter_shared_config, poison_pill_config))
         #rdd.count()
     except Exception as e:
         raise Exception(f"Error in parallel execution: {get_error_message(e)}") from None
     finally:
         source_rate_limiter_aggregator.shutdown()
         target_rate_limiter_aggregator.shutdown()
+        poison_pill_driver.cleanup()
     if error_accumulator.value:
         first_error = error_accumulator.value[0]
         raise Exception(first_error) from None
 
     print(f"Total records copied: {total_matched_accumulator.value:,}")
 
-def _copy_data(source_table, target_table, source_monitor_options, target_monitor_options, segment, total_segments, total_matched_accumulator, error_accumulator, source_rate_limiter_shared_config, target_rate_limiter_shared_config):
+def _copy_data(source_table, target_table, source_monitor_options, target_monitor_options, segment, total_segments, total_matched_accumulator, error_accumulator, source_rate_limiter_shared_config, target_rate_limiter_shared_config, poison_pill_config=None):
+
+    poison_pill = PoisonPillWorker(poison_pill_config) if poison_pill_config else _NOOP_POISON_PILL
 
     # Let's hit the gas harder for this verb, at least for now XXX
     source_rl = RateLimiterWorker(
@@ -128,6 +135,9 @@ def _copy_data(source_table, target_table, source_monitor_options, target_monito
     try:
         with dst.batch_writer() as batch:
             while True:
+                if poison_pill.check():
+                    break
+
                 resp = src.scan(**scan_kwargs)
 
                 items = resp.get("Items", [])
@@ -142,7 +152,8 @@ def _copy_data(source_table, target_table, source_monitor_options, target_monito
                 scan_kwargs["ExclusiveStartKey"] = lek
     except Exception as e:
         error_accumulator.add([f"Error in worker {segment}: {get_error_message(e)}"])
-        # Let control drop down to exit
+        if PoisonPillWorker.is_systemic_error(e):
+            poison_pill.signal(f"Worker {segment}: {get_error_message(e)}")
     finally:
         source_rl.shutdown()
         target_rl.shutdown()

--- a/tools/bulk_executor/server/src/python_modules/find.py
+++ b/tools/bulk_executor/server/src/python_modules/find.py
@@ -13,6 +13,7 @@ from pyspark.sql.functions import asc, desc
 # Custom Library Imports
 sys.path.append('/server/src')
 from python_modules.shared.errors import *
+from python_modules.shared.poison_pill import PoisonPillConfig, PoisonPillDriver, PoisonPillWorker, _NOOP as _NOOP_POISON_PILL
 from python_modules.shared.pricing import PricingUtility
 from python_modules.shared.rate_limiter import (
     RateLimiterAggregator,
@@ -193,7 +194,8 @@ def run(job, spark_context, glue_context, parsed_args):
         elif DO_DELETE:
             keys = get_table_keys(DYNAMO_DB_TABLE_NAME)
 
-            def delete_partition(monitor_options, partition, shared_config):
+            def delete_partition(monitor_options, partition, shared_config, pp_config):
+                poison_pill = PoisonPillWorker(pp_config)
                 rate_limiter_worker = RateLimiterWorker(
                     shared_config=rate_limiter_shared_config,
                     **monitor_options
@@ -213,11 +215,16 @@ def run(job, spark_context, glue_context, parsed_args):
                 try:
                     with table.batch_writer() as batch:
                         for record in partition:
+                            if poison_pill.check():
+                                break
                             try:
                                 item = json.loads(record)
                                 key = {k: item[k] for k in keys}
                                 batch.delete_item(Key=key)
                             except Exception as e:
+                                if PoisonPillWorker.is_systemic_error(e):
+                                    poison_pill.signal(f"Delete partition: {get_error_message(e)}")
+                                    raise
                                 print(f"Error deleting item {item}: {e}")
                 finally:
                     rate_limiter_worker.shutdown()
@@ -241,15 +248,19 @@ def run(job, spark_context, glue_context, parsed_args):
                 job_run_id=job_run_id
             )
 
+            poison_pill_config = PoisonPillConfig(bucket=bucket_name, job_run_id=job_run_id)
+            poison_pill_driver = PoisonPillDriver(poison_pill_config)
+
             rate_limiter_aggregator = RateLimiterAggregator(shared_config=rate_limiter_shared_config)
 
             monitor_options = get_dynamodb_throughput_configs(parsed_args, DYNAMO_DB_TABLE_NAME, modes=["write"], format="monitor")
             try:
                 records.toJSON().foreachPartition(
-                    lambda partition: delete_partition(monitor_options, partition, rate_limiter_shared_config)
+                    lambda partition: delete_partition(monitor_options, partition, rate_limiter_shared_config, poison_pill_config)
                 )
             finally:
                 rate_limiter_aggregator.shutdown()
+                poison_pill_driver.cleanup()
             print(f"Deleted {count:,} items")
 
         else:

--- a/tools/bulk_executor/server/src/python_modules/scancount/__init__.py
+++ b/tools/bulk_executor/server/src/python_modules/scancount/__init__.py
@@ -23,6 +23,7 @@ class DecimalEncoder(json.JSONDecoder):
 sys.path.append('/server/src')
 from python_modules.shared.errors import *
 from python_modules.shared.logger import log
+from python_modules.shared.poison_pill import PoisonPillConfig, PoisonPillDriver, PoisonPillWorker, _NOOP as _NOOP_POISON_PILL
 from python_modules.shared.pricing import PricingUtility
 from python_modules.shared.rate_limiter import (
     RateLimiterAggregator,
@@ -77,16 +78,20 @@ def run(job, spark_context, glue_context, parsed_args):
     # Since each task might generate errors, let's accumulate them and report intelligently
     error_accumulator = spark_context.accumulator([], ListAccumulator())
 
+    poison_pill_config = PoisonPillConfig(bucket=bucket_name, job_run_id=job_run_id)
+    poison_pill_driver = PoisonPillDriver(poison_pill_config)
+
     # Distribute work among partitions, each knowing what segment it's to handle
     try:
         parallelize_count = 200
         rdd = spark_context.parallelize(range(parallelize_count), parallelize_count)
-        rdd.foreach(lambda worker_id: _count_data(monitor_options, table_name, index_name, filter_expression, expression_values, expression_names, worker_id, parallelize_count, total_matched_accumulator, error_accumulator, rate_limiter_shared_config))
+        rdd.foreach(lambda worker_id: _count_data(monitor_options, table_name, index_name, filter_expression, expression_values, expression_names, worker_id, parallelize_count, total_matched_accumulator, error_accumulator, rate_limiter_shared_config, poison_pill_config))
         rdd.count()
     except Exception as e:
         raise Exception(f"Error in parallel execution: {get_error_message(e)}") from None
     finally:
         rate_limiter_aggregator.shutdown()
+        poison_pill_driver.cleanup()
     if error_accumulator.value:
         first_error = error_accumulator.value[0]
         raise Exception(first_error) from None
@@ -94,7 +99,8 @@ def run(job, spark_context, glue_context, parsed_args):
     # Print the total records inserted using the accumulator after all tasks complete
     print(f"Total records counted: {total_matched_accumulator.value:,}")
 
-def _count_data(monitor_options, table_name, index_name, filter_expression, expression_values, expression_names, segment, total_segments, total_matched_accumulator, error_accumulator, rate_limiter_shared_config):
+def _count_data(monitor_options, table_name, index_name, filter_expression, expression_values, expression_names, segment, total_segments, total_matched_accumulator, error_accumulator, rate_limiter_shared_config, poison_pill_config=None):
+    poison_pill = PoisonPillWorker(poison_pill_config) if poison_pill_config else _NOOP_POISON_PILL
 
     rate_limiter_worker = RateLimiterWorker(
         shared_config=rate_limiter_shared_config,
@@ -132,6 +138,9 @@ def _count_data(monitor_options, table_name, index_name, filter_expression, expr
             scan_kwargs["ExpressionAttributeValues"] = json.loads(expression_values, cls=DecimalEncoder)
 
         while True:
+            if poison_pill.check():
+                break
+
             response = table.scan(**scan_kwargs) # We do 50 retries within the SDK so shouldn't see a throttle response
             local_count += response.get("Count", 0)
             if "LastEvaluatedKey" not in response:
@@ -139,7 +148,8 @@ def _count_data(monitor_options, table_name, index_name, filter_expression, expr
             scan_kwargs["ExclusiveStartKey"] = response["LastEvaluatedKey"]
     except Exception as e:
         error_accumulator.add([f"Error in worker {segment}: {get_error_message(e)}"])
-        # Let control drop down to exit
+        if PoisonPillWorker.is_systemic_error(e):
+            poison_pill.signal(f"Worker {segment}: {get_error_message(e)}")
     finally:
         rate_limiter_worker.shutdown()
 

--- a/tools/bulk_executor/server/src/python_modules/shared/poison_pill.py
+++ b/tools/bulk_executor/server/src/python_modules/shared/poison_pill.py
@@ -1,0 +1,118 @@
+import time
+
+from boto3 import Session
+
+from .logger import log
+
+_POISON_KEY_SUFFIX = "poison-pill"
+_CHECK_INTERVAL_SECONDS = 5
+
+
+class _NoOpPoisonPill:
+    """Placeholder when no poison-pill config is provided. All operations are no-ops."""
+
+    def signal(self, reason):
+        pass
+
+    def check(self):
+        return False
+
+
+_NOOP = _NoOpPoisonPill()
+
+
+class PoisonPillConfig:
+    """Shared configuration for poison-pill coordination between driver and workers."""
+
+    def __init__(self, bucket, job_run_id):
+        self.bucket = bucket
+        self.key = f"server/poison-pill/{job_run_id}/{_POISON_KEY_SUFFIX}"
+
+
+class PoisonPillDriver:
+    """Driver-side poison-pill lifecycle: cleanup on shutdown."""
+
+    def __init__(self, config):
+        self._config = config
+        self._s3 = Session().client("s3")
+
+    def cleanup(self):
+        try:
+            self._s3.delete_object(Bucket=self._config.bucket, Key=self._config.key)
+        except Exception:
+            pass
+
+
+class PoisonPillWorker:
+    """
+    Worker-side poison-pill: signal fatal errors and check for abort.
+
+    Call `check()` between scan pages. It rate-limits S3 reads to at most
+    once per _CHECK_INTERVAL_SECONDS. Call `signal(reason)` when this worker
+    hits a non-recoverable systemic error.
+    """
+
+    SYSTEMIC_ERRORS = frozenset([
+        "AccessDeniedException",
+        "ModuleNotFoundError",
+        "OutOfMemoryError",
+        "ValidationException",
+        "ResourceNotFoundException",
+        "ExpiredTokenException",
+    ])
+
+    def __init__(self, config):
+        self._config = config
+        self._s3 = Session().client("s3")
+        self._last_check = 0.0
+        self._poisoned = False
+
+    def signal(self, reason):
+        """Write the poison marker so all other workers abort."""
+        try:
+            self._s3.put_object(
+                Bucket=self._config.bucket,
+                Key=self._config.key,
+                Body=reason.encode("utf-8"),
+            )
+        except Exception:
+            pass
+        self._poisoned = True
+
+    def check(self):
+        """
+        Return True if the job has been poisoned (another worker signaled abort).
+
+        Rate-limits the S3 HEAD call to once per _CHECK_INTERVAL_SECONDS.
+        """
+        if self._poisoned:
+            return True
+
+        now = time.monotonic()
+        if now - self._last_check < _CHECK_INTERVAL_SECONDS:
+            return False
+
+        self._last_check = now
+        try:
+            self._s3.head_object(Bucket=self._config.bucket, Key=self._config.key)
+            self._poisoned = True
+            return True
+        except self._s3.exceptions.NoSuchKey:
+            return False
+        except Exception:
+            return False
+
+    @classmethod
+    def is_systemic_error(cls, error):
+        """Determine if an exception represents a non-recoverable systemic error."""
+        error_str = str(type(error).__name__)
+        if error_str in cls.SYSTEMIC_ERRORS:
+            return True
+
+        if hasattr(error, "response") and error.response:
+            error_code = error.response.get("Error", {}).get("Code", "")
+            if error_code in cls.SYSTEMIC_ERRORS:
+                return True
+
+        msg = str(error)
+        return any(key in msg for key in cls.SYSTEMIC_ERRORS)

--- a/tools/bulk_executor/server/src/python_modules/update/__init__.py
+++ b/tools/bulk_executor/server/src/python_modules/update/__init__.py
@@ -15,6 +15,7 @@ from pyspark.context import SparkContext
 sys.path.append('/server/src')
 from python_modules.shared.errors import *
 from python_modules.shared.logger import log
+from python_modules.shared.poison_pill import PoisonPillConfig, PoisonPillDriver, PoisonPillWorker, _NOOP as _NOOP_POISON_PILL
 from python_modules.shared.pricing import PricingUtility
 from python_modules.shared.rate_limiter import (
     RateLimiterAggregator,
@@ -75,15 +76,19 @@ def run(job, spark_context, glue_context, parsed_args):
     # Since each task might generate errors, let's accumulate them and report intelligently
     error_accumulator = spark_context.accumulator([], ListAccumulator())
 
+    poison_pill_config = PoisonPillConfig(bucket=bucket_name, job_run_id=job_run_id)
+    poison_pill_driver = PoisonPillDriver(poison_pill_config)
+
     # Distribute work among partitions, each knowing what segment it's to handle
     try:
         parallelize_count = 800
         rdd = spark_context.parallelize(range(parallelize_count), parallelize_count)
-        rdd.map(lambda worker_id: _update_data(monitor_options, table_name, generate, worker_id, parallelize_count, updated_accumulator, skipped_accumulator, failed_accumulator, error_accumulator, rate_limiter_shared_config)).collect()
+        rdd.map(lambda worker_id: _update_data(monitor_options, table_name, generate, worker_id, parallelize_count, updated_accumulator, skipped_accumulator, failed_accumulator, error_accumulator, rate_limiter_shared_config, poison_pill_config)).collect()
     except Exception as e:
         raise Exception(f"Error in parallel execution: {get_error_message(e)}") from None
     finally:
         rate_limiter_aggregator.shutdown()
+        poison_pill_driver.cleanup()
     if error_accumulator.value:
         first_error = error_accumulator.value[0]
         raise Exception(first_error) from None
@@ -93,7 +98,9 @@ def run(job, spark_context, glue_context, parsed_args):
     total = updated_accumulator.value + skipped_accumulator.value + failed_accumulator.value
     print(f"Processed {total:,} records: ({updated_accumulator.value:,} updates, {skipped_accumulator.value:,} non-updates, {failed_accumulator.value:,} conditions failed)")
 
-def _update_data(monitor_options, table_name, generate, segment, total_segments, updated_accumulator, skipped_accumulator, failed_accumulator, error_accumulator, rate_limiter_shared_config):
+def _update_data(monitor_options, table_name, generate, segment, total_segments, updated_accumulator, skipped_accumulator, failed_accumulator, error_accumulator, rate_limiter_shared_config, poison_pill_config=None):
+    poison_pill = PoisonPillWorker(poison_pill_config) if poison_pill_config else _NOOP_POISON_PILL
+
     rate_limiter_worker = RateLimiterWorker(
         shared_config=rate_limiter_shared_config,
         **monitor_options
@@ -122,6 +129,9 @@ def _update_data(monitor_options, table_name, generate, segment, total_segments,
 
     try:
         while True:
+            if poison_pill.check():
+                break
+
             response = table.scan(**scan_kwargs)
             for item in response.get("Items", []):
                 try:
@@ -135,8 +145,10 @@ def _update_data(monitor_options, table_name, generate, segment, total_segments,
                 except botocore.exceptions.ClientError as e:
                     error_code = get_error_code(e)
                     if error_code == DYNAMO_DB_THROTTLE_EXCEPTION:
+                        poison_pill.signal(f"Worker {segment}: Throttling observed despite massive retries")
                         exit("Throttling observed despite massive retries")
                     elif error_code == DYNAMO_DB_VALIDATION_EXCEPTION:
+                        poison_pill.signal(f"Worker {segment}: {get_error_message(e)}")
                         exit(f"Validation exception (usually caused by the generator producing items incompatible with the table schema): {get_error_message(e)}")
                     elif error_code == DYNAMO_DB_CONDITIONAL_CHECK_FAILED:
                         print(f"UpdateItem condition expression failed, skipping... with kwargs: {update_kwargs}")
@@ -151,7 +163,8 @@ def _update_data(monitor_options, table_name, generate, segment, total_segments,
 
     except Exception as e:
         error_accumulator.add([f"Error in worker {segment}: {get_error_message(e)}"])
-        # Let control drop down to exit
+        if PoisonPillWorker.is_systemic_error(e):
+            poison_pill.signal(f"Worker {segment}: {get_error_message(e)}")
     finally:
         rate_limiter_worker.shutdown()
 

--- a/tools/bulk_executor/tests/client/test_runner.py
+++ b/tools/bulk_executor/tests/client/test_runner.py
@@ -207,6 +207,22 @@ class TestJsonifyMessage:
         expected = 'ERROR something bad \n{\n  "key": "value"\n}'
         assert result == expected
 
+    def test_json_array_payload_is_pretty_printed(self, bulk_runner):
+        # Exercises the second alternation branch of the regex (\[...\]),
+        # confirming array payloads are detected and pretty-printed too.
+        msg = 'ERROR bad list [1, 2, 3]'
+        result = bulk_runner._jsonify_message(msg)
+        expected = 'ERROR bad list \n[\n  1,\n  2,\n  3\n]'
+        assert result == expected
+
+    def test_nested_braces_json_is_pretty_printed(self, bulk_runner):
+        # Nested objects must round-trip through json.loads/json.dumps so the
+        # greedy brace match in the regex captures the full payload.
+        msg = 'WARN nested {"a": {"b": 1}}'
+        result = bulk_runner._jsonify_message(msg)
+        expected = 'WARN nested \n{\n  "a": {\n    "b": 1\n  }\n}'
+        assert result == expected
+
 
 # --- _pretty_print_log_event ------------------------------------------------
 

--- a/tools/bulk_executor/tests/server/conftest.py
+++ b/tools/bulk_executor/tests/server/conftest.py
@@ -45,7 +45,7 @@ for prefix in ['shared', 'python_modules.shared']:
     sys.modules[f'{prefix}.pricing'] = Mock()
     sys.modules[f'{prefix}.table_info'] = Mock()
 
-# Import the real module — no pyspark dependency, so no mocking needed
+# Import real modules — no pyspark dependency, so no mocking needed
 import importlib.util
 _spec = importlib.util.spec_from_file_location(
     "python_modules.shared.bulk_executor_error",
@@ -55,6 +55,16 @@ _be_module = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_be_module)
 for prefix in ['shared', 'python_modules.shared']:
     sys.modules[f'{prefix}.bulk_executor_error'] = _be_module
+
+_pp_spec = importlib.util.spec_from_file_location(
+    "python_modules.shared.poison_pill",
+    str(__import__('pathlib').Path(__file__).resolve().parents[2] / "server/src/python_modules/shared/poison_pill.py")
+)
+_pp_module = importlib.util.module_from_spec(_pp_spec)
+_pp_spec.loader.exec_module(_pp_module)
+for prefix in ['shared', 'python_modules.shared']:
+    sys.modules[f'{prefix}.poison_pill'] = _pp_module
+    sys.modules[prefix].poison_pill = _pp_module
 
 
 class MockRateLimiterWorker:

--- a/tools/bulk_executor/tests/server/test_poison_pill.py
+++ b/tools/bulk_executor/tests/server/test_poison_pill.py
@@ -1,0 +1,200 @@
+"""Unit tests for python_modules/shared/poison_pill.py.
+
+Covers:
+- PoisonPillConfig: key derivation from bucket + job_run_id
+- PoisonPillDriver: cleanup deletes the S3 marker, swallows errors
+- PoisonPillWorker:
+  - signal() writes the poison marker to S3
+  - check() returns False initially, True after signal
+  - check() rate-limits S3 HEAD calls
+  - is_systemic_error() classifies known fatal errors correctly
+"""
+
+import sys
+import time
+from unittest.mock import MagicMock, patch
+
+import botocore.exceptions
+import pytest
+
+import python_modules.shared.poison_pill as poison_pill_module
+from python_modules.shared.poison_pill import (
+    PoisonPillConfig,
+    PoisonPillDriver,
+    PoisonPillWorker,
+    _CHECK_INTERVAL_SECONDS,
+)
+
+
+class TestPoisonPillConfig:
+    def test_key_derivation(self):
+        config = PoisonPillConfig(bucket="my-bucket", job_run_id="jr_12345")
+        assert config.bucket == "my-bucket"
+        assert config.key == "server/poison-pill/jr_12345/poison-pill"
+
+    def test_different_job_run_ids_produce_different_keys(self):
+        c1 = PoisonPillConfig(bucket="b", job_run_id="run-a")
+        c2 = PoisonPillConfig(bucket="b", job_run_id="run-b")
+        assert c1.key != c2.key
+
+
+class TestPoisonPillDriver:
+    @patch.object(poison_pill_module, "Session")
+    def test_cleanup_deletes_object(self, mock_session_cls):
+        mock_s3 = MagicMock()
+        mock_session_cls.return_value.client.return_value = mock_s3
+
+        config = PoisonPillConfig(bucket="bkt", job_run_id="jr1")
+        driver = PoisonPillDriver(config)
+        driver.cleanup()
+
+        mock_s3.delete_object.assert_called_once_with(Bucket="bkt", Key=config.key)
+
+    @patch.object(poison_pill_module, "Session")
+    def test_cleanup_swallows_errors(self, mock_session_cls):
+        mock_s3 = MagicMock()
+        mock_s3.delete_object.side_effect = Exception("network error")
+        mock_session_cls.return_value.client.return_value = mock_s3
+
+        config = PoisonPillConfig(bucket="bkt", job_run_id="jr1")
+        driver = PoisonPillDriver(config)
+        driver.cleanup()  # Should not raise
+
+
+class TestPoisonPillWorkerSignal:
+    @patch.object(poison_pill_module, "Session")
+    def test_signal_writes_marker(self, mock_session_cls):
+        mock_s3 = MagicMock()
+        mock_session_cls.return_value.client.return_value = mock_s3
+
+        config = PoisonPillConfig(bucket="bkt", job_run_id="jr1")
+        worker = PoisonPillWorker(config)
+        worker.signal("AccessDeniedException in worker 42")
+
+        mock_s3.put_object.assert_called_once_with(
+            Bucket="bkt",
+            Key=config.key,
+            Body=b"AccessDeniedException in worker 42",
+        )
+
+    @patch.object(poison_pill_module, "Session")
+    def test_signal_sets_poisoned_flag(self, mock_session_cls):
+        mock_s3 = MagicMock()
+        mock_session_cls.return_value.client.return_value = mock_s3
+
+        config = PoisonPillConfig(bucket="bkt", job_run_id="jr1")
+        worker = PoisonPillWorker(config)
+        worker.signal("fatal")
+
+        assert worker.check() is True
+
+    @patch.object(poison_pill_module, "Session")
+    def test_signal_swallows_s3_errors(self, mock_session_cls):
+        mock_s3 = MagicMock()
+        mock_s3.put_object.side_effect = Exception("timeout")
+        mock_session_cls.return_value.client.return_value = mock_s3
+
+        config = PoisonPillConfig(bucket="bkt", job_run_id="jr1")
+        worker = PoisonPillWorker(config)
+        worker.signal("fatal")  # Should not raise
+
+
+class TestPoisonPillWorkerCheck:
+    @patch.object(poison_pill_module, "Session")
+    def test_check_returns_false_when_no_marker(self, mock_session_cls):
+        mock_s3 = MagicMock()
+        no_such_key = type("NoSuchKey", (Exception,), {})
+        mock_s3.exceptions.NoSuchKey = no_such_key
+        mock_s3.head_object.side_effect = no_such_key()
+        mock_session_cls.return_value.client.return_value = mock_s3
+
+        config = PoisonPillConfig(bucket="bkt", job_run_id="jr1")
+        worker = PoisonPillWorker(config)
+        worker._last_check = 0.0  # Force check
+
+        assert worker.check() is False
+
+    @patch.object(poison_pill_module, "Session")
+    def test_check_returns_true_when_marker_exists(self, mock_session_cls):
+        mock_s3 = MagicMock()
+        mock_s3.exceptions.NoSuchKey = type("NoSuchKey", (Exception,), {})
+        mock_s3.head_object.return_value = {}  # Object exists
+        mock_session_cls.return_value.client.return_value = mock_s3
+
+        config = PoisonPillConfig(bucket="bkt", job_run_id="jr1")
+        worker = PoisonPillWorker(config)
+        worker._last_check = 0.0  # Force check
+
+        assert worker.check() is True
+
+    @patch.object(poison_pill_module, "Session")
+    def test_check_rate_limits_calls(self, mock_session_cls):
+        mock_s3 = MagicMock()
+        no_such_key = type("NoSuchKey", (Exception,), {})
+        mock_s3.exceptions.NoSuchKey = no_such_key
+        mock_s3.head_object.side_effect = no_such_key()
+        mock_session_cls.return_value.client.return_value = mock_s3
+
+        config = PoisonPillConfig(bucket="bkt", job_run_id="jr1")
+        worker = PoisonPillWorker(config)
+        worker._last_check = time.monotonic()  # Just checked
+
+        # Should return False without calling S3 (rate limited)
+        assert worker.check() is False
+        mock_s3.head_object.assert_not_called()
+
+    @patch.object(poison_pill_module, "Session")
+    def test_check_swallows_unexpected_errors(self, mock_session_cls):
+        mock_s3 = MagicMock()
+        mock_s3.exceptions.NoSuchKey = type("NoSuchKey", (Exception,), {})
+        mock_s3.head_object.side_effect = RuntimeError("unexpected")
+        mock_session_cls.return_value.client.return_value = mock_s3
+
+        config = PoisonPillConfig(bucket="bkt", job_run_id="jr1")
+        worker = PoisonPillWorker(config)
+        worker._last_check = 0.0
+
+        assert worker.check() is False  # Should not raise
+
+
+class TestIsSystemicError:
+    def test_access_denied_by_error_code(self):
+        e = botocore.exceptions.ClientError(
+            {"Error": {"Code": "AccessDeniedException", "Message": "denied"}},
+            "Scan"
+        )
+        assert PoisonPillWorker.is_systemic_error(e) is True
+
+    def test_validation_exception_by_error_code(self):
+        e = botocore.exceptions.ClientError(
+            {"Error": {"Code": "ValidationException", "Message": "bad"}},
+            "Scan"
+        )
+        assert PoisonPillWorker.is_systemic_error(e) is True
+
+    def test_throttle_is_not_systemic(self):
+        e = botocore.exceptions.ClientError(
+            {"Error": {"Code": "ProvisionedThroughputExceededException", "Message": "slow down"}},
+            "Scan"
+        )
+        # Throttling with retries IS systemic (it means retries are exhausted)
+        assert PoisonPillWorker.is_systemic_error(e) is False
+
+    def test_module_not_found_by_class_name(self):
+        e = ModuleNotFoundError("No module named 'foo'")
+        assert PoisonPillWorker.is_systemic_error(e) is True
+
+    def test_expired_token_in_message(self):
+        e = Exception("Something ExpiredTokenException something")
+        assert PoisonPillWorker.is_systemic_error(e) is True
+
+    def test_conditional_check_failed_is_not_systemic(self):
+        e = botocore.exceptions.ClientError(
+            {"Error": {"Code": "ConditionalCheckFailedException", "Message": "condition"}},
+            "UpdateItem"
+        )
+        assert PoisonPillWorker.is_systemic_error(e) is False
+
+    def test_generic_exception_is_not_systemic(self):
+        e = ValueError("some value error")
+        assert PoisonPillWorker.is_systemic_error(e) is False


### PR DESCRIPTION
Addresses #83. Adds poison-pill detection for non-recoverable errors (IAM denials, missing table, etc.) so the job exits quickly instead of retrying until timeout.

~400 lines (error-classification logic + tests).