### PR TITLE
[bulk_executor] feat(update): scan phase then update phase to spread writes

### DIFF
--- a/tools/bulk_executor/server/src/python_modules/update/__init__.py
+++ b/tools/bulk_executor/server/src/python_modules/update/__init__.py
@@ -68,32 +68,124 @@ def run(job, spark_context, glue_context, parsed_args):
     # Get monitor options for rate limiting
     monitor_options = get_dynamodb_throughput_configs(parsed_args, table_name, modes=["read", "write"], format="monitor")
 
-    updated_accumulator = spark_context.accumulator(0)
-    skipped_accumulator = spark_context.accumulator(0)
-    failed_accumulator = spark_context.accumulator(0)
-
     # Since each task might generate errors, let's accumulate them and report intelligently
     error_accumulator = spark_context.accumulator([], ListAccumulator())
 
-    # Distribute work among partitions, each knowing what segment it's to handle
+    parallelize_count = 800
+
+    # --- Phase 1: Scan all segments, collect update operations ---
+    print(f"Phase 1: Scanning {parallelize_count} segments to identify items needing updates...")
     try:
-        parallelize_count = 800
-        rdd = spark_context.parallelize(range(parallelize_count), parallelize_count)
-        rdd.map(lambda worker_id: _update_data(monitor_options, table_name, generate, worker_id, parallelize_count, updated_accumulator, skipped_accumulator, failed_accumulator, error_accumulator, rate_limiter_shared_config)).collect()
+        scan_rdd = spark_context.parallelize(range(parallelize_count), parallelize_count)
+        pending_ops = scan_rdd.flatMap(
+            lambda worker_id: _scan_segment(
+                monitor_options, table_name, generate, worker_id, parallelize_count,
+                error_accumulator, rate_limiter_shared_config
+            )
+        ).collect()
     except Exception as e:
-        raise Exception(f"Error in parallel execution: {get_error_message(e)}") from None
+        raise Exception(f"Error in scan phase: {get_error_message(e)}") from None
     finally:
         rate_limiter_aggregator.shutdown()
+
     if error_accumulator.value:
         first_error = error_accumulator.value[0]
         raise Exception(first_error) from None
 
-    # Print the total records inserted using the accumulator after all tasks complete
-    #print(f"Total records scanned and possibly updated: {updated_accumulator.value:,}")
-    total = updated_accumulator.value + skipped_accumulator.value + failed_accumulator.value
-    print(f"Processed {total:,} records: ({updated_accumulator.value:,} updates, {skipped_accumulator.value:,} non-updates, {failed_accumulator.value:,} conditions failed)")
+    print(f"Phase 1 complete: {len(pending_ops):,} items identified for update")
 
-def _update_data(monitor_options, table_name, generate, segment, total_segments, updated_accumulator, skipped_accumulator, failed_accumulator, error_accumulator, rate_limiter_shared_config):
+    if not pending_ops:
+        print("No items need updating. Done.")
+        return
+
+    # --- Phase 2: Execute updates spread evenly across workers ---
+    print(f"Phase 2: Executing {len(pending_ops):,} updates spread across {parallelize_count} workers...")
+
+    rate_limiter_aggregator_2 = RateLimiterAggregator(shared_config=rate_limiter_shared_config)
+
+    updated_accumulator = spark_context.accumulator(0)
+    failed_accumulator = spark_context.accumulator(0)
+    error_accumulator_2 = spark_context.accumulator([], ListAccumulator())
+
+    try:
+        ops_rdd = spark_context.parallelize(pending_ops, parallelize_count)
+        ops_rdd.foreachPartition(
+            lambda partition: _execute_updates(
+                partition, table_name, updated_accumulator, failed_accumulator,
+                error_accumulator_2, rate_limiter_shared_config, monitor_options
+            )
+        )
+    except Exception as e:
+        raise Exception(f"Error in update phase: {get_error_message(e)}") from None
+    finally:
+        rate_limiter_aggregator_2.shutdown()
+
+    if error_accumulator_2.value:
+        first_error = error_accumulator_2.value[0]
+        raise Exception(first_error) from None
+
+    skipped_count = len(pending_ops) - updated_accumulator.value - failed_accumulator.value
+    total = len(pending_ops)
+    print(f"Phase 2 complete. Processed {total:,} operations: ({updated_accumulator.value:,} updates, {failed_accumulator.value:,} conditions failed)")
+
+
+def _scan_segment(monitor_options, table_name, generate, segment, total_segments, error_accumulator, rate_limiter_shared_config):
+    """Phase 1: Scan a single segment and return a list of update_kwargs for items needing updates."""
+    rate_limiter_worker = RateLimiterWorker(
+        shared_config=rate_limiter_shared_config,
+        **monitor_options
+    )
+
+    session = rate_limiter_worker.get_session()
+    dynamodb_resource = session.resource('dynamodb', config=Config(
+        connect_timeout=4.0,
+        read_timeout=4.0,
+        retries={
+            'mode': 'standard',
+            'total_max_attempts': 50
+        }
+    ))
+
+    table = dynamodb_resource.Table(table_name)
+
+    pending_ops = []
+    scanned_count = 0
+    scan_kwargs = {
+        "TableName": table_name,
+        "Segment": segment,
+        "TotalSegments": total_segments
+    }
+
+    try:
+        while True:
+            response = table.scan(**scan_kwargs)
+            for item in response.get("Items", []):
+                scanned_count += 1
+                try:
+                    update_kwargs = generate(item)
+                    if update_kwargs:
+                        pending_ops.append(update_kwargs)
+                except botocore.exceptions.ClientError as e:
+                    error_code = get_error_code(e)
+                    if error_code == DYNAMO_DB_VALIDATION_EXCEPTION:
+                        exit(f"Validation exception (usually caused by the generator producing items incompatible with the table schema): {get_error_message(e)}")
+                    else:
+                        raise
+            if "LastEvaluatedKey" not in response:
+                break
+            scan_kwargs["ExclusiveStartKey"] = response["LastEvaluatedKey"]
+
+    except Exception as e:
+        error_accumulator.add([f"Error in scan worker {segment}: {get_error_message(e)}"])
+    finally:
+        rate_limiter_worker.shutdown()
+
+    print(f"Scan worker {segment}/{total_segments}: scanned {scanned_count:,} items, {len(pending_ops):,} need updates")
+    return pending_ops
+
+
+def _execute_updates(partition, table_name, updated_accumulator, failed_accumulator, error_accumulator, rate_limiter_shared_config, monitor_options):
+    """Phase 2: Execute a partition of update operations against DynamoDB."""
     rate_limiter_worker = RateLimiterWorker(
         shared_config=rate_limiter_shared_config,
         **monitor_options
@@ -112,52 +204,30 @@ def _update_data(monitor_options, table_name, generate, segment, total_segments,
     table = dynamodb_resource.Table(table_name)
 
     updated_count = 0
-    skipped_count = 0
     failed_count = 0
-    scan_kwargs = {
-        "TableName": table_name,
-        "Segment": segment,
-        "TotalSegments": total_segments
-    }
 
     try:
-        while True:
-            response = table.scan(**scan_kwargs)
-            for item in response.get("Items", []):
-                try:
-                    update_kwargs = generate(item)          # Generate update parameters
-                    if update_kwargs:                       # Empty return allowed if no update needed
-                        table.update_item(**update_kwargs)  # Perform update, no API for batch update
-                        updated_count += 1
-                    else:
-                        skipped_count += 1
-
-                except botocore.exceptions.ClientError as e:
-                    error_code = get_error_code(e)
-                    if error_code == DYNAMO_DB_THROTTLE_EXCEPTION:
-                        exit("Throttling observed despite massive retries")
-                    elif error_code == DYNAMO_DB_VALIDATION_EXCEPTION:
-                        exit(f"Validation exception (usually caused by the generator producing items incompatible with the table schema): {get_error_message(e)}")
-                    elif error_code == DYNAMO_DB_CONDITIONAL_CHECK_FAILED:
-                        print(f"UpdateItem condition expression failed, skipping... with kwargs: {update_kwargs}")
-                        failed_count += 1
-                    else:
-                        print('Unhandled ClientError thrown!', e, file=sys.stderr)
-                        raise e
-            # If there are more items, continue scanning
-            if "LastEvaluatedKey" not in response:
-                break
-            scan_kwargs["ExclusiveStartKey"] = response["LastEvaluatedKey"]
-
+        for update_kwargs in partition:
+            try:
+                table.update_item(**update_kwargs)
+                updated_count += 1
+            except botocore.exceptions.ClientError as e:
+                error_code = get_error_code(e)
+                if error_code == DYNAMO_DB_THROTTLE_EXCEPTION:
+                    exit("Throttling observed despite massive retries")
+                elif error_code == DYNAMO_DB_VALIDATION_EXCEPTION:
+                    exit(f"Validation exception: {get_error_message(e)}")
+                elif error_code == DYNAMO_DB_CONDITIONAL_CHECK_FAILED:
+                    print(f"UpdateItem condition expression failed, skipping... with kwargs: {update_kwargs}")
+                    failed_count += 1
+                else:
+                    print('Unhandled ClientError thrown!', e, file=sys.stderr)
+                    raise e
     except Exception as e:
-        error_accumulator.add([f"Error in worker {segment}: {get_error_message(e)}"])
-        # Let control drop down to exit
+        error_accumulator.add([f"Error in update worker: {get_error_message(e)}"])
     finally:
         rate_limiter_worker.shutdown()
 
-    total_count = updated_count + skipped_count + failed_count
-    print(f"Worker {segment}/{total_segments} processed {total_count:,} records: ({updated_count:,} updates, {skipped_count:,} non-updates, {failed_count:,} conditions failed)")
     updated_accumulator.add(updated_count)
-    skipped_accumulator.add(skipped_count)
     failed_accumulator.add(failed_count)
     return 0

--- a/tools/bulk_executor/tests/client/test_runner.py
+++ b/tools/bulk_executor/tests/client/test_runner.py
@@ -207,6 +207,22 @@ class TestJsonifyMessage:
         expected = 'ERROR something bad \n{\n  "key": "value"\n}'
         assert result == expected
 
+    def test_json_array_payload_is_pretty_printed(self, bulk_runner):
+        # Exercises the second alternation branch of the regex (\[...\]),
+        # confirming array payloads are detected and pretty-printed too.
+        msg = 'ERROR bad list [1, 2, 3]'
+        result = bulk_runner._jsonify_message(msg)
+        expected = 'ERROR bad list \n[\n  1,\n  2,\n  3\n]'
+        assert result == expected
+
+    def test_nested_braces_json_is_pretty_printed(self, bulk_runner):
+        # Nested objects must round-trip through json.loads/json.dumps so the
+        # greedy brace match in the regex captures the full payload.
+        msg = 'WARN nested {"a": {"b": 1}}'
+        result = bulk_runner._jsonify_message(msg)
+        expected = 'WARN nested \n{\n  "a": {\n    "b": 1\n  }\n}'
+        assert result == expected
+
 
 # --- _pretty_print_log_event ------------------------------------------------
 

--- a/tools/bulk_executor/tests/server/test_update.py
+++ b/tools/bulk_executor/tests/server/test_update.py
@@ -1,17 +1,17 @@
-"""Unit tests for the `update` server-side verb.
+"""Unit tests for the `update` server-side verb (two-phase architecture).
 
 Covers `python_modules/update/__init__.py`:
 - ListAccumulator: zero / addInPlace contract for error accumulation
 - print_dynamodb_table_info: helper call ordering and output
-- run(): argument wiring (table, generator, s3-bucket-name, JOB_RUN_ID),
-  importlib dynamic module loading, rate-limiter config, monitor options,
-  spark parallelize count (800), accumulator initialization,
-  error propagation, rate-limiter shutdown in finally, summary output
-- _update_data: boto3 Config (timeouts, retries), scan pagination via
-  LastEvaluatedKey presence check, generate() dispatch, update_item calls,
-  skipped items (generate returns falsy), ClientError handling
-  (throttle/validation/conditional-check/unhandled), per-worker error
-  accumulation, rate-limiter shutdown in finally, accumulator reporting
+- run(): two-phase execution —
+  Phase 1: scan segments with flatMap to collect pending operations
+  Phase 2: repartition ops across workers with foreachPartition
+  Rate-limiter lifecycle, error propagation, summary output
+- _scan_segment: scan pagination, generate() dispatch, error handling,
+  rate-limiter shutdown in finally
+- _execute_updates: partition iteration, update_item calls,
+  ClientError handling (throttle/validation/conditional-check/unhandled),
+  rate-limiter shutdown, accumulator reporting
 """
 
 import sys
@@ -62,13 +62,21 @@ def rate_limiter_mocks(monkeypatch):
 
 @pytest.fixture
 def spark_context():
-    """Mock SparkContext with accumulator() and parallelize()."""
+    """Mock SparkContext with accumulator(), parallelize(), and foreachPartition support."""
     sc = MagicMock()
     sc.accumulator = MagicMock(side_effect=lambda init, *_: MagicMock(value=init))
-    rdd = MagicMock()
-    rdd.map = MagicMock(return_value=rdd)
-    rdd.collect = MagicMock(return_value=[])
-    sc.parallelize = MagicMock(return_value=rdd)
+
+    # Phase 1: scan RDD returns flatMap results via collect()
+    scan_rdd = MagicMock()
+    scan_rdd.flatMap = MagicMock(return_value=scan_rdd)
+    scan_rdd.collect = MagicMock(return_value=[])
+
+    # Phase 2: ops RDD with foreachPartition
+    ops_rdd = MagicMock()
+    ops_rdd.foreachPartition = MagicMock()
+
+    # parallelize returns scan_rdd first (Phase 1), ops_rdd second (Phase 2)
+    sc.parallelize = MagicMock(side_effect=[scan_rdd, ops_rdd])
     return sc
 
 
@@ -87,13 +95,13 @@ class TestListAccumulator:
     """update/__init__.py defines ListAccumulator to collect per-worker errors."""
 
     def test_zero_returns_empty_list(self):
-        """Line 29: zero() always returns [] regardless of initialValue."""
+        """zero() always returns [] regardless of initialValue."""
         acc = update_module.ListAccumulator()
         assert acc.zero(['ignored']) == []
         assert acc.zero(None) == []
 
     def test_addInPlace_extends_first_and_returns_it(self):
-        """Lines 32-34: addInPlace extends v1 with v2 in place, returns v1."""
+        """addInPlace extends v1 with v2 in place, returns v1."""
         acc = update_module.ListAccumulator()
         a = ['err1']
         b = ['err2', 'err3']
@@ -102,13 +110,13 @@ class TestListAccumulator:
         assert result is a, "returns the mutated first list"
 
     def test_addInPlace_with_empty_right(self):
-        """Line 32: extend with empty list is a no-op."""
+        """extend with empty list is a no-op."""
         acc = update_module.ListAccumulator()
         result = acc.addInPlace(['x'], [])
         assert result == ['x']
 
     def test_addInPlace_with_empty_left(self):
-        """Line 32: extend empty list with items works."""
+        """extend empty list with items works."""
         acc = update_module.ListAccumulator()
         result = acc.addInPlace([], ['y'])
         assert result == ['y']
@@ -117,28 +125,24 @@ class TestListAccumulator:
 # --- Constants ---------------------------------------------------------------
 
 class TestConstants:
-    """Lines 36-38: module-level exception name constants."""
+    """Module-level exception name constants."""
 
     def test_throttle_exception_constant(self):
-        """Line 36."""
         assert update_module.DYNAMO_DB_THROTTLE_EXCEPTION == 'ProvisionedThroughputExceededException'
 
     def test_validation_exception_constant(self):
-        """Line 37."""
         assert update_module.DYNAMO_DB_VALIDATION_EXCEPTION == 'ValidationException'
 
     def test_conditional_check_failed_constant(self):
-        """Line 38."""
         assert update_module.DYNAMO_DB_CONDITIONAL_CHECK_FAILED == 'ConditionalCheckFailedException'
 
 
 # --- print_dynamodb_table_info -----------------------------------------------
 
 class TestPrintDynamodbTableInfo:
-    """Lines 40-44: helper that prints table info and scan cost."""
+    """Helper that prints table info and scan cost."""
 
     def test_calls_get_and_print_dynamodb_table_info(self, shared_table_info_mocks, monkeypatch):
-        """Line 42: calls get_and_print_dynamodb_table_info with table_name."""
         mock_session = MagicMock()
         mock_session.return_value.region_name = 'us-west-2'
         monkeypatch.setattr(update_module, 'boto3', MagicMock(Session=mock_session))
@@ -148,7 +152,6 @@ class TestPrintDynamodbTableInfo:
         shared_table_info_mocks.get_and_print_dynamodb_table_info.assert_called_once_with('test-table')
 
     def test_calls_get_and_print_table_scan_cost(self, shared_table_info_mocks, monkeypatch):
-        """Line 43: calls get_and_print_table_scan_cost with table_info and region."""
         mock_session = MagicMock()
         mock_session.return_value.region_name = 'eu-west-1'
         monkeypatch.setattr(update_module, 'boto3', MagicMock(Session=mock_session))
@@ -161,7 +164,6 @@ class TestPrintDynamodbTableInfo:
         assert args.args[1] == 'eu-west-1'
 
     def test_prints_write_cost_message(self, shared_table_info_mocks, monkeypatch, capsys):
-        """Line 44: prints a message about write cost depending on updates."""
         mock_session = MagicMock()
         mock_session.return_value.region_name = 'us-east-1'
         monkeypatch.setattr(update_module, 'boto3', MagicMock(Session=mock_session))
@@ -172,14 +174,14 @@ class TestPrintDynamodbTableInfo:
         assert 'Cost for writes depends on how many items will be updated' in out
 
 
-# --- run() ------------------------------------------------------------------
+# --- run() Two-Phase Architecture -------------------------------------------
 
 class TestRunArgumentWiring:
     """run() pulls table, generator, bucket, and job-run-id from parsed_args."""
 
     def test_uses_default_generator_name(self, monkeypatch, shared_table_info_mocks,
                                           rate_limiter_mocks, spark_context, base_args):
-        """Line 49: generator defaults to 'default' when not in parsed_args."""
+        """generator defaults to 'default' when not in parsed_args."""
         imported_modules = []
 
         def fake_import(name):
@@ -197,7 +199,7 @@ class TestRunArgumentWiring:
 
     def test_uses_custom_generator_name(self, monkeypatch, shared_table_info_mocks,
                                          rate_limiter_mocks, spark_context, base_args):
-        """Line 49: generator name from parsed_args overrides default."""
+        """generator name from parsed_args overrides default."""
         imported_modules = []
         base_args['generator'] = 'custom_gen'
 
@@ -216,33 +218,21 @@ class TestRunArgumentWiring:
 
     def test_uses_custom_generator_function_name(self, monkeypatch, shared_table_info_mocks,
                                                    rate_limiter_mocks, spark_context, base_args):
-        """Line 50: generatorfunctionname overrides 'generate'."""
+        """generatorfunctionname overrides 'generate'."""
         base_args['generatorfunctionname'] = 'custom_fn'
         mock_module = MagicMock()
         mock_module.custom_fn = MagicMock()
         monkeypatch.setattr(update_module.importlib, 'import_module', MagicMock(return_value=mock_module))
         monkeypatch.setattr(update_module, 'print_dynamodb_table_info', MagicMock())
 
-        captured_fn = []
-        original_map = spark_context.parallelize.return_value.map
-
-        def capture_map(fn):
-            captured_fn.append(fn)
-            rdd = MagicMock()
-            rdd.collect = MagicMock(return_value=[])
-            return rdd
-
-        spark_context.parallelize.return_value.map = capture_map
-
         update_module.run(MagicMock(), spark_context, MagicMock(), base_args)
 
-        # The map lambda captures the generate function — getattr(module, 'custom_fn')
         # Verify getattr was used correctly by checking the module attribute
         assert hasattr(mock_module, 'custom_fn')
 
     def test_rate_limiter_shared_config_wiring(self, monkeypatch, shared_table_info_mocks,
                                                 rate_limiter_mocks, spark_context, base_args):
-        """Lines 61-64: RateLimiterSharedConfig gets bucket and job_run_id."""
+        """RateLimiterSharedConfig gets bucket and job_run_id."""
         monkeypatch.setattr(update_module.importlib, 'import_module',
                             MagicMock(return_value=MagicMock(generate=MagicMock())))
         monkeypatch.setattr(update_module, 'print_dynamodb_table_info', MagicMock())
@@ -255,7 +245,7 @@ class TestRunArgumentWiring:
 
     def test_monitor_options_called_with_read_and_write(self, monkeypatch, shared_table_info_mocks,
                                                          rate_limiter_mocks, spark_context, base_args):
-        """Line 69: get_dynamodb_throughput_configs called with modes=["read", "write"]."""
+        """get_dynamodb_throughput_configs called with modes=["read", "write"]."""
         monkeypatch.setattr(update_module.importlib, 'import_module',
                             MagicMock(return_value=MagicMock(generate=MagicMock())))
         monkeypatch.setattr(update_module, 'print_dynamodb_table_info', MagicMock())
@@ -268,94 +258,139 @@ class TestRunArgumentWiring:
         assert call_kwargs.kwargs['modes'] == ['read', 'write']
         assert call_kwargs.kwargs['format'] == 'monitor'
 
-    def test_parallelize_count_is_800(self, monkeypatch, shared_table_info_mocks,
-                                       rate_limiter_mocks, spark_context, base_args):
-        """Line 81: parallelize uses 800 partitions."""
+    def test_parallelize_count_is_800_for_scan_phase(self, monkeypatch, shared_table_info_mocks,
+                                                      rate_limiter_mocks, spark_context, base_args):
+        """Phase 1 parallelize uses 800 partitions for scanning."""
         monkeypatch.setattr(update_module.importlib, 'import_module',
                             MagicMock(return_value=MagicMock(generate=MagicMock())))
         monkeypatch.setattr(update_module, 'print_dynamodb_table_info', MagicMock())
 
         update_module.run(MagicMock(), spark_context, MagicMock(), base_args)
 
-        pc_args = spark_context.parallelize.call_args
+        # First call to parallelize is the scan phase
+        pc_args = spark_context.parallelize.call_args_list[0]
         assert list(pc_args.args[0]) == list(range(800)), "first arg is range(800)"
         assert pc_args.args[1] == 800, "numSlices is 800"
 
 
-class TestRunAccumulators:
-    """Lines 71-76: run() initializes four accumulators."""
+class TestRunTwoPhaseFlow:
+    """Tests for the two-phase scan-then-update flow."""
 
-    def test_updated_accumulator_initialized_to_zero(self, monkeypatch, shared_table_info_mocks,
-                                                      rate_limiter_mocks, spark_context, base_args):
-        """Line 71: updated_accumulator starts at 0."""
+    def test_no_pending_ops_skips_phase_2(self, monkeypatch, shared_table_info_mocks,
+                                            rate_limiter_mocks, spark_context, base_args, capsys):
+        """When scan phase returns empty list, phase 2 is skipped."""
         monkeypatch.setattr(update_module.importlib, 'import_module',
                             MagicMock(return_value=MagicMock(generate=MagicMock())))
         monkeypatch.setattr(update_module, 'print_dynamodb_table_info', MagicMock())
 
+        # Phase 1 returns no ops
+        scan_rdd = MagicMock()
+        scan_rdd.flatMap = MagicMock(return_value=scan_rdd)
+        scan_rdd.collect = MagicMock(return_value=[])
+        spark_context.parallelize = MagicMock(return_value=scan_rdd)
+
         update_module.run(MagicMock(), spark_context, MagicMock(), base_args)
 
-        first_call = spark_context.accumulator.call_args_list[0]
-        assert first_call.args[0] == 0
+        out = capsys.readouterr().out
+        assert 'No items need updating' in out
+        # parallelize called only once (scan phase, not update phase)
+        assert spark_context.parallelize.call_count == 1
 
-    def test_skipped_accumulator_initialized_to_zero(self, monkeypatch, shared_table_info_mocks,
-                                                      rate_limiter_mocks, spark_context, base_args):
-        """Line 72: skipped_accumulator starts at 0."""
+    def test_phase_2_repartitions_pending_ops(self, monkeypatch, shared_table_info_mocks,
+                                               base_args, capsys):
+        """Phase 2 distributes collected ops across workers via parallelize + foreachPartition."""
         monkeypatch.setattr(update_module.importlib, 'import_module',
                             MagicMock(return_value=MagicMock(generate=MagicMock())))
         monkeypatch.setattr(update_module, 'print_dynamodb_table_info', MagicMock())
 
-        update_module.run(MagicMock(), spark_context, MagicMock(), base_args)
+        config_cls = MagicMock(side_effect=lambda **kw: MagicMock(**kw))
+        aggregator_cls = MagicMock()
+        monkeypatch.setattr(update_module, 'RateLimiterSharedConfig', config_cls)
+        monkeypatch.setattr(update_module, 'RateLimiterAggregator', aggregator_cls)
 
-        second_call = spark_context.accumulator.call_args_list[1]
-        assert second_call.args[0] == 0
+        pending_ops = [{'Key': {'id': i}} for i in range(10)]
 
-    def test_failed_accumulator_initialized_to_zero(self, monkeypatch, shared_table_info_mocks,
-                                                     rate_limiter_mocks, spark_context, base_args):
-        """Line 73: failed_accumulator starts at 0."""
-        monkeypatch.setattr(update_module.importlib, 'import_module',
-                            MagicMock(return_value=MagicMock(generate=MagicMock())))
-        monkeypatch.setattr(update_module, 'print_dynamodb_table_info', MagicMock())
+        # Phase 1 scan returns pending_ops
+        scan_rdd = MagicMock()
+        scan_rdd.flatMap = MagicMock(return_value=scan_rdd)
+        scan_rdd.collect = MagicMock(return_value=pending_ops)
 
-        update_module.run(MagicMock(), spark_context, MagicMock(), base_args)
+        # Phase 2 ops RDD
+        ops_rdd = MagicMock()
+        ops_rdd.foreachPartition = MagicMock()
 
-        third_call = spark_context.accumulator.call_args_list[2]
-        assert third_call.args[0] == 0
+        sc = MagicMock()
+        accs = [
+            MagicMock(value=[]),   # error_accumulator for scan
+            MagicMock(value=10),   # updated_accumulator
+            MagicMock(value=0),    # failed_accumulator
+            MagicMock(value=[]),   # error_accumulator_2
+        ]
+        sc.accumulator = MagicMock(side_effect=accs)
+        sc.parallelize = MagicMock(side_effect=[scan_rdd, ops_rdd])
 
-    def test_error_accumulator_seeded_with_empty_list(self, monkeypatch, shared_table_info_mocks,
-                                                       rate_limiter_mocks, spark_context, base_args):
-        """Line 76: error_accumulator starts with [] and ListAccumulator."""
-        monkeypatch.setattr(update_module.importlib, 'import_module',
-                            MagicMock(return_value=MagicMock(generate=MagicMock())))
-        monkeypatch.setattr(update_module, 'print_dynamodb_table_info', MagicMock())
+        update_module.run(MagicMock(), sc, MagicMock(), base_args)
 
-        update_module.run(MagicMock(), spark_context, MagicMock(), base_args)
+        # Phase 2: parallelize called with the pending_ops and 800 partitions
+        phase2_call = sc.parallelize.call_args_list[1]
+        assert phase2_call.args[0] == pending_ops
+        assert phase2_call.args[1] == 800
+        ops_rdd.foreachPartition.assert_called_once()
 
-        fourth_call = spark_context.accumulator.call_args_list[3]
-        assert fourth_call.args[0] == []
-        assert isinstance(fourth_call.args[1], update_module.ListAccumulator)
-
-
-class TestRunErrorHandling:
-    """Lines 83-89: error propagation from workers."""
-
-    def test_parallel_execution_error_wraps_exception(self, monkeypatch, shared_table_info_mocks,
-                                                       rate_limiter_mocks, spark_context, base_args):
-        """Line 84: RuntimeError from collect() is wrapped in 'Error in parallel execution'."""
+    def test_scan_phase_error_propagated(self, monkeypatch, shared_table_info_mocks,
+                                          rate_limiter_mocks, spark_context, base_args):
+        """Error during scan phase collect() is wrapped and raised."""
         monkeypatch.setattr(update_module.importlib, 'import_module',
                             MagicMock(return_value=MagicMock(generate=MagicMock())))
         monkeypatch.setattr(update_module, 'print_dynamodb_table_info', MagicMock())
         monkeypatch.setattr(update_module, 'get_error_message', lambda e: str(e))
 
-        spark_context.parallelize.return_value.map.return_value.collect = MagicMock(
-            side_effect=RuntimeError('spark died')
-        )
+        scan_rdd = MagicMock()
+        scan_rdd.flatMap = MagicMock(return_value=scan_rdd)
+        scan_rdd.collect = MagicMock(side_effect=RuntimeError('spark died'))
+        spark_context.parallelize = MagicMock(return_value=scan_rdd)
 
-        with pytest.raises(Exception, match='Error in parallel execution'):
+        with pytest.raises(Exception, match='Error in scan phase'):
             update_module.run(MagicMock(), spark_context, MagicMock(), base_args)
 
-    def test_aggregator_shutdown_even_on_collect_failure(self, monkeypatch, shared_table_info_mocks,
-                                                          spark_context, base_args):
-        """Line 86: rate_limiter_aggregator.shutdown() is in finally block."""
+    def test_update_phase_error_propagated(self, monkeypatch, shared_table_info_mocks,
+                                            base_args):
+        """Error during update phase foreachPartition() is wrapped and raised."""
+        monkeypatch.setattr(update_module.importlib, 'import_module',
+                            MagicMock(return_value=MagicMock(generate=MagicMock())))
+        monkeypatch.setattr(update_module, 'print_dynamodb_table_info', MagicMock())
+        monkeypatch.setattr(update_module, 'get_error_message', lambda e: str(e))
+
+        config_cls = MagicMock(side_effect=lambda **kw: MagicMock(**kw))
+        aggregator_cls = MagicMock()
+        monkeypatch.setattr(update_module, 'RateLimiterSharedConfig', config_cls)
+        monkeypatch.setattr(update_module, 'RateLimiterAggregator', aggregator_cls)
+
+        # Phase 1 returns some ops
+        scan_rdd = MagicMock()
+        scan_rdd.flatMap = MagicMock(return_value=scan_rdd)
+        scan_rdd.collect = MagicMock(return_value=[{'Key': {'id': 1}}])
+
+        # Phase 2 raises
+        ops_rdd = MagicMock()
+        ops_rdd.foreachPartition = MagicMock(side_effect=RuntimeError('update crashed'))
+
+        sc = MagicMock()
+        accs = [
+            MagicMock(value=[]),   # error_accumulator scan
+            MagicMock(value=0),    # updated
+            MagicMock(value=0),    # failed
+            MagicMock(value=[]),   # error_accumulator_2
+        ]
+        sc.accumulator = MagicMock(side_effect=accs)
+        sc.parallelize = MagicMock(side_effect=[scan_rdd, ops_rdd])
+
+        with pytest.raises(Exception, match='Error in update phase'):
+            update_module.run(MagicMock(), sc, MagicMock(), base_args)
+
+    def test_aggregator_shutdown_on_scan_failure(self, monkeypatch, shared_table_info_mocks,
+                                                  base_args):
+        """Rate limiter aggregator shutdown called even when scan fails."""
         monkeypatch.setattr(update_module.importlib, 'import_module',
                             MagicMock(return_value=MagicMock(generate=MagicMock())))
         monkeypatch.setattr(update_module, 'print_dynamodb_table_info', MagicMock())
@@ -365,96 +400,78 @@ class TestRunErrorHandling:
         monkeypatch.setattr(update_module, 'RateLimiterSharedConfig', MagicMock())
         monkeypatch.setattr(update_module, 'RateLimiterAggregator', MagicMock(return_value=agg_instance))
 
-        spark_context.parallelize.return_value.map.return_value.collect = MagicMock(
-            side_effect=RuntimeError('boom')
-        )
+        scan_rdd = MagicMock()
+        scan_rdd.flatMap = MagicMock(return_value=scan_rdd)
+        scan_rdd.collect = MagicMock(side_effect=RuntimeError('boom'))
+
+        sc = MagicMock()
+        sc.accumulator = MagicMock(return_value=MagicMock(value=[]))
+        sc.parallelize = MagicMock(return_value=scan_rdd)
 
         with pytest.raises(Exception):
-            update_module.run(MagicMock(), spark_context, MagicMock(), base_args)
+            update_module.run(MagicMock(), sc, MagicMock(), base_args)
 
         agg_instance.shutdown.assert_called_once()
 
-    def test_first_worker_error_is_raised(self, monkeypatch, shared_table_info_mocks,
-                                            rate_limiter_mocks, spark_context, base_args):
-        """Lines 87-89: if error_accumulator.value is non-empty, first error raised."""
+    def test_scan_error_accumulator_raises_first_error(self, monkeypatch, shared_table_info_mocks,
+                                                        rate_limiter_mocks, spark_context, base_args):
+        """If scan error_accumulator has errors after collect, first error is raised."""
         monkeypatch.setattr(update_module.importlib, 'import_module',
                             MagicMock(return_value=MagicMock(generate=MagicMock())))
         monkeypatch.setattr(update_module, 'print_dynamodb_table_info', MagicMock())
 
-        accs = [
-            MagicMock(value=10),   # updated
-            MagicMock(value=5),    # skipped
-            MagicMock(value=2),    # failed
-            MagicMock(value=['first error', 'second error']),  # errors
-        ]
-        spark_context.accumulator = MagicMock(side_effect=accs)
-        spark_context.parallelize.return_value.map.return_value.collect = MagicMock(return_value=[])
+        scan_rdd = MagicMock()
+        scan_rdd.flatMap = MagicMock(return_value=scan_rdd)
+        scan_rdd.collect = MagicMock(return_value=[])
 
-        with pytest.raises(Exception, match='first error'):
-            update_module.run(MagicMock(), spark_context, MagicMock(), base_args)
+        sc = MagicMock()
+        error_acc = MagicMock(value=['first scan error', 'second error'])
+        sc.accumulator = MagicMock(return_value=error_acc)
+        sc.parallelize = MagicMock(return_value=scan_rdd)
 
-    def test_no_errors_prints_summary(self, monkeypatch, shared_table_info_mocks,
-                                       rate_limiter_mocks, spark_context, base_args, capsys):
-        """Lines 93-94: prints total, updates, non-updates, conditions failed."""
+        with pytest.raises(Exception, match='first scan error'):
+            update_module.run(MagicMock(), sc, MagicMock(), base_args)
+
+    def test_prints_phase_summary(self, monkeypatch, shared_table_info_mocks,
+                                   base_args, capsys):
+        """run() prints phase 1 and phase 2 summaries."""
         monkeypatch.setattr(update_module.importlib, 'import_module',
                             MagicMock(return_value=MagicMock(generate=MagicMock())))
         monkeypatch.setattr(update_module, 'print_dynamodb_table_info', MagicMock())
 
-        accs = [
-            MagicMock(value=10),  # updated
-            MagicMock(value=5),   # skipped
-            MagicMock(value=2),   # failed
-            MagicMock(value=[]),  # no errors
-        ]
-        spark_context.accumulator = MagicMock(side_effect=accs)
-        spark_context.parallelize.return_value.map.return_value.collect = MagicMock(return_value=[])
+        config_cls = MagicMock(side_effect=lambda **kw: MagicMock(**kw))
+        aggregator_cls = MagicMock()
+        monkeypatch.setattr(update_module, 'RateLimiterSharedConfig', config_cls)
+        monkeypatch.setattr(update_module, 'RateLimiterAggregator', aggregator_cls)
 
-        update_module.run(MagicMock(), spark_context, MagicMock(), base_args)
+        pending_ops = [{'Key': {'id': i}} for i in range(5)]
+        scan_rdd = MagicMock()
+        scan_rdd.flatMap = MagicMock(return_value=scan_rdd)
+        scan_rdd.collect = MagicMock(return_value=pending_ops)
+
+        ops_rdd = MagicMock()
+        ops_rdd.foreachPartition = MagicMock()
+
+        sc = MagicMock()
+        accs = [
+            MagicMock(value=[]),  # error acc scan
+            MagicMock(value=4),   # updated
+            MagicMock(value=1),   # failed
+            MagicMock(value=[]),  # error acc update
+        ]
+        sc.accumulator = MagicMock(side_effect=accs)
+        sc.parallelize = MagicMock(side_effect=[scan_rdd, ops_rdd])
+
+        update_module.run(MagicMock(), sc, MagicMock(), base_args)
 
         out = capsys.readouterr().out
-        assert '17' in out, "total = 10 + 5 + 2 = 17"
-        assert '10' in out, "updates count"
-        assert '5' in out, "non-updates count"
-        assert '2' in out, "conditions failed count"
+        assert 'Phase 1' in out
+        assert '5' in out  # 5 items identified
+        assert 'Phase 2' in out
+        assert '4' in out  # 4 updates
 
 
-class TestRunMapDispatch:
-    """Line 82: the lambda passed to rdd.map calls _update_data with correct args."""
-
-    def test_map_lambda_invokes_update_data(self, monkeypatch, shared_table_info_mocks,
-                                              rate_limiter_mocks, spark_context, base_args):
-        """Line 82: _update_data called with all required positional args."""
-        captured = {}
-
-        def fake_update_data(*args, **kwargs):
-            captured.setdefault('calls', []).append(args)
-            return 0
-
-        monkeypatch.setattr(update_module, '_update_data', fake_update_data)
-        monkeypatch.setattr(update_module.importlib, 'import_module',
-                            MagicMock(return_value=MagicMock(generate=MagicMock())))
-        monkeypatch.setattr(update_module, 'print_dynamodb_table_info', MagicMock())
-
-        def fake_map(fn):
-            rdd = MagicMock()
-            rdd.collect = MagicMock(return_value=[fn(0), fn(5), fn(799)])
-            return rdd
-
-        spark_context.parallelize.return_value.map = fake_map
-
-        update_module.run(MagicMock(), spark_context, MagicMock(), base_args)
-
-        assert len(captured['calls']) == 3
-        # _update_data(monitor_options, table_name, generate, worker_id, parallelize_count, ...)
-        for c in captured['calls']:
-            assert c[1] == 'my-table', "table_name is second arg"
-            assert c[4] == 800, "total_segments (parallelize_count) is 5th arg"
-        assert captured['calls'][0][3] == 0, "worker_id=0"
-        assert captured['calls'][1][3] == 5, "worker_id=5"
-        assert captured['calls'][2][3] == 799, "worker_id=799"
-
-
-# --- _update_data -----------------------------------------------------------
+# --- _scan_segment -----------------------------------------------------------
 
 def _make_rl_worker(table_mock):
     """Create a mock RateLimiterWorker that returns a session wired to table_mock."""
@@ -473,11 +490,186 @@ def _make_table_with_scan(scan_responses):
     return table
 
 
-class TestUpdateDataConfig:
-    """Lines 97-111: boto3 Config and session setup."""
+class TestScanSegmentPagination:
+    """_scan_segment scan loop with LastEvaluatedKey-based pagination."""
+
+    def test_single_page_no_lek(self, monkeypatch):
+        """If no LastEvaluatedKey in response, scan stops after one page."""
+        table = _make_table_with_scan([{'Items': [{'id': 1}]}])
+        rl = _make_rl_worker(table)
+        monkeypatch.setattr(update_module, 'RateLimiterWorker', MagicMock(return_value=rl))
+
+        result = update_module._scan_segment(
+            {}, 'tbl', lambda item: {'Key': item}, 0, 1,
+            MagicMock(), MagicMock()
+        )
+
+        assert table.scan.call_count == 1
+        assert len(result) == 1
+        assert result[0] == {'Key': {'id': 1}}
+
+    def test_multi_page_threads_lek(self, monkeypatch):
+        """ExclusiveStartKey is set from previous LastEvaluatedKey."""
+        scan_kwargs_seen = []
+        responses = iter([
+            {'Items': [{'a': 1}], 'LastEvaluatedKey': {'pk': 'page1'}},
+            {'Items': [{'b': 2}], 'LastEvaluatedKey': {'pk': 'page2'}},
+            {'Items': [{'c': 3}]},
+        ])
+
+        table = MagicMock()
+
+        def scan_capture(**kwargs):
+            scan_kwargs_seen.append(dict(kwargs))
+            return next(responses)
+
+        table.scan = scan_capture
+        rl = _make_rl_worker(table)
+        monkeypatch.setattr(update_module, 'RateLimiterWorker', MagicMock(return_value=rl))
+
+        result = update_module._scan_segment(
+            {}, 'tbl', lambda item: {'Key': item}, 3, 10,
+            MagicMock(), MagicMock()
+        )
+
+        assert len(scan_kwargs_seen) == 3
+        assert 'ExclusiveStartKey' not in scan_kwargs_seen[0]
+        assert scan_kwargs_seen[1]['ExclusiveStartKey'] == {'pk': 'page1'}
+        assert scan_kwargs_seen[2]['ExclusiveStartKey'] == {'pk': 'page2'}
+        assert len(result) == 3
+
+    def test_scan_kwargs_include_segment_and_total(self, monkeypatch):
+        """scan_kwargs includes TableName, Segment, TotalSegments."""
+        scan_kwargs_seen = []
+        table = MagicMock()
+
+        def scan_capture(**kwargs):
+            scan_kwargs_seen.append(dict(kwargs))
+            return {'Items': []}
+
+        table.scan = scan_capture
+        rl = _make_rl_worker(table)
+        monkeypatch.setattr(update_module, 'RateLimiterWorker', MagicMock(return_value=rl))
+
+        update_module._scan_segment(
+            {}, 'my-tbl', lambda item: None, 7, 100,
+            MagicMock(), MagicMock()
+        )
+
+        assert scan_kwargs_seen[0]['TableName'] == 'my-tbl'
+        assert scan_kwargs_seen[0]['Segment'] == 7
+        assert scan_kwargs_seen[0]['TotalSegments'] == 100
+
+
+class TestScanSegmentGenerate:
+    """_scan_segment calls generate() per item and collects truthy results."""
+
+    def test_generate_returns_truthy_collected(self, monkeypatch):
+        """If generate returns truthy, it's added to pending_ops."""
+        table = _make_table_with_scan([{'Items': [{'id': 1}, {'id': 2}]}])
+        rl = _make_rl_worker(table)
+        monkeypatch.setattr(update_module, 'RateLimiterWorker', MagicMock(return_value=rl))
+
+        def gen(item):
+            return {'Key': {'id': item['id']}, 'UpdateExpression': 'SET #a = :v'}
+
+        result = update_module._scan_segment(
+            {}, 'tbl', gen, 0, 1, MagicMock(), MagicMock()
+        )
+
+        assert len(result) == 2
+
+    def test_generate_returns_falsy_skipped(self, monkeypatch):
+        """If generate returns falsy, item is not collected."""
+        table = _make_table_with_scan([{'Items': [{'id': 1}, {'id': 2}, {'id': 3}]}])
+        rl = _make_rl_worker(table)
+        monkeypatch.setattr(update_module, 'RateLimiterWorker', MagicMock(return_value=rl))
+
+        def gen(item):
+            if item['id'] == 2:
+                return {'Key': item}
+            return None
+
+        result = update_module._scan_segment(
+            {}, 'tbl', gen, 0, 1, MagicMock(), MagicMock()
+        )
+
+        assert len(result) == 1
+        assert result[0] == {'Key': {'id': 2}}
+
+    def test_generate_validation_error_exits(self, monkeypatch):
+        """ValidationException from generate raises SystemExit."""
+        table = _make_table_with_scan([{'Items': [{'id': 1}]}])
+        rl = _make_rl_worker(table)
+        monkeypatch.setattr(update_module, 'RateLimiterWorker', MagicMock(return_value=rl))
+        monkeypatch.setattr(update_module, 'get_error_code',
+                            lambda e: e.response['Error']['Code'])
+        monkeypatch.setattr(update_module, 'get_error_message', lambda e: 'bad schema')
+
+        def gen(item):
+            raise botocore.exceptions.ClientError(
+                {'Error': {'Code': 'ValidationException', 'Message': 'bad'}},
+                'Scan'
+            )
+
+        with pytest.raises(SystemExit):
+            update_module._scan_segment(
+                {}, 'tbl', gen, 0, 1, MagicMock(), MagicMock()
+            )
+
+
+class TestScanSegmentErrorHandling:
+    """_scan_segment error handling and rate limiter shutdown."""
+
+    def test_scan_error_captured_in_accumulator(self, monkeypatch):
+        """Error from scan is caught and added to error_accumulator."""
+        table = MagicMock()
+        table.scan = MagicMock(side_effect=RuntimeError('network fail'))
+        rl = _make_rl_worker(table)
+        monkeypatch.setattr(update_module, 'RateLimiterWorker', MagicMock(return_value=rl))
+        monkeypatch.setattr(update_module, 'get_error_message', lambda e: f'wrapped:{e}')
+
+        error_acc = MagicMock()
+        update_module._scan_segment(
+            {}, 'tbl', lambda item: {'Key': item}, 7, 10,
+            error_acc, MagicMock()
+        )
+
+        error_acc.add.assert_called_once()
+        appended = error_acc.add.call_args.args[0]
+        assert isinstance(appended, list) and len(appended) == 1
+        assert 'scan worker 7' in appended[0]
+
+    def test_shutdown_called_on_success(self, monkeypatch):
+        """rate_limiter_worker.shutdown() called after successful scan."""
+        table = _make_table_with_scan([{'Items': []}])
+        rl_instance = MagicMock()
+        rl_instance.get_session.return_value.resource.return_value.Table.return_value = table
+        monkeypatch.setattr(update_module, 'RateLimiterWorker', MagicMock(return_value=rl_instance))
+
+        update_module._scan_segment(
+            {}, 'tbl', lambda item: None, 0, 1, MagicMock(), MagicMock()
+        )
+
+        rl_instance.shutdown.assert_called_once()
+
+    def test_shutdown_called_on_error(self, monkeypatch):
+        """rate_limiter_worker.shutdown() called even when scan raises."""
+        table = MagicMock()
+        table.scan = MagicMock(side_effect=RuntimeError('boom'))
+        rl_instance = MagicMock()
+        rl_instance.get_session.return_value.resource.return_value.Table.return_value = table
+        monkeypatch.setattr(update_module, 'RateLimiterWorker', MagicMock(return_value=rl_instance))
+        monkeypatch.setattr(update_module, 'get_error_message', lambda e: str(e))
+
+        update_module._scan_segment(
+            {}, 'tbl', lambda item: None, 0, 1, MagicMock(), MagicMock()
+        )
+
+        rl_instance.shutdown.assert_called_once()
 
     def test_boto3_config_has_4_second_timeouts_and_50_retries(self, monkeypatch):
-        """Lines 103-109: Config has connect_timeout=4.0, read_timeout=4.0, 50 retries."""
+        """Config has connect_timeout=4.0, read_timeout=4.0, 50 retries."""
         seen_configs = []
 
         rl_instance = MagicMock()
@@ -493,9 +685,8 @@ class TestUpdateDataConfig:
         rl_instance.get_session.return_value = session
         monkeypatch.setattr(update_module, 'RateLimiterWorker', MagicMock(return_value=rl_instance))
 
-        update_module._update_data(
-            {}, 'tbl', lambda item: None, 0, 1,
-            MagicMock(), MagicMock(), MagicMock(), MagicMock(), MagicMock()
+        update_module._scan_segment(
+            {}, 'tbl', lambda item: None, 0, 1, MagicMock(), MagicMock()
         )
 
         assert len(seen_configs) == 1
@@ -506,157 +697,59 @@ class TestUpdateDataConfig:
         assert cfg.retries['total_max_attempts'] == 50
 
 
-class TestUpdateDataPagination:
-    """Lines 124-150: scan loop with LastEvaluatedKey presence-based pagination."""
+# --- _execute_updates --------------------------------------------------------
 
-    def test_single_page_no_lek_key(self, monkeypatch):
-        """Line 148: if 'LastEvaluatedKey' not in response -> break."""
-        table = _make_table_with_scan([{'Items': [{'id': 1}]}])
+class TestExecuteUpdatesBasic:
+    """_execute_updates iterates partition and calls update_item."""
+
+    def test_updates_all_items_in_partition(self, monkeypatch):
+        """Each item in partition gets update_item called."""
+        table = MagicMock()
         rl = _make_rl_worker(table)
         monkeypatch.setattr(update_module, 'RateLimiterWorker', MagicMock(return_value=rl))
 
+        ops = [{'Key': {'id': 1}}, {'Key': {'id': 2}}, {'Key': {'id': 3}}]
         updated_acc = MagicMock()
-        skipped_acc = MagicMock()
         failed_acc = MagicMock()
 
-        update_module._update_data(
-            {}, 'tbl', lambda item: {'Key': item}, 0, 1,
-            updated_acc, skipped_acc, failed_acc, MagicMock(), MagicMock()
+        update_module._execute_updates(
+            iter(ops), 'tbl', updated_acc, failed_acc, MagicMock(), MagicMock(), {}
         )
 
-        assert table.scan.call_count == 1
-        updated_acc.add.assert_called_once_with(1)
-
-    def test_multi_page_threads_lek(self, monkeypatch):
-        """Line 150: ExclusiveStartKey set from previous LastEvaluatedKey."""
-        scan_kwargs_seen = []
-        responses = iter([
-            {'Items': [{'a': 1}], 'LastEvaluatedKey': {'pk': 'page1'}},
-            {'Items': [{'b': 2}], 'LastEvaluatedKey': {'pk': 'page2'}},
-            {'Items': [{'c': 3}]},  # no LastEvaluatedKey key at all
-        ])
-
-        table = MagicMock()
-
-        def scan_capture(**kwargs):
-            scan_kwargs_seen.append(dict(kwargs))
-            return next(responses)
-
-        table.scan = scan_capture
-        rl = _make_rl_worker(table)
-        monkeypatch.setattr(update_module, 'RateLimiterWorker', MagicMock(return_value=rl))
-
-        updated_acc = MagicMock()
-        update_module._update_data(
-            {}, 'tbl', lambda item: {'Key': item}, 3, 10,
-            updated_acc, MagicMock(), MagicMock(), MagicMock(), MagicMock()
-        )
-
-        assert len(scan_kwargs_seen) == 3
-        assert 'ExclusiveStartKey' not in scan_kwargs_seen[0]
-        assert scan_kwargs_seen[1]['ExclusiveStartKey'] == {'pk': 'page1'}
-        assert scan_kwargs_seen[2]['ExclusiveStartKey'] == {'pk': 'page2'}
+        assert table.update_item.call_count == 3
         updated_acc.add.assert_called_once_with(3)
+        failed_acc.add.assert_called_once_with(0)
 
-    def test_scan_kwargs_include_segment_and_total(self, monkeypatch):
-        """Lines 117-121: scan_kwargs includes TableName, Segment, TotalSegments."""
-        scan_kwargs_seen = []
+    def test_empty_partition(self, monkeypatch):
+        """Empty partition results in zero counts."""
         table = MagicMock()
-
-        def scan_capture(**kwargs):
-            scan_kwargs_seen.append(dict(kwargs))
-            return {'Items': []}
-
-        table.scan = scan_capture
         rl = _make_rl_worker(table)
         monkeypatch.setattr(update_module, 'RateLimiterWorker', MagicMock(return_value=rl))
-
-        update_module._update_data(
-            {}, 'my-tbl', lambda item: None, 7, 100,
-            MagicMock(), MagicMock(), MagicMock(), MagicMock(), MagicMock()
-        )
-
-        assert scan_kwargs_seen[0]['TableName'] == 'my-tbl'
-        assert scan_kwargs_seen[0]['Segment'] == 7
-        assert scan_kwargs_seen[0]['TotalSegments'] == 100
-
-
-class TestUpdateDataGenerateDispatch:
-    """Lines 128-133: generate() is called per item; update_item if truthy, skip if falsy."""
-
-    def test_generate_returns_truthy_calls_update_item(self, monkeypatch):
-        """Lines 129-131: if update_kwargs is truthy, table.update_item called."""
-        table = _make_table_with_scan([{'Items': [{'id': 1}, {'id': 2}]}])
-        rl = _make_rl_worker(table)
-        monkeypatch.setattr(update_module, 'RateLimiterWorker', MagicMock(return_value=rl))
-
-        def gen(item):
-            return {'Key': {'id': item['id']}, 'UpdateExpression': 'SET #a = :v'}
 
         updated_acc = MagicMock()
-        skipped_acc = MagicMock()
+        failed_acc = MagicMock()
 
-        update_module._update_data(
-            {}, 'tbl', gen, 0, 1,
-            updated_acc, skipped_acc, MagicMock(), MagicMock(), MagicMock()
-        )
-
-        assert table.update_item.call_count == 2
-        updated_acc.add.assert_called_once_with(2)
-        skipped_acc.add.assert_called_once_with(0)
-
-    def test_generate_returns_falsy_skips_update(self, monkeypatch):
-        """Lines 132-133: if generate returns falsy (None, {}, etc.), item is skipped."""
-        table = _make_table_with_scan([{'Items': [{'id': 1}, {'id': 2}, {'id': 3}]}])
-        rl = _make_rl_worker(table)
-        monkeypatch.setattr(update_module, 'RateLimiterWorker', MagicMock(return_value=rl))
-
-        def gen(item):
-            if item['id'] == 2:
-                return {'Key': item}
-            return None
-
-        updated_acc = MagicMock()
-        skipped_acc = MagicMock()
-
-        update_module._update_data(
-            {}, 'tbl', gen, 0, 1,
-            updated_acc, skipped_acc, MagicMock(), MagicMock(), MagicMock()
-        )
-
-        assert table.update_item.call_count == 1
-        updated_acc.add.assert_called_once_with(1)
-        skipped_acc.add.assert_called_once_with(2)
-
-    def test_generate_returns_empty_dict_is_falsy(self, monkeypatch):
-        """Line 129: empty dict is falsy so item is skipped."""
-        table = _make_table_with_scan([{'Items': [{'id': 1}]}])
-        rl = _make_rl_worker(table)
-        monkeypatch.setattr(update_module, 'RateLimiterWorker', MagicMock(return_value=rl))
-
-        skipped_acc = MagicMock()
-        update_module._update_data(
-            {}, 'tbl', lambda item: {}, 0, 1,
-            MagicMock(), skipped_acc, MagicMock(), MagicMock(), MagicMock()
+        update_module._execute_updates(
+            iter([]), 'tbl', updated_acc, failed_acc, MagicMock(), MagicMock(), {}
         )
 
         table.update_item.assert_not_called()
-        skipped_acc.add.assert_called_once_with(1)
+        updated_acc.add.assert_called_once_with(0)
+        failed_acc.add.assert_called_once_with(0)
 
 
-class TestUpdateDataClientErrors:
-    """Lines 135-146: ClientError handling per error code."""
+class TestExecuteUpdatesClientErrors:
+    """_execute_updates ClientError handling per error code."""
 
     def _make_client_error(self, code, message='error'):
-        """Create a botocore ClientError with the given error code."""
         return botocore.exceptions.ClientError(
             {'Error': {'Code': code, 'Message': message}},
             'UpdateItem'
         )
 
     def test_throttle_exception_exits(self, monkeypatch):
-        """Lines 137-138: ProvisionedThroughputExceededException calls exit()."""
-        table = _make_table_with_scan([{'Items': [{'id': 1}]}])
+        """ProvisionedThroughputExceededException calls exit()."""
+        table = MagicMock()
         table.update_item = MagicMock(
             side_effect=self._make_client_error('ProvisionedThroughputExceededException')
         )
@@ -668,14 +761,14 @@ class TestUpdateDataClientErrors:
 
         error_acc = MagicMock()
         with pytest.raises(SystemExit):
-            update_module._update_data(
-                {}, 'tbl', lambda item: {'Key': item}, 0, 1,
-                MagicMock(), MagicMock(), MagicMock(), error_acc, MagicMock()
+            update_module._execute_updates(
+                iter([{'Key': {'id': 1}}]), 'tbl',
+                MagicMock(), MagicMock(), error_acc, MagicMock(), {}
             )
 
     def test_validation_exception_exits(self, monkeypatch):
-        """Lines 139-140: ValidationException calls exit() with message."""
-        table = _make_table_with_scan([{'Items': [{'id': 1}]}])
+        """ValidationException calls exit() with message."""
+        table = MagicMock()
         table.update_item = MagicMock(
             side_effect=self._make_client_error('ValidationException', 'bad schema')
         )
@@ -687,14 +780,14 @@ class TestUpdateDataClientErrors:
 
         error_acc = MagicMock()
         with pytest.raises(SystemExit):
-            update_module._update_data(
-                {}, 'tbl', lambda item: {'Key': item}, 0, 1,
-                MagicMock(), MagicMock(), MagicMock(), error_acc, MagicMock()
+            update_module._execute_updates(
+                iter([{'Key': {'id': 1}}]), 'tbl',
+                MagicMock(), MagicMock(), error_acc, MagicMock(), {}
             )
 
-    def test_conditional_check_failed_increments_failed_count(self, monkeypatch):
-        """Lines 141-143: ConditionalCheckFailedException prints and increments failed_count."""
-        table = _make_table_with_scan([{'Items': [{'id': 1}, {'id': 2}]}])
+    def test_conditional_check_failed_increments_failed(self, monkeypatch):
+        """ConditionalCheckFailedException increments failed_count."""
+        table = MagicMock()
         table.update_item = MagicMock(
             side_effect=self._make_client_error('ConditionalCheckFailedException')
         )
@@ -706,17 +799,17 @@ class TestUpdateDataClientErrors:
         failed_acc = MagicMock()
         updated_acc = MagicMock()
 
-        update_module._update_data(
-            {}, 'tbl', lambda item: {'Key': item}, 0, 1,
-            updated_acc, MagicMock(), failed_acc, MagicMock(), MagicMock()
+        update_module._execute_updates(
+            iter([{'Key': {'id': 1}}, {'Key': {'id': 2}}]), 'tbl',
+            updated_acc, failed_acc, MagicMock(), MagicMock(), {}
         )
 
         failed_acc.add.assert_called_once_with(2)
         updated_acc.add.assert_called_once_with(0)
 
     def test_conditional_check_failed_prints_kwargs(self, monkeypatch, capsys):
-        """Line 142: prints the update_kwargs that caused the condition failure."""
-        table = _make_table_with_scan([{'Items': [{'id': 'x'}]}])
+        """Prints the update_kwargs that caused the condition failure."""
+        table = MagicMock()
         table.update_item = MagicMock(
             side_effect=self._make_client_error('ConditionalCheckFailedException')
         )
@@ -725,18 +818,18 @@ class TestUpdateDataClientErrors:
         monkeypatch.setattr(update_module, 'get_error_code',
                             lambda e: e.response['Error']['Code'])
 
-        update_module._update_data(
-            {}, 'tbl', lambda item: {'Key': {'id': 'x'}, 'CE': 'cond'}, 0, 1,
-            MagicMock(), MagicMock(), MagicMock(), MagicMock(), MagicMock()
+        update_module._execute_updates(
+            iter([{'Key': {'id': 'x'}, 'CE': 'cond'}]), 'tbl',
+            MagicMock(), MagicMock(), MagicMock(), MagicMock(), {}
         )
 
         out = capsys.readouterr().out
         assert 'condition expression failed' in out
         assert "{'Key': {'id': 'x'}, 'CE': 'cond'}" in out
 
-    def test_unhandled_client_error_re_raises(self, monkeypatch):
-        """Lines 144-146: unknown error code prints to stderr and re-raises."""
-        table = _make_table_with_scan([{'Items': [{'id': 1}]}])
+    def test_unhandled_client_error_captured(self, monkeypatch):
+        """Unknown error code is caught by outer except and added to error_accumulator."""
+        table = MagicMock()
         err = self._make_client_error('InternalServerError', 'oops')
         table.update_item = MagicMock(side_effect=err)
         rl = _make_rl_worker(table)
@@ -746,19 +839,18 @@ class TestUpdateDataClientErrors:
         monkeypatch.setattr(update_module, 'get_error_message', lambda e: str(e))
 
         error_acc = MagicMock()
-        # The re-raise is caught by the outer except (line 152)
-        update_module._update_data(
-            {}, 'tbl', lambda item: {'Key': item}, 5, 10,
-            MagicMock(), MagicMock(), MagicMock(), error_acc, MagicMock()
+        update_module._execute_updates(
+            iter([{'Key': {'id': 1}}]), 'tbl',
+            MagicMock(), MagicMock(), error_acc, MagicMock(), {}
         )
 
         error_acc.add.assert_called_once()
         msg = error_acc.add.call_args.args[0][0]
-        assert 'worker 5' in msg
+        assert 'update worker' in msg
 
     def test_unhandled_client_error_prints_to_stderr(self, monkeypatch, capsys):
-        """Line 145: unhandled error printed to stderr."""
-        table = _make_table_with_scan([{'Items': [{'id': 1}]}])
+        """Unhandled error printed to stderr."""
+        table = MagicMock()
         err = self._make_client_error('InternalServerError', 'oops')
         table.update_item = MagicMock(side_effect=err)
         rl = _make_rl_worker(table)
@@ -767,169 +859,88 @@ class TestUpdateDataClientErrors:
                             lambda e: e.response['Error']['Code'])
         monkeypatch.setattr(update_module, 'get_error_message', lambda e: str(e))
 
-        update_module._update_data(
-            {}, 'tbl', lambda item: {'Key': item}, 0, 1,
-            MagicMock(), MagicMock(), MagicMock(), MagicMock(), MagicMock()
+        update_module._execute_updates(
+            iter([{'Key': {'id': 1}}]), 'tbl',
+            MagicMock(), MagicMock(), MagicMock(), MagicMock(), {}
         )
 
         err_out = capsys.readouterr().err
         assert 'Unhandled ClientError' in err_out
 
 
-class TestUpdateDataErrorAccumulation:
-    """Lines 152-153: outer except catches errors and adds to error_accumulator."""
-
-    def test_scan_error_captured_in_accumulator(self, monkeypatch):
-        """Line 153: error from scan is caught and added to error_accumulator."""
-        table = MagicMock()
-        table.scan = MagicMock(side_effect=RuntimeError('network fail'))
-        rl = _make_rl_worker(table)
-        monkeypatch.setattr(update_module, 'RateLimiterWorker', MagicMock(return_value=rl))
-        monkeypatch.setattr(update_module, 'get_error_message', lambda e: f'wrapped:{e}')
-
-        error_acc = MagicMock()
-        update_module._update_data(
-            {}, 'tbl', lambda item: {'Key': item}, 7, 10,
-            MagicMock(), MagicMock(), MagicMock(), error_acc, MagicMock()
-        )
-
-        error_acc.add.assert_called_once()
-        appended = error_acc.add.call_args.args[0]
-        assert isinstance(appended, list) and len(appended) == 1
-        assert 'worker 7' in appended[0]
-        assert 'wrapped:' in appended[0]
-
-    def test_system_exit_from_throttle_captured(self, monkeypatch):
-        """Lines 137-138 + 152: exit() raises SystemExit caught by outer except."""
-        table = _make_table_with_scan([{'Items': [{'id': 1}]}])
-        table.update_item = MagicMock(
-            side_effect=botocore.exceptions.ClientError(
-                {'Error': {'Code': 'ProvisionedThroughputExceededException', 'Message': 'throttled'}},
-                'UpdateItem'
-            )
-        )
-        rl = _make_rl_worker(table)
-        monkeypatch.setattr(update_module, 'RateLimiterWorker', MagicMock(return_value=rl))
-        monkeypatch.setattr(update_module, 'get_error_code',
-                            lambda e: e.response['Error']['Code'])
-        monkeypatch.setattr(update_module, 'get_error_message', lambda e: str(e))
-
-        error_acc = MagicMock()
-        # SystemExit is a BaseException — the except Exception won't catch it
-        with pytest.raises(SystemExit):
-            update_module._update_data(
-                {}, 'tbl', lambda item: {'Key': item}, 0, 1,
-                MagicMock(), MagicMock(), MagicMock(), error_acc, MagicMock()
-            )
-
-
-class TestUpdateDataShutdown:
-    """Lines 155-156: rate_limiter_worker.shutdown() always called in finally."""
+class TestExecuteUpdatesShutdown:
+    """rate_limiter_worker.shutdown() always called in finally."""
 
     def test_shutdown_called_on_success(self, monkeypatch):
-        """Line 156: shutdown called after successful scan loop."""
-        table = _make_table_with_scan([{'Items': []}])
+        table = MagicMock()
         rl_instance = MagicMock()
         rl_instance.get_session.return_value.resource.return_value.Table.return_value = table
         monkeypatch.setattr(update_module, 'RateLimiterWorker', MagicMock(return_value=rl_instance))
 
-        update_module._update_data(
-            {}, 'tbl', lambda item: None, 0, 1,
-            MagicMock(), MagicMock(), MagicMock(), MagicMock(), MagicMock()
+        update_module._execute_updates(
+            iter([]), 'tbl', MagicMock(), MagicMock(), MagicMock(), MagicMock(), {}
         )
 
         rl_instance.shutdown.assert_called_once()
 
     def test_shutdown_called_on_error(self, monkeypatch):
-        """Line 156: shutdown called even when scan raises."""
         table = MagicMock()
-        table.scan = MagicMock(side_effect=RuntimeError('boom'))
+        table.update_item = MagicMock(side_effect=RuntimeError('boom'))
         rl_instance = MagicMock()
         rl_instance.get_session.return_value.resource.return_value.Table.return_value = table
         monkeypatch.setattr(update_module, 'RateLimiterWorker', MagicMock(return_value=rl_instance))
         monkeypatch.setattr(update_module, 'get_error_message', lambda e: str(e))
 
-        update_module._update_data(
-            {}, 'tbl', lambda item: None, 0, 1,
-            MagicMock(), MagicMock(), MagicMock(), MagicMock(), MagicMock()
+        update_module._execute_updates(
+            iter([{'Key': {'id': 1}}]), 'tbl',
+            MagicMock(), MagicMock(), MagicMock(), MagicMock(), {}
         )
 
         rl_instance.shutdown.assert_called_once()
 
+    def test_boto3_config_has_4_second_timeouts_and_50_retries(self, monkeypatch):
+        """Config has connect_timeout=4.0, read_timeout=4.0, 50 retries."""
+        seen_configs = []
 
-class TestUpdateDataAccumulatorReporting:
-    """Lines 158-163: after the try/finally, accumulators get .add() and print."""
+        rl_instance = MagicMock()
+        session = MagicMock()
 
-    def test_accumulators_receive_correct_counts(self, monkeypatch):
-        """Lines 160-162: updated/skipped/failed counts added to accumulators."""
-        # 3 items: first two get updated, third skipped
-        table = _make_table_with_scan([{'Items': [{'id': 1}, {'id': 2}, {'id': 3}]}])
-        rl = _make_rl_worker(table)
-        monkeypatch.setattr(update_module, 'RateLimiterWorker', MagicMock(return_value=rl))
+        def capture_resource(name, **kw):
+            seen_configs.append(kw.get('config'))
+            r = MagicMock()
+            r.Table.return_value = MagicMock()
+            return r
 
-        def gen(item):
-            if item['id'] == 3:
-                return None
-            return {'Key': item}
+        session.resource = capture_resource
+        rl_instance.get_session.return_value = session
+        monkeypatch.setattr(update_module, 'RateLimiterWorker', MagicMock(return_value=rl_instance))
 
-        updated_acc = MagicMock()
-        skipped_acc = MagicMock()
-        failed_acc = MagicMock()
-
-        update_module._update_data(
-            {}, 'tbl', gen, 0, 1,
-            updated_acc, skipped_acc, failed_acc, MagicMock(), MagicMock()
+        update_module._execute_updates(
+            iter([]), 'tbl', MagicMock(), MagicMock(), MagicMock(), MagicMock(), {}
         )
 
-        updated_acc.add.assert_called_once_with(2)
-        skipped_acc.add.assert_called_once_with(1)
-        failed_acc.add.assert_called_once_with(0)
-
-    def test_prints_worker_summary(self, monkeypatch, capsys):
-        """Line 159: prints worker segment/total and record breakdown."""
-        table = _make_table_with_scan([{'Items': [{'id': 1}]}])
-        rl = _make_rl_worker(table)
-        monkeypatch.setattr(update_module, 'RateLimiterWorker', MagicMock(return_value=rl))
-
-        update_module._update_data(
-            {}, 'tbl', lambda item: {'Key': item}, 3, 10,
-            MagicMock(), MagicMock(), MagicMock(), MagicMock(), MagicMock()
-        )
-
-        out = capsys.readouterr().out
-        assert 'Worker 3/10' in out
-        assert '1' in out  # 1 record processed
-
-    def test_returns_zero(self, monkeypatch):
-        """Line 163: _update_data always returns 0."""
-        table = _make_table_with_scan([{'Items': []}])
-        rl = _make_rl_worker(table)
-        monkeypatch.setattr(update_module, 'RateLimiterWorker', MagicMock(return_value=rl))
-
-        result = update_module._update_data(
-            {}, 'tbl', lambda item: None, 0, 1,
-            MagicMock(), MagicMock(), MagicMock(), MagicMock(), MagicMock()
-        )
-
-        assert result == 0
+        assert len(seen_configs) == 1
+        cfg = seen_configs[0]
+        assert cfg.connect_timeout == 4.0
+        assert cfg.read_timeout == 4.0
+        assert cfg.retries['mode'] == 'standard'
+        assert cfg.retries['total_max_attempts'] == 50
 
 
-class TestUpdateDataMonitorOptions:
-    """Line 99: monitor_options are passed as kwargs to RateLimiterWorker."""
+class TestExecuteUpdatesMonitorOptions:
+    """monitor_options are passed as kwargs to RateLimiterWorker."""
 
     def test_monitor_options_splatted_into_worker(self, monkeypatch):
-        """Line 99: **monitor_options passed to RateLimiterWorker constructor."""
         rl_class = MagicMock()
         rl_instance = MagicMock()
-        rl_instance.get_session.return_value.resource.return_value.Table.return_value.scan.return_value = {'Items': []}
+        rl_instance.get_session.return_value.resource.return_value.Table.return_value = MagicMock()
         rl_class.return_value = rl_instance
         monkeypatch.setattr(update_module, 'RateLimiterWorker', rl_class)
 
         monitor_opts = {'monitor_table': 'my-tbl', 'max_rate': 500}
 
-        update_module._update_data(
-            monitor_opts, 'tbl', lambda item: None, 0, 1,
-            MagicMock(), MagicMock(), MagicMock(), MagicMock(), MagicMock()
+        update_module._execute_updates(
+            iter([]), 'tbl', MagicMock(), MagicMock(), MagicMock(), MagicMock(), monitor_opts
         )
 
         call_kwargs = rl_class.call_args.kwargs


### PR DESCRIPTION
Addresses #87. Splits update into a scan phase followed by an update phase, spreading write traffic more evenly across partitions.

~530 lines (refactor of update module + tests).