### PR TITLE
[bulk_executor] fix+feat: client-side UX, validation, and performance

### DIFF
--- a/tools/bulk_executor/bulk
+++ b/tools/bulk_executor/bulk
@@ -4,6 +4,7 @@ import importlib
 import sys
 
 sys.path.append('./client/src/')
+import botocore.exceptions
 import utils
 from env_configs import EnvConfigs
 from infrastructure import BootstrapInfrastructure
@@ -83,19 +84,31 @@ action_script_function = _get_action_script_function(action)
 if(action_script_function is None):
     exit(1) # No verb to take additional action on.
 
-env_configs = _get_env_configs()
+try:
+    env_configs = _get_env_configs()
 
-# Run client side verb script
-is_client_and_server_action, processed_args = action_script_function(env_configs)  # Run the client side verb function
+    # Run client side verb script
+    is_client_and_server_action, processed_args = action_script_function(env_configs)  # Run the client side verb function
 
-if(is_client_and_server_action): # Only run the server if the client script DNE or verifies the server script should also be run.
-    # Run server side verb script
-    args = utils.get_args_from_processed_args(processed_args)
-    script_args = utils.convert_client_dict_to_script_args(processed_args)
+    if(is_client_and_server_action): # Only run the server if the client script DNE or verifies the server script should also be run.
+        # Run server side verb script
+        args = utils.get_args_from_processed_args(processed_args)
+        script_args = utils.convert_client_dict_to_script_args(processed_args)
 
-    # Dev Mode - Push new code to S3 without a full bootstrap
-    if(args.get('XDev')):
-        BootstrapInfrastructure(env_configs).update_python_modules_in_s3()
+        # Dev Mode - Push new code to S3 without a full bootstrap
+        if(args.get('XDev')):
+            BootstrapInfrastructure(env_configs).update_python_modules_in_s3()
 
-    # Run the server side verb function (Glue Job)
-    BulkDynamoDbRunner(env_configs).run(args, script_args)
+        # Run the server side verb function (Glue Job)
+        BulkDynamoDbRunner(env_configs).run(args, script_args)
+
+except botocore.exceptions.ClientError as e:
+    error_code = e.response['Error']['Code']
+    error_message = e.response['Error']['Message']
+    print(f"\nError: {error_code} — {error_message}", file=sys.stderr)
+    print("Job failed.", file=sys.stderr)
+    exit(1)
+except botocore.exceptions.BotoCoreError as e:
+    print(f"\nError: {e}", file=sys.stderr)
+    print("Job failed.", file=sys.stderr)
+    exit(1)

--- a/tools/bulk_executor/client/src/infrastructure/bootstrap.py
+++ b/tools/bulk_executor/client/src/infrastructure/bootstrap.py
@@ -37,6 +37,8 @@ from .constants import (
     THIRD_PARTY_PYTHON_MODULES,
 )
 
+ROLE_VERSION_TAG_KEY = 'BulkDynamoDBVersion'
+
 
 class BootstrapInfrastructure:
     def __init__(self, env_configs):
@@ -74,6 +76,10 @@ class BootstrapInfrastructure:
         is_write_access = role_param == ROLE_TYPE_READ_WRITE
         role_id = READ_WRITE_ROLE_ID if is_write_access else READ_ONLY_ROLE_ID
         return f"{GLUE_JOB_ROOT_ROLE_NAME}-{role_id}-{self.aws_region}" # region definition for separate region specific permissioning
+
+    def _is_builtin_role(self, args):
+        role_param = args.get('XRole', '')
+        return not role_param or role_param in READ_WRITE_ROLE_TYPES
 
     def _add_glue_job_role(self, args):
         log.info("Adding Glue Job role...")
@@ -120,7 +126,8 @@ class BootstrapInfrastructure:
             ]
         }
 
-        # Create the role
+        # Create the role or check if it needs a policy refresh
+        role_exists = False
         try:
             response = self.iam_client.create_role(
                 RoleName=role_name,
@@ -129,12 +136,22 @@ class BootstrapInfrastructure:
 
             log.info(f"Bulk Executor Glue Job Role created: {role_name}")
             log.debug(f'Role ARN: {response["Role"]["Arn"]}')
-        except self.iam_client.exceptions.EntityAlreadyExistsException as e:
+        except self.iam_client.exceptions.EntityAlreadyExistsException:
+            role_exists = True
             log.info(f"Found Bulk Executor Glue Job Role: {role_name}")
-            return # Roles exists. No additional actions needed.
         except Exception as e:
             log.error(f'Unexpected error: {e}')
             exit(1)
+
+        if role_exists:
+            if not self._is_builtin_role(args):
+                log.info(f"Custom role {role_name} exists. Skipping policy management.")
+                return
+            existing_version = self._get_role_version_tag(role_name)
+            if existing_version == VERSION:
+                log.info(f"Role {role_name} is up to date (version {VERSION}).")
+                return
+            log.info(f"Role {role_name} version mismatch (tagged={existing_version}, current={VERSION}). Refreshing policies...")
 
         policy_arns = [
             'arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole', # S3 permissions etc are handled here
@@ -172,6 +189,27 @@ class BootstrapInfrastructure:
         except Exception as e:
             log.error(f'Unexpected error: {e}')
             exit(1)
+
+        self._tag_role_version(role_name)
+
+    def _get_role_version_tag(self, role_name):
+        try:
+            response = self.iam_client.list_role_tags(RoleName=role_name)
+            for tag in response.get('Tags', []):
+                if tag['Key'] == ROLE_VERSION_TAG_KEY:
+                    return tag['Value']
+            return None
+        except Exception:
+            return None
+
+    def _tag_role_version(self, role_name):
+        try:
+            self.iam_client.tag_role(
+                RoleName=role_name,
+                Tags=[{'Key': ROLE_VERSION_TAG_KEY, 'Value': VERSION}]
+            )
+        except Exception as e:
+            log.warning(f'Could not tag role {role_name} with version: {e}')
 
     def _is_existing_role(self, role_name):
         try:

--- a/tools/bulk_executor/client/src/infrastructure/bootstrap.py
+++ b/tools/bulk_executor/client/src/infrastructure/bootstrap.py
@@ -277,7 +277,7 @@ class BootstrapInfrastructure:
         # concerns and are not needed at job runtime, so they are excluded
         # from DefaultArguments. See issue #85.
         for key, value in args.items():
-            if key.startswith('X') and key not in ('XRole', 'XRegion', 'XAccount'):
+            if key.startswith('X') and key not in ('XRole', 'XRegion', 'XAccount', 'XExistingBucket'):
                 default_arguments[f'--{key}'] = str(value)
 
         default_arguments.update({ # Update last intentional.
@@ -369,23 +369,24 @@ class BootstrapInfrastructure:
     def _upload_job_root_to_s3(self):
         glue_job_bucket = self._get_glue_job_bucket_name()
 
-        # Check if the bucket exists
-        if not self._bucket_exists(self.s3_client, glue_job_bucket):
-            try:
-                # Create the bucket
-                bucket_config = {}
-                if self.aws_region != 'us-east-1': # Default is us-east-1 so LocationConstraint fails if configured for this region.
-                    bucket_config['CreateBucketConfiguration'] = {'LocationConstraint': self.aws_region}
-                self.s3_client.create_bucket(
-                    Bucket=glue_job_bucket,
-                    **bucket_config
-                )
-                log.info(f"Bucket '{glue_job_bucket}' created successfully!")
-            except Exception as e:
-                log.error(f"Error creating bucket '{glue_job_bucket}': {e}")
-                exit(1)
-        else:
-            log.info(f"Bucket '{glue_job_bucket}' already exists.")
+        if not getattr(self, '_existing_bucket', None):
+            # Check if the bucket exists
+            if not self._bucket_exists(self.s3_client, glue_job_bucket):
+                try:
+                    # Create the bucket
+                    bucket_config = {}
+                    if self.aws_region != 'us-east-1': # Default is us-east-1 so LocationConstraint fails if configured for this region.
+                        bucket_config['CreateBucketConfiguration'] = {'LocationConstraint': self.aws_region}
+                    self.s3_client.create_bucket(
+                        Bucket=glue_job_bucket,
+                        **bucket_config
+                    )
+                    log.info(f"Bucket '{glue_job_bucket}' created successfully!")
+                except Exception as e:
+                    log.error(f"Error creating bucket '{glue_job_bucket}': {e}")
+                    exit(1)
+            else:
+                log.info(f"Bucket '{glue_job_bucket}' already exists.")
 
         # Apply the secure transport policy
         try:
@@ -423,7 +424,16 @@ class BootstrapInfrastructure:
         self.s3_client.upload_file(f"./{GLUE_JOB_SERVER_ROOT_PATH}", glue_job_bucket, GLUE_JOB_SERVER_ROOT_PATH)
         log.info(f"Glue script '{GLUE_JOB_SERVER_ROOT_PATH}' uploaded into S3 successfully.")
 
+    def _validate_existing_bucket(self, bucket_name):
+        if not self._bucket_exists(self.s3_client, bucket_name):
+            log.error(f"The specified bucket '{bucket_name}' does not exist or is not accessible.")
+            exit(1)
+        log.info(f"Using existing S3 bucket: {bucket_name}")
+
     def _get_glue_job_bucket_name(self):
+        if getattr(self, '_existing_bucket', None):
+            return self._existing_bucket
+
         # Return the existing persisted S3 Bucket name
         job_details = self._get_glue_job_details()
         if job_details:
@@ -588,6 +598,13 @@ class BootstrapInfrastructure:
                 exit(1)
 
     def bootstrap(self, args):
+        existing_bucket = args.get('XExistingBucket')
+        if existing_bucket:
+            self._validate_existing_bucket(existing_bucket)
+            self._existing_bucket = existing_bucket
+        else:
+            self._existing_bucket = None
+
         self._add_glue_job_role(args)
         self._create_glue_log_groups()
         self._ensure_dynamodb_glue_connection()

--- a/tools/bulk_executor/client/src/infrastructure/bootstrap.py
+++ b/tools/bulk_executor/client/src/infrastructure/bootstrap.py
@@ -290,9 +290,11 @@ class BootstrapInfrastructure:
             '--s3-bucket-name': glue_job_bucket,
             '--s3-script-location': s3_script_location,
             '--extra-py-files': s3_python_module_location,
-            '--additional-python-modules': THIRD_PARTY_PYTHON_MODULES,
             '--bulk-dynamodb-version': VERSION
         })
+
+        if THIRD_PARTY_PYTHON_MODULES:
+            default_arguments['--additional-python-modules'] = THIRD_PARTY_PYTHON_MODULES
 
         # Custom log4j2 properties override continuous CloudWatch logging
         # Reference: https://repost.aws/knowledge-center/glue-reduce-cloudwatch-logs

--- a/tools/bulk_executor/client/src/infrastructure/bootstrap.py
+++ b/tools/bulk_executor/client/src/infrastructure/bootstrap.py
@@ -67,6 +67,7 @@ class BootstrapInfrastructure:
             if not self._is_existing_role(role_param):
                 print(f"Provided --XRole '{role_param}' name does not exist!")
                 exit(1)
+            self._check_custom_role_permissions(role_param)
             return role_param
 
         # Handle standard role types
@@ -181,6 +182,39 @@ class BootstrapInfrastructure:
         except Exception as e:
             log.error(f'Unexpected error when checking for existing IAM Role: {e}')
             exit(1)
+
+    # Minimum actions a custom Glue execution role must be able to perform.
+    REQUIRED_ACTIONS = [
+        'dynamodb:DescribeTable',
+        'dynamodb:Scan',
+        's3:GetObject',
+        's3:PutObject',
+        'logs:CreateLogGroup',
+        'logs:PutLogEvents',
+        'pricing:GetProducts',
+        'servicequotas:GetServiceQuota',
+    ]
+
+    def _check_custom_role_permissions(self, role_name):
+        role_arn = f"arn:aws:iam::{self.aws_account_id}:role/{role_name}"
+        try:
+            response = self.iam_client.simulate_principal_policy(
+                PolicySourceArn=role_arn,
+                ActionNames=self.REQUIRED_ACTIONS,
+            )
+            denied = [
+                r['EvalActionName']
+                for r in response.get('EvaluationResults', [])
+                if r.get('EvalDecision') != 'allowed'
+            ]
+            if denied:
+                log.warning(
+                    f"Custom role '{role_name}' may be missing required permissions: "
+                    f"{', '.join(denied)}. "
+                    f"Execution may fail. See documentation for minimum required permissions."
+                )
+        except Exception as e:
+            log.debug(f"Unable to verify permissions for role '{role_name}': {e}")
 
     def _create_or_update_glue_job(self, args, is_create_allowed=True):
         glue_job_bucket = self._get_glue_job_bucket_name()

--- a/tools/bulk_executor/client/src/infrastructure/constants.py
+++ b/tools/bulk_executor/client/src/infrastructure/constants.py
@@ -42,10 +42,16 @@ class GlueJobDefaults(Enum):
     NumberOfWorkers=220
     WorkerType='G.1X'
 
-# Third Party Dependencies as an alpha-numeric list
-_THIRD_PARTY_PYTHON_MODULES = [
-  'faker'
-]
+# Third Party Dependencies installed on every Glue run (alpha-numeric list).
+# Verb-specific deps go in VERB_PYTHON_MODULES below.
+_THIRD_PARTY_PYTHON_MODULES = []
 
 # Convert to AWS Glue Readable Format
 THIRD_PARTY_PYTHON_MODULES = ','.join(map(str, _THIRD_PARTY_PYTHON_MODULES))
+
+# Dependencies needed only for specific verbs (keyed by verb name).
+# These are added per-run via start_job_run Arguments to avoid
+# installing them for every job invocation.
+VERB_PYTHON_MODULES = {
+    'fill': ['faker'],
+}

--- a/tools/bulk_executor/client/src/infrastructure/constants.py
+++ b/tools/bulk_executor/client/src/infrastructure/constants.py
@@ -38,6 +38,7 @@ class GlueJobDefaults(Enum):
     MaxConcurrentRuns=20
     Retries=0
     Timeout=60
+    IdleTimeout=5
     NumberOfWorkers=220
     WorkerType='G.1X'
 

--- a/tools/bulk_executor/client/src/infrastructure/constants.py
+++ b/tools/bulk_executor/client/src/infrastructure/constants.py
@@ -43,7 +43,9 @@ class GlueJobDefaults(Enum):
     WorkerType='G.1X'
 
 # Third Party Dependencies installed on every Glue run (alpha-numeric list).
-# Verb-specific deps go in VERB_PYTHON_MODULES below.
+# Verb-specific deps go in VERB_PYTHON_MODULES below — faker moved there
+# because it's only needed by 'fill' and pip-installing it on every run
+# added ~8s to worker startup for all other verbs.
 _THIRD_PARTY_PYTHON_MODULES = []
 
 # Convert to AWS Glue Readable Format

--- a/tools/bulk_executor/client/src/python_modules/bootstrap.py
+++ b/tools/bulk_executor/client/src/python_modules/bootstrap.py
@@ -40,6 +40,7 @@ def run(env_configs):
     parser.add_argument("--XRole", type=validate_role, default=argparse.SUPPRESS, help="The AWS Role to use for executing the action. Specify a custom role name, or use the special keywords READ-ONLY or READ-WRITE to generate a managed role.")
     parser.add_argument("--XMaxConcurrentRuns", type=int, default=argparse.SUPPRESS, help="The maximum number of concurrent runs to allow for the single Glue Job (default is 20).")
     parser.add_argument("--XRetries", type=int, default=argparse.SUPPRESS, help="The max number of Glue Job retries. Defaults to zero to fail a misconfigured Glue Job quickly.")
+    parser.add_argument("--XExistingBucket", type=str, default=argparse.SUPPRESS, help="Use an existing S3 bucket instead of creating a new one. The bucket must exist and be accessible. It should follow the Glue naming prefix convention (aws-glue-*).")
 
     #result = {k: v for k, v in vars(args).items() if v is not None}
     result = parser.parse_args().__dict__

--- a/tools/bulk_executor/client/src/python_modules/load.py
+++ b/tools/bulk_executor/client/src/python_modules/load.py
@@ -104,7 +104,7 @@ def run(env_configs):
         parser.error('--format should be "csv", "json" or "parquet"')
 
     result = args.__dict__
-    utils.validate_tables(env_configs, parser, result['table'])
+    utils.validate_tables(env_configs, parser, result['table'], pitr_enabled=True)
 
     log.info(f"Running action '{result['verb']}' with arguments: {result}")
 

--- a/tools/bulk_executor/client/src/runner.py
+++ b/tools/bulk_executor/client/src/runner.py
@@ -14,7 +14,7 @@ from botocore.exceptions import (
 # project files
 from clients import Clients
 from infrastructure import GLUE_JOB_NAME, GlueJobDefaults
-from infrastructure.constants import GLUE_LOG_GROUP_ERROR, GLUE_LOG_GROUP_OUTPUT
+from infrastructure.constants import GLUE_LOG_GROUP_ERROR, GLUE_LOG_GROUP_OUTPUT, VERB_PYTHON_MODULES
 from infrastructure.verifier import assert_version_parity, is_existing_glue_job
 from reassembler import GlueLogReassembler
 from utils.graceful_interrupt_handler import GracefulInterruptHandler
@@ -333,6 +333,11 @@ class BulkDynamoDbRunner:
                     if key == "verb": # Server-side thinks of verb as XAction
                         key = "XAction"
                     arguments[f"--{key}"] = value
+
+        action = arguments.get('--XAction', '')
+        verb_modules = VERB_PYTHON_MODULES.get(action, [])
+        if verb_modules:
+            arguments['--additional-python-modules'] = ','.join(verb_modules)
 
         log.debug(f"All Glue Job args: {arguments}")
         return arguments

--- a/tools/bulk_executor/client/src/runner.py
+++ b/tools/bulk_executor/client/src/runner.py
@@ -374,6 +374,7 @@ class BulkDynamoDbRunner:
                 NumberOfWorkers=args.get('XNumberOfWorkers', GlueJobDefaults.NumberOfWorkers.value),
                 Timeout=args.get('XTimeout', GlueJobDefaults.Timeout.value),
                 WorkerType=args.get('XWorkerType', GlueJobDefaults.WorkerType.value),
+                IdleTimeout=args.get('XIdleTimeout', GlueJobDefaults.IdleTimeout.value),
             )
             return response['JobRunId']
         except Exception as e:

--- a/tools/bulk_executor/client/src/runner.py
+++ b/tools/bulk_executor/client/src/runner.py
@@ -14,7 +14,7 @@ from botocore.exceptions import (
 # project files
 from clients import Clients
 from infrastructure import GLUE_JOB_NAME, GlueJobDefaults
-from infrastructure.constants import GLUE_LOG_GROUP_ERROR, GLUE_LOG_GROUP_OUTPUT, VERB_PYTHON_MODULES
+from infrastructure.constants import GLUE_LOG_GROUP_ERROR, GLUE_LOG_GROUP_OUTPUT, THIRD_PARTY_PYTHON_MODULES, VERB_PYTHON_MODULES
 from infrastructure.verifier import assert_version_parity, is_existing_glue_job
 from reassembler import GlueLogReassembler
 from utils.graceful_interrupt_handler import GracefulInterruptHandler
@@ -337,7 +337,8 @@ class BulkDynamoDbRunner:
         action = arguments.get('--XAction', '')
         verb_modules = VERB_PYTHON_MODULES.get(action, [])
         if verb_modules:
-            arguments['--additional-python-modules'] = ','.join(verb_modules)
+            all_modules = ([THIRD_PARTY_PYTHON_MODULES] if THIRD_PARTY_PYTHON_MODULES else []) + verb_modules
+            arguments['--additional-python-modules'] = ','.join(all_modules)
 
         log.debug(f"All Glue Job args: {arguments}")
         return arguments

--- a/tools/bulk_executor/client/src/utils/__init__.py
+++ b/tools/bulk_executor/client/src/utils/__init__.py
@@ -81,6 +81,17 @@ def validate_timeout(x):
         raise argparse.ArgumentTypeError(f"Timeout must be an integer")
 
 
+def validate_idle_timeout(x):
+    try:
+        value = int(x)
+        if 1 <= value <= 10080:
+            return value
+        else:
+            raise argparse.ArgumentTypeError(f"IdleTimeout must be between 1 and 10080 minutes (7 days)")
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"IdleTimeout must be an integer")
+
+
 # The defaults stated below should perhaps be dynamic from constants.py
 def parse_action():
     parser = argparse.ArgumentParser(
@@ -98,6 +109,7 @@ def glue_job_arguments():
 
     parser.add_argument("--XExecutionClass", type=str, default=argparse.SUPPRESS, help="Set to STANDARD (default) or FLEX (lower DPU cost by using spare capacity, may take longer).", choices=SUPPORTED_EXECUTION_CLASSES)
     parser.add_argument("--XTimeout", type=validate_timeout, default=argparse.SUPPRESS, help="The Glue Job timeout (in minutes). Must be between 1 and 10080 minutes (7 days is the max allowed timeout). Default is 60 minutes.")
+    parser.add_argument("--XIdleTimeout", type=validate_idle_timeout, default=argparse.SUPPRESS, help="The Glue Job idle timeout (in minutes). Workers stop early when idle for this duration, reducing cost. Must be between 1 and 10080 minutes. Default is 5 minutes.")
     parser.add_argument("--XNumberOfWorkers", type=int, default=argparse.SUPPRESS, help="The number of Glue workers (default 220).")
     parser.add_argument("--XWorkerType", type=str, default=argparse.SUPPRESS, help="The Glue worker type. ex. G.1X", choices=SUPPORTED_WORKER_TYPES)
     parser.add_argument("--XWaitForDPU", action='store_true', default=argparse.SUPPRESS, help="Causes execution to wait 40 seconds at the end of execution for DPU metrics to be available.")

--- a/tools/bulk_executor/client/src/utils/module_zipper.py
+++ b/tools/bulk_executor/client/src/utils/module_zipper.py
@@ -8,6 +8,23 @@ from infrastructure.constants import (
 )
 from utils.logger import log
 
+EXCLUDED_DIRS = {'__pycache__', '.pytest_cache', '.git', '*.egg-info'}
+EXCLUDED_FILES = {'.DS_Store', 'Thumbs.db', '.gitignore'}
+EXCLUDED_EXTENSIONS = {'.pyc', '.pyo'}
+
+
+def _is_excluded_dir(name):
+    if name in EXCLUDED_DIRS:
+        return True
+    return name.endswith('.egg-info')
+
+
+def _is_excluded_file(name):
+    if name in EXCLUDED_FILES:
+        return True
+    _, ext = os.path.splitext(name)
+    return ext in EXCLUDED_EXTENSIONS
+
 
 def zip_module():
     return _zip_module(PYTHON_MODULE_CLIENT_DIR_PATH, PYTHON_MODULE_CLIENT_ZIP_PATH)
@@ -28,7 +45,12 @@ def _zip_module(source_path, zip_path):
             zipf.writestr(parent_dir + '/', '')
 
             for root, dirs, files in os.walk(source_path):
+                dirs[:] = [d for d in dirs if not _is_excluded_dir(d)]
+
                 for file in files:
+                    if _is_excluded_file(file):
+                        continue
+
                     file_path = os.path.join(root, file)
 
                     # Skip any symlinked files out of an abundance of caution

--- a/tools/bulk_executor/tests/client/infrastructure/test_constants.py
+++ b/tools/bulk_executor/tests/client/infrastructure/test_constants.py
@@ -1,0 +1,32 @@
+"""Unit tests for client/src/infrastructure/constants.py.
+
+Verifies that third-party dependency declarations are correct:
+- faker MUST be available for the 'fill' verb (moved from global to verb-specific)
+- Non-fill verbs must not pull in faker (the performance optimization)
+"""
+
+from infrastructure.constants import (
+    _THIRD_PARTY_PYTHON_MODULES,
+    THIRD_PARTY_PYTHON_MODULES,
+    VERB_PYTHON_MODULES,
+)
+
+
+class TestVerbPythonModules:
+    """Verify verb-specific dependency declarations."""
+
+    def test_faker_declared_for_fill_verb(self):
+        """faker must be available for the fill verb — it generates fake data."""
+        assert 'fill' in VERB_PYTHON_MODULES
+        assert 'faker' in VERB_PYTHON_MODULES['fill']
+
+    def test_faker_not_in_global_modules(self):
+        """faker should NOT be in global modules (perf: avoid pip install on every run)."""
+        assert 'faker' not in _THIRD_PARTY_PYTHON_MODULES
+        assert 'faker' not in THIRD_PARTY_PYTHON_MODULES
+
+    def test_non_fill_verbs_do_not_include_faker(self):
+        """Verbs other than fill must not declare faker as a dependency."""
+        for verb, modules in VERB_PYTHON_MODULES.items():
+            if verb != 'fill':
+                assert 'faker' not in modules, f"verb '{verb}' should not require faker"

--- a/tools/bulk_executor/tests/client/load/test_load_validate_tables.py
+++ b/tools/bulk_executor/tests/client/load/test_load_validate_tables.py
@@ -1,0 +1,121 @@
+"""Unit tests for load.run() — validate_tables invocation.
+
+PR #218 added pitr_enabled=True to the validate_tables call in load.py
+(commit 187adee). The reviewer asked for a unit test proving that load
+always requires PITR when validating the target table.
+"""
+
+import argparse
+import importlib.util
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_CLIENT_SRC = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), '..', '..', '..', 'client', 'src')
+)
+_LOAD_PY = os.path.join(_CLIENT_SRC, 'python_modules', 'load.py')
+
+
+@pytest.fixture
+def load_module():
+    """Import load.py from client/src without server-side collision."""
+    spec = importlib.util.spec_from_file_location('client_load', _LOAD_PY)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def csv_args():
+    """Minimal Namespace for CSV format."""
+    return argparse.Namespace(
+        verb='load',
+        table='my-table',
+        format='csv',
+        s3_path='s3://bucket/path',
+    )
+
+
+@pytest.fixture
+def json_args():
+    """Minimal Namespace for JSON format."""
+    return argparse.Namespace(
+        verb='load',
+        table='json-table',
+        format='json',
+        s3_path='s3://bucket/data.json',
+    )
+
+
+@pytest.fixture
+def parquet_args():
+    """Minimal Namespace for Parquet format."""
+    return argparse.Namespace(
+        verb='load',
+        table='parquet-table',
+        format='parquet',
+        s3_path='s3://bucket/data.parquet',
+    )
+
+
+class TestLoadValidateTablesCallsPitrEnabled:
+    """load.run() must call validate_tables with pitr_enabled=True."""
+
+    def _run_load_with_args(self, load_module, fake_args):
+        """Helper: run load.run() with mocked parser and utils."""
+        mock_utils = MagicMock()
+        mock_utils.glue_job_arguments.return_value = argparse.ArgumentParser(add_help=False)
+        mock_utils.environment_arguments.return_value = argparse.ArgumentParser(add_help=False)
+        mock_utils.validate_tables.return_value = None
+
+        mock_parser = MagicMock()
+        mock_parser.parse_args.return_value = fake_args
+
+        with patch.object(load_module, 'utils', mock_utils):
+            with patch.object(load_module, 'BulkArgumentParser', return_value=mock_parser):
+                load_module.run({'region': 'us-east-1'})
+
+        return mock_utils
+
+    def test_csv_load_calls_validate_tables_with_pitr_enabled(self, load_module, csv_args):
+        """CSV format load must require pitr_enabled=True."""
+        mock_utils = self._run_load_with_args(load_module, csv_args)
+
+        mock_utils.validate_tables.assert_called_once()
+        _, kwargs = mock_utils.validate_tables.call_args
+        assert kwargs.get('pitr_enabled') is True, (
+            "load.run() must pass pitr_enabled=True to validate_tables "
+            "so that bulk loads cannot target tables without PITR safety"
+        )
+
+    def test_json_load_calls_validate_tables_with_pitr_enabled(self, load_module, json_args):
+        """JSON format load must require pitr_enabled=True."""
+        mock_utils = self._run_load_with_args(load_module, json_args)
+
+        mock_utils.validate_tables.assert_called_once()
+        _, kwargs = mock_utils.validate_tables.call_args
+        assert kwargs.get('pitr_enabled') is True, (
+            "JSON format loads must also require pitr_enabled=True"
+        )
+
+    def test_parquet_load_calls_validate_tables_with_pitr_enabled(self, load_module, parquet_args):
+        """Parquet format load must require pitr_enabled=True."""
+        mock_utils = self._run_load_with_args(load_module, parquet_args)
+
+        mock_utils.validate_tables.assert_called_once()
+        _, kwargs = mock_utils.validate_tables.call_args
+        assert kwargs.get('pitr_enabled') is True, (
+            "Parquet format loads must also require pitr_enabled=True"
+        )
+
+    def test_validate_tables_receives_correct_table_name(self, load_module, csv_args):
+        """validate_tables must receive the table name from parsed args."""
+        mock_utils = self._run_load_with_args(load_module, csv_args)
+
+        args, _ = mock_utils.validate_tables.call_args
+        assert 'my-table' in args, (
+            "validate_tables must receive the table name from the parsed arguments"
+        )

--- a/tools/bulk_executor/tests/client/test_bootstrap.py
+++ b/tools/bulk_executor/tests/client/test_bootstrap.py
@@ -970,3 +970,112 @@ class TestBootstrapInit:
         assert instance.s3_client is clients.s3_client
         assert instance.glue_client is clients.glue_client
         assert instance.logs_client is clients.logs_client
+
+
+# -- XExistingBucket feature (GH#130) -------------------------------------
+
+class TestExistingBucket:
+    """Coverage for the --XExistingBucket parameter that allows users to
+    skip bucket creation and use a pre-existing S3 bucket."""
+
+    def test_existing_bucket_is_used_by_get_bucket_name(self, bootstrap):
+        from infrastructure.bootstrap import BootstrapInfrastructure
+        bootstrap._get_glue_job_bucket_name = BootstrapInfrastructure._get_glue_job_bucket_name.__get__(bootstrap)
+        bootstrap._existing_bucket = 'my-existing-bucket'
+        assert bootstrap._get_glue_job_bucket_name() == 'my-existing-bucket'
+
+    def test_existing_bucket_skips_bucket_creation(self, bootstrap):
+        from infrastructure.bootstrap import BootstrapInfrastructure
+        bootstrap._get_glue_job_bucket_name = BootstrapInfrastructure._get_glue_job_bucket_name.__get__(bootstrap)
+        bootstrap._existing_bucket = 'my-existing-bucket'
+        bootstrap._bucket_exists = MagicMock(return_value=True)
+
+        bootstrap._upload_job_root_to_s3()
+
+        bootstrap.s3_client.create_bucket.assert_not_called()
+        # Script upload still happens
+        bootstrap.s3_client.upload_file.assert_called_once()
+
+    def test_existing_bucket_still_applies_bucket_policy(self, bootstrap):
+        from infrastructure.bootstrap import BootstrapInfrastructure
+        bootstrap._get_glue_job_bucket_name = BootstrapInfrastructure._get_glue_job_bucket_name.__get__(bootstrap)
+        bootstrap._existing_bucket = 'my-existing-bucket'
+        bootstrap._bucket_exists = MagicMock(return_value=True)
+
+        bootstrap._upload_job_root_to_s3()
+
+        bootstrap.s3_client.put_bucket_policy.assert_called_once()
+        policy_kwargs = bootstrap.s3_client.put_bucket_policy.call_args.kwargs
+        assert policy_kwargs['Bucket'] == 'my-existing-bucket'
+
+    def test_validate_existing_bucket_succeeds_when_exists(self, bootstrap):
+        bootstrap.s3_client.head_bucket.return_value = {}
+        bootstrap._validate_existing_bucket('good-bucket')
+
+    def test_validate_existing_bucket_exits_when_not_found(self, bootstrap):
+        bootstrap.s3_client.head_bucket.side_effect = ClientError(
+            {'Error': {'Code': '404', 'Message': 'Not Found'}}, 'HeadBucket'
+        )
+        with pytest.raises(SystemExit) as exc:
+            bootstrap._validate_existing_bucket('bad-bucket')
+        assert exc.value.code == 1
+
+    def test_validate_existing_bucket_exits_when_forbidden(self, bootstrap):
+        bootstrap.s3_client.head_bucket.side_effect = ClientError(
+            {'Error': {'Code': '403', 'Message': 'Forbidden'}}, 'HeadBucket'
+        )
+        with pytest.raises(SystemExit) as exc:
+            bootstrap._validate_existing_bucket('forbidden-bucket')
+        assert exc.value.code == 1
+
+    def test_bootstrap_with_existing_bucket_sets_field(self, bootstrap):
+        bootstrap._validate_existing_bucket = MagicMock()
+        bootstrap._add_glue_job_role = MagicMock()
+        bootstrap._create_glue_log_groups = MagicMock()
+        bootstrap._create_or_update_glue_job = MagicMock()
+        bootstrap._upload_job_root_to_s3 = MagicMock()
+        bootstrap.update_python_modules_in_s3 = MagicMock()
+        bootstrap._upload_property_files_to_s3 = MagicMock()
+
+        bootstrap.bootstrap({'XRole': 'READ-ONLY', 'XExistingBucket': 'my-bucket'})
+
+        bootstrap._validate_existing_bucket.assert_called_once_with('my-bucket')
+        assert bootstrap._existing_bucket == 'my-bucket'
+
+    def test_bootstrap_without_existing_bucket_leaves_field_none(self, bootstrap):
+        bootstrap._add_glue_job_role = MagicMock()
+        bootstrap._create_glue_log_groups = MagicMock()
+        bootstrap._create_or_update_glue_job = MagicMock()
+        bootstrap._upload_job_root_to_s3 = MagicMock()
+        bootstrap.update_python_modules_in_s3 = MagicMock()
+        bootstrap._upload_property_files_to_s3 = MagicMock()
+
+        bootstrap.bootstrap({'XRole': 'READ-ONLY'})
+
+        assert bootstrap._existing_bucket is None
+
+    def test_existing_bucket_excluded_from_default_arguments(self, bootstrap):
+        result = _run(bootstrap, {'XExistingBucket': 'my-bucket', 'XWorkerType': 'G.1X'})
+        assert '--XExistingBucket' not in result
+        assert result.get('--XWorkerType') == 'G.1X'
+
+    def test_existing_bucket_none_does_not_override_persisted_bucket(self, bootstrap):
+        """When no existing bucket is specified, the persisted bucket from the
+        Glue job details is still used (standard behavior)."""
+        with patch('infrastructure.bootstrap.Clients') as MockClients:
+            clients = MagicMock()
+            clients.iam_client = MagicMock()
+            clients.s3_client = MagicMock()
+            clients.glue_client = MagicMock()
+            clients.logs_client = MagicMock()
+            MockClients.return_value = clients
+
+            from infrastructure.bootstrap import BootstrapInfrastructure
+            env = MagicMock(aws_region='us-east-1', aws_account_id='123456789012')
+            instance = BootstrapInfrastructure(env)
+
+        instance._existing_bucket = None
+        instance._get_glue_job_details = MagicMock(return_value={
+            'Job': {'DefaultArguments': {'--s3-bucket-name': 'persisted-bucket'}}
+        })
+        assert instance._get_glue_job_bucket_name() == 'persisted-bucket'

--- a/tools/bulk_executor/tests/client/test_bootstrap.py
+++ b/tools/bulk_executor/tests/client/test_bootstrap.py
@@ -151,6 +151,74 @@ class TestGetRoleName:
         assert 'NoSuchRole' in out
 
 
+# -- _check_custom_role_permissions -------------------------------------
+
+class TestCheckCustomRolePermissions:
+    """Coverage for the custom role minimum-permissions warning."""
+
+    def test_all_permissions_allowed_no_warning(self, bootstrap, caplog):
+        import logging
+        bootstrap.iam_client.simulate_principal_policy.return_value = {
+            'EvaluationResults': [
+                {'EvalActionName': action, 'EvalDecision': 'allowed'}
+                for action in bootstrap.REQUIRED_ACTIONS
+            ]
+        }
+        with caplog.at_level(logging.WARNING):
+            bootstrap._check_custom_role_permissions('GoodRole')
+        assert 'missing required permissions' not in caplog.text
+
+    def test_some_permissions_denied_emits_warning(self, bootstrap, caplog):
+        import logging
+        results = [
+            {'EvalActionName': 'dynamodb:DescribeTable', 'EvalDecision': 'allowed'},
+            {'EvalActionName': 'dynamodb:Scan', 'EvalDecision': 'allowed'},
+            {'EvalActionName': 's3:GetObject', 'EvalDecision': 'implicitDeny'},
+            {'EvalActionName': 's3:PutObject', 'EvalDecision': 'allowed'},
+            {'EvalActionName': 'logs:CreateLogGroup', 'EvalDecision': 'allowed'},
+            {'EvalActionName': 'logs:PutLogEvents', 'EvalDecision': 'allowed'},
+            {'EvalActionName': 'pricing:GetProducts', 'EvalDecision': 'explicitDeny'},
+            {'EvalActionName': 'servicequotas:GetServiceQuota', 'EvalDecision': 'allowed'},
+        ]
+        bootstrap.iam_client.simulate_principal_policy.return_value = {
+            'EvaluationResults': results
+        }
+        with caplog.at_level(logging.WARNING):
+            bootstrap._check_custom_role_permissions('PartialRole')
+        assert 'missing required permissions' in caplog.text
+        assert 's3:GetObject' in caplog.text
+        assert 'pricing:GetProducts' in caplog.text
+        assert 'dynamodb:DescribeTable' not in caplog.text
+
+    def test_simulate_api_error_does_not_block(self, bootstrap, caplog):
+        import logging
+        bootstrap.iam_client.simulate_principal_policy.side_effect = RuntimeError('access denied')
+        with caplog.at_level(logging.DEBUG):
+            bootstrap._check_custom_role_permissions('AnyRole')
+        assert 'Unable to verify permissions' in caplog.text
+
+    def test_constructs_correct_arn(self, bootstrap):
+        bootstrap.iam_client.simulate_principal_policy.return_value = {
+            'EvaluationResults': []
+        }
+        bootstrap._check_custom_role_permissions('MyRole')
+        call_kwargs = bootstrap.iam_client.simulate_principal_policy.call_args.kwargs
+        assert call_kwargs['PolicySourceArn'] == 'arn:aws:iam::123456789012:role/MyRole'
+        assert call_kwargs['ActionNames'] == bootstrap.REQUIRED_ACTIONS
+
+    def test_get_role_name_calls_check_for_custom_role(self, bootstrap):
+        bootstrap._is_existing_role = MagicMock(return_value=True)
+        bootstrap._check_custom_role_permissions = MagicMock()
+        bootstrap._get_role_name({'XRole': 'CustomRole'})
+        bootstrap._check_custom_role_permissions.assert_called_once_with('CustomRole')
+
+    def test_get_role_name_skips_check_for_standard_roles(self, bootstrap):
+        from infrastructure.constants import ROLE_TYPE_READ_ONLY
+        bootstrap._check_custom_role_permissions = MagicMock()
+        bootstrap._get_role_name({'XRole': ROLE_TYPE_READ_ONLY})
+        bootstrap._check_custom_role_permissions.assert_not_called()
+
+
 # -- _is_existing_role --------------------------------------------------
 
 class TestIsExistingRole:

--- a/tools/bulk_executor/tests/client/test_bootstrap.py
+++ b/tools/bulk_executor/tests/client/test_bootstrap.py
@@ -244,6 +244,61 @@ class TestIsExistingRole:
         assert exc.value.code == 1
 
 
+# -- _get_role_version_tag / _tag_role_version / _is_builtin_role --------
+
+class TestRoleVersionTag:
+    def test_returns_version_when_tag_present(self, bootstrap):
+        bootstrap.iam_client.list_role_tags.return_value = {
+            'Tags': [
+                {'Key': 'BulkDynamoDBVersion', 'Value': '1.2.3'},
+                {'Key': 'OtherTag', 'Value': 'x'},
+            ]
+        }
+        assert bootstrap._get_role_version_tag('MyRole') == '1.2.3'
+
+    def test_returns_none_when_tag_absent(self, bootstrap):
+        bootstrap.iam_client.list_role_tags.return_value = {
+            'Tags': [{'Key': 'OtherTag', 'Value': 'x'}]
+        }
+        assert bootstrap._get_role_version_tag('MyRole') is None
+
+    def test_returns_none_on_empty_tags(self, bootstrap):
+        bootstrap.iam_client.list_role_tags.return_value = {'Tags': []}
+        assert bootstrap._get_role_version_tag('MyRole') is None
+
+    def test_returns_none_on_exception(self, bootstrap):
+        bootstrap.iam_client.list_role_tags.side_effect = RuntimeError('boom')
+        assert bootstrap._get_role_version_tag('MyRole') is None
+
+    def test_tag_role_version_calls_tag_role(self, bootstrap):
+        from __version__ import __version__ as VERSION
+        bootstrap._tag_role_version('MyRole')
+        bootstrap.iam_client.tag_role.assert_called_once_with(
+            RoleName='MyRole',
+            Tags=[{'Key': 'BulkDynamoDBVersion', 'Value': VERSION}]
+        )
+
+    def test_tag_role_version_swallows_error(self, bootstrap):
+        bootstrap.iam_client.tag_role.side_effect = RuntimeError('no perms')
+        bootstrap._tag_role_version('MyRole')  # should not raise
+
+
+class TestIsBuiltinRole:
+    def test_no_role_is_builtin(self, bootstrap):
+        assert bootstrap._is_builtin_role({}) is True
+
+    def test_read_only_is_builtin(self, bootstrap):
+        from infrastructure.constants import ROLE_TYPE_READ_ONLY
+        assert bootstrap._is_builtin_role({'XRole': ROLE_TYPE_READ_ONLY}) is True
+
+    def test_read_write_is_builtin(self, bootstrap):
+        from infrastructure.constants import ROLE_TYPE_READ_WRITE
+        assert bootstrap._is_builtin_role({'XRole': ROLE_TYPE_READ_WRITE}) is True
+
+    def test_custom_role_is_not_builtin(self, bootstrap):
+        assert bootstrap._is_builtin_role({'XRole': 'MyCustomRole'}) is False
+
+
 # -- _is_write_access_enabled -------------------------------------------
 
 class TestIsWriteAccessEnabled:
@@ -316,9 +371,11 @@ class TestAddGlueJobRole:
         assert 'arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess' in attached
         assert 'arn:aws:iam::aws:policy/AmazonDynamoDBReadOnlyAccess' not in attached
 
-    def test_role_already_exists_returns_without_attaching_policies(self, bootstrap):
+    def test_role_already_exists_with_current_version_skips_policy_refresh(self, bootstrap):
         from infrastructure.constants import ROLE_TYPE_READ_ONLY
+        from __version__ import __version__ as VERSION
         bootstrap._prompt_for_role = MagicMock()
+        bootstrap._get_role_version_tag = MagicMock(return_value=VERSION)
 
         class EntityAlreadyExistsException(Exception):
             pass
@@ -329,9 +386,61 @@ class TestAddGlueJobRole:
 
         bootstrap._add_glue_job_role({'XRole': ROLE_TYPE_READ_ONLY})
 
-        # Early return — no policy attachments
         bootstrap.iam_client.attach_role_policy.assert_not_called()
         bootstrap.iam_client.put_role_policy.assert_not_called()
+
+    def test_role_already_exists_with_old_version_refreshes_policies(self, bootstrap):
+        from infrastructure.constants import ROLE_TYPE_READ_ONLY
+        bootstrap._prompt_for_role = MagicMock()
+        bootstrap._get_role_version_tag = MagicMock(return_value='old-version')
+
+        class EntityAlreadyExistsException(Exception):
+            pass
+        bootstrap.iam_client.exceptions.EntityAlreadyExistsException = (
+            EntityAlreadyExistsException
+        )
+        bootstrap.iam_client.create_role.side_effect = EntityAlreadyExistsException()
+
+        bootstrap._add_glue_job_role({'XRole': ROLE_TYPE_READ_ONLY})
+
+        assert bootstrap.iam_client.attach_role_policy.call_count == 2
+        assert bootstrap.iam_client.put_role_policy.call_count == 2
+        bootstrap.iam_client.tag_role.assert_called_once()
+
+    def test_role_already_exists_with_no_version_tag_refreshes_policies(self, bootstrap):
+        from infrastructure.constants import ROLE_TYPE_READ_ONLY
+        bootstrap._prompt_for_role = MagicMock()
+        bootstrap._get_role_version_tag = MagicMock(return_value=None)
+
+        class EntityAlreadyExistsException(Exception):
+            pass
+        bootstrap.iam_client.exceptions.EntityAlreadyExistsException = (
+            EntityAlreadyExistsException
+        )
+        bootstrap.iam_client.create_role.side_effect = EntityAlreadyExistsException()
+
+        bootstrap._add_glue_job_role({'XRole': ROLE_TYPE_READ_ONLY})
+
+        assert bootstrap.iam_client.attach_role_policy.call_count == 2
+        assert bootstrap.iam_client.put_role_policy.call_count == 2
+        bootstrap.iam_client.tag_role.assert_called_once()
+
+    def test_custom_role_exists_skips_policy_management(self, bootstrap):
+        bootstrap._prompt_for_role = MagicMock()
+        bootstrap._is_existing_role = MagicMock(return_value=True)
+
+        class EntityAlreadyExistsException(Exception):
+            pass
+        bootstrap.iam_client.exceptions.EntityAlreadyExistsException = (
+            EntityAlreadyExistsException
+        )
+        bootstrap.iam_client.create_role.side_effect = EntityAlreadyExistsException()
+
+        bootstrap._add_glue_job_role({'XRole': 'MyCustomRole'})
+
+        bootstrap.iam_client.attach_role_policy.assert_not_called()
+        bootstrap.iam_client.put_role_policy.assert_not_called()
+        bootstrap.iam_client.tag_role.assert_not_called()
 
     def test_unexpected_create_role_error_exits(self, bootstrap):
         from infrastructure.constants import ROLE_TYPE_READ_ONLY

--- a/tools/bulk_executor/tests/client/test_bulk_driver_error_handling.py
+++ b/tools/bulk_executor/tests/client/test_bulk_driver_error_handling.py
@@ -1,0 +1,177 @@
+"""Tests for the top-level error handling in the `bulk` driver script.
+
+Verifies that known AWS errors (ClientError, BotoCoreError) produce a clean
+one-line message + exit(1) instead of a full Python stack trace.
+
+The `bulk` script wraps its main execution in a try/except for ClientError
+and BotoCoreError. These tests exercise that code path by running the script
+as a subprocess from the correct working directory.
+"""
+
+import subprocess
+import sys
+import os
+import tempfile
+
+import pytest
+
+BULK_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), '..', '..')
+)
+
+
+def _run_bulk_subprocess(inject_code):
+    """Run the bulk script with injected setup code.
+
+    The wrapper adds necessary paths and patches, then exec's the bulk script.
+    """
+    preamble = (
+        "import sys, os\n"
+        f"os.chdir('{BULK_DIR}')\n"
+        f"sys.path.insert(0, '{BULK_DIR}')\n"
+        f"sys.path.insert(0, '{BULK_DIR}/client/src')\n"
+    )
+    script = preamble + inject_code + "\nexec(compile(open('bulk').read(), 'bulk', 'exec'))\n"
+
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False) as f:
+        f.write(script)
+        f.flush()
+        try:
+            result = subprocess.run(
+                [sys.executable, f.name],
+                capture_output=True,
+                text=True,
+                cwd=BULK_DIR,
+                timeout=10,
+            )
+        finally:
+            os.unlink(f.name)
+    return result
+
+
+INJECT_CLIENT_ERROR_ACCESS_DENIED = """\
+from unittest.mock import patch, MagicMock
+import botocore.exceptions
+
+sys.argv = ['bulk', 'copy', '--source', 'src-tbl', '--target', 'dst-tbl']
+
+error_response = {
+    'Error': {
+        'Code': 'AccessDeniedException',
+        'Message': 'Not authorized to perform dynamodb:DescribeTable on table/src-tbl'
+    }
+}
+
+mock_env = MagicMock(aws_region='us-east-1', aws_account_id='123456789012')
+
+def fake_action(env_configs):
+    raise botocore.exceptions.ClientError(error_response, 'DescribeTable')
+
+patch('env_configs.EnvConfigs', return_value=mock_env).start()
+patch('utils.logger.init').start()
+_m = patch('importlib.import_module').start()
+_mod = MagicMock()
+_mod.run = fake_action
+_m.return_value = _mod
+"""
+
+INJECT_CLIENT_ERROR_RESOURCE_NOT_FOUND = """\
+from unittest.mock import patch, MagicMock
+import botocore.exceptions
+
+sys.argv = ['bulk', 'copy', '--source', 'src-tbl', '--target', 'dst-tbl']
+
+error_response = {
+    'Error': {
+        'Code': 'ResourceNotFoundException',
+        'Message': 'Requested resource not found: Table: nonexistent-table not found'
+    }
+}
+
+mock_env = MagicMock(aws_region='us-east-1', aws_account_id='123456789012')
+
+def fake_action(env_configs):
+    raise botocore.exceptions.ClientError(error_response, 'DescribeTable')
+
+patch('env_configs.EnvConfigs', return_value=mock_env).start()
+patch('utils.logger.init').start()
+_m = patch('importlib.import_module').start()
+_mod = MagicMock()
+_mod.run = fake_action
+_m.return_value = _mod
+"""
+
+INJECT_BOTOCORE_ENDPOINT_ERROR = """\
+from unittest.mock import patch, MagicMock
+import botocore.exceptions
+
+sys.argv = ['bulk', 'copy', '--source', 'src-tbl', '--target', 'dst-tbl']
+
+mock_env = MagicMock(aws_region='us-east-1', aws_account_id='123456789012')
+
+def fake_action(env_configs):
+    raise botocore.exceptions.EndpointConnectionError(
+        endpoint_url='https://dynamodb.bad-region.amazonaws.com')
+
+patch('env_configs.EnvConfigs', return_value=mock_env).start()
+patch('utils.logger.init').start()
+_m = patch('importlib.import_module').start()
+_mod = MagicMock()
+_mod.run = fake_action
+_m.return_value = _mod
+"""
+
+INJECT_TYPE_ERROR = """\
+from unittest.mock import patch, MagicMock
+
+sys.argv = ['bulk', 'copy', '--source', 'src-tbl', '--target', 'dst-tbl']
+
+mock_env = MagicMock(aws_region='us-east-1', aws_account_id='123456789012')
+
+def fake_action(env_configs):
+    raise TypeError("something internal broke")
+
+patch('env_configs.EnvConfigs', return_value=mock_env).start()
+patch('utils.logger.init').start()
+_m = patch('importlib.import_module').start()
+_mod = MagicMock()
+_mod.run = fake_action
+_m.return_value = _mod
+"""
+
+
+class TestClientErrorHandling:
+    """Verify ClientError triggers clean message + exit(1), no stack trace."""
+
+    def test_access_denied_shows_code_and_message(self):
+        result = _run_bulk_subprocess(INJECT_CLIENT_ERROR_ACCESS_DENIED)
+        assert result.returncode == 1
+        assert 'Traceback' not in result.stderr
+        assert 'AccessDeniedException' in result.stderr
+        assert 'Not authorized' in result.stderr
+        assert 'Job failed.' in result.stderr
+
+    def test_resource_not_found_shows_clean_error(self):
+        result = _run_bulk_subprocess(INJECT_CLIENT_ERROR_RESOURCE_NOT_FOUND)
+        assert result.returncode == 1
+        assert 'Traceback' not in result.stderr
+        assert 'ResourceNotFoundException' in result.stderr
+        assert 'Job failed.' in result.stderr
+
+
+class TestBotoCoreErrorHandling:
+    """Verify BotoCoreError (non-ClientError) triggers clean message."""
+
+    def test_endpoint_connection_error_clean_output(self):
+        result = _run_bulk_subprocess(INJECT_BOTOCORE_ENDPOINT_ERROR)
+        assert result.returncode == 1
+        assert 'Traceback' not in result.stderr
+        assert 'Job failed.' in result.stderr
+
+    def test_non_aws_error_still_shows_traceback(self):
+        """Non-AWS errors (e.g. TypeError) should still produce a traceback
+        so bugs are visible during development."""
+        result = _run_bulk_subprocess(INJECT_TYPE_ERROR)
+        assert result.returncode == 1
+        assert 'Traceback' in result.stderr
+        assert 'TypeError' in result.stderr

--- a/tools/bulk_executor/tests/client/test_runner.py
+++ b/tools/bulk_executor/tests/client/test_runner.py
@@ -942,6 +942,18 @@ class TestStartGlueJob:
         with pytest.raises(SystemExit):
             bulk_runner._start_glue_job({}, {})
 
+    def test_uses_default_idle_timeout_when_missing(self, bulk_runner):
+        bulk_runner.glue_client.start_job_run.return_value = {'JobRunId': 'x'}
+        bulk_runner._start_glue_job({}, {})
+        kwargs = bulk_runner.glue_client.start_job_run.call_args.kwargs
+        assert kwargs['IdleTimeout'] == runner_module.GlueJobDefaults.IdleTimeout.value
+
+    def test_overrides_idle_timeout_with_provided_arg(self, bulk_runner):
+        bulk_runner.glue_client.start_job_run.return_value = {'JobRunId': 'x'}
+        bulk_runner._start_glue_job({}, {'XIdleTimeout': 10})
+        kwargs = bulk_runner.glue_client.start_job_run.call_args.kwargs
+        assert kwargs['IdleTimeout'] == 10
+
 
 # --- _stop_glue_job ---------------------------------------------------------
 

--- a/tools/bulk_executor/tests/client/test_runner.py
+++ b/tools/bulk_executor/tests/client/test_runner.py
@@ -841,6 +841,41 @@ class TestGetGlueJobArguments:
         result = bulk_runner._get_glue_job_arguments({}, ['--key', None])
         assert '--key' not in result
 
+    def test_fill_verb_injects_faker_as_additional_python_module(self, bulk_runner):
+        result = bulk_runner._get_glue_job_arguments({}, ['--verb', 'fill'])
+        assert '--additional-python-modules' in result
+        assert 'faker' in result['--additional-python-modules']
+
+    def test_copy_verb_does_not_inject_additional_python_modules(self, bulk_runner):
+        result = bulk_runner._get_glue_job_arguments({}, ['--verb', 'copy'])
+        assert '--additional-python-modules' not in result
+
+    def test_delete_verb_does_not_inject_additional_python_modules(self, bulk_runner):
+        result = bulk_runner._get_glue_job_arguments({}, ['--verb', 'delete'])
+        assert '--additional-python-modules' not in result
+
+    def test_find_verb_does_not_inject_additional_python_modules(self, bulk_runner):
+        result = bulk_runner._get_glue_job_arguments({}, ['--verb', 'find'])
+        assert '--additional-python-modules' not in result
+
+    def test_verb_modules_combined_with_global_modules(self, bulk_runner):
+        """When both global and verb-specific modules exist, per-run args must include both.
+
+        The reviewer concern: removing faker from the global list means per-run
+        Arguments for fill only include verb-specific deps. If a global module
+        is ever added, the per-run override would clobber DefaultArguments. The
+        runner must merge global + verb-specific modules so that both reach the
+        worker.
+        """
+        with patch.object(runner_module, 'VERB_PYTHON_MODULES', {'fill': ['faker']}):
+            with patch.object(
+                runner_module, 'THIRD_PARTY_PYTHON_MODULES', 'boto3', create=True
+            ):
+                result = bulk_runner._get_glue_job_arguments({}, ['--verb', 'fill'])
+                modules = result['--additional-python-modules'].split(',')
+                assert 'faker' in modules, "verb-specific module missing"
+                assert 'boto3' in modules, "global module missing from per-run args"
+
 
 # --- _assert_expected_script_args -------------------------------------------
 

--- a/tools/bulk_executor/tests/client/utils/test_module_zipper.py
+++ b/tools/bulk_executor/tests/client/utils/test_module_zipper.py
@@ -5,6 +5,7 @@ Covers `client/src/utils/module_zipper.py`:
   infrastructure.constants
 - _zip_module(): happy path (writes parent dir entry, recurses os.walk,
   writes files, writes subdir entries to preserve empty dirs, skips symlinks),
+  exclusion of __pycache__, .DS_Store, .pyc/.pyo, and other junk,
   guard against zip_path inside source_path (raises ValueError → caught,
   returns False), exception during zipping (caught, log.error, returns False)
 
@@ -147,6 +148,156 @@ class TestZipModuleInternalHappyPath:
 
         # Zip materialized at the absolute location
         assert (tmp_path / 'out.zip').exists()
+
+
+class TestZipModuleExclusions:
+    """Tests for file/directory exclusion logic."""
+
+    def test_pycache_excluded(self, tmp_path):
+        """__pycache__ directories and their contents are excluded."""
+        source = tmp_path / "modules"
+        source.mkdir()
+        (source / "a.py").write_text("a")
+        cache = source / "__pycache__"
+        cache.mkdir()
+        (cache / "a.cpython-311.pyc").write_bytes(b"\x00")
+
+        zip_path = tmp_path / "out.zip"
+
+        with patch.object(module_zipper, 'log'):
+            assert module_zipper._zip_module(str(source), str(zip_path)) is True
+
+        with zipfile.ZipFile(zip_path) as zf:
+            names = zf.namelist()
+        assert 'modules/a.py' in names
+        assert not any('__pycache__' in n for n in names)
+
+    def test_nested_pycache_excluded(self, tmp_path):
+        """__pycache__ inside a subdirectory is also excluded."""
+        source = tmp_path / "modules"
+        source.mkdir()
+        sub = source / "sub"
+        sub.mkdir()
+        (sub / "b.py").write_text("b")
+        cache = sub / "__pycache__"
+        cache.mkdir()
+        (cache / "b.cpython-311.pyc").write_bytes(b"\x00")
+
+        zip_path = tmp_path / "out.zip"
+
+        with patch.object(module_zipper, 'log'):
+            assert module_zipper._zip_module(str(source), str(zip_path)) is True
+
+        with zipfile.ZipFile(zip_path) as zf:
+            names = zf.namelist()
+        assert 'modules/sub/b.py' in names
+        assert not any('__pycache__' in n for n in names)
+
+    def test_ds_store_excluded(self, tmp_path):
+        """.DS_Store files are excluded from the archive."""
+        source = tmp_path / "modules"
+        source.mkdir()
+        (source / "a.py").write_text("a")
+        (source / ".DS_Store").write_bytes(b"\x00\x00\x00\x01")
+
+        zip_path = tmp_path / "out.zip"
+
+        with patch.object(module_zipper, 'log'):
+            assert module_zipper._zip_module(str(source), str(zip_path)) is True
+
+        with zipfile.ZipFile(zip_path) as zf:
+            names = zf.namelist()
+        assert 'modules/a.py' in names
+        assert not any('.DS_Store' in n for n in names)
+
+    def test_pyc_files_excluded(self, tmp_path):
+        """.pyc files outside __pycache__ are also excluded."""
+        source = tmp_path / "modules"
+        source.mkdir()
+        (source / "a.py").write_text("a")
+        (source / "a.pyc").write_bytes(b"\x00")
+
+        zip_path = tmp_path / "out.zip"
+
+        with patch.object(module_zipper, 'log'):
+            assert module_zipper._zip_module(str(source), str(zip_path)) is True
+
+        with zipfile.ZipFile(zip_path) as zf:
+            names = zf.namelist()
+        assert 'modules/a.py' in names
+        assert 'modules/a.pyc' not in names
+
+    def test_pyo_files_excluded(self, tmp_path):
+        """.pyo files are excluded."""
+        source = tmp_path / "modules"
+        source.mkdir()
+        (source / "a.py").write_text("a")
+        (source / "a.pyo").write_bytes(b"\x00")
+
+        zip_path = tmp_path / "out.zip"
+
+        with patch.object(module_zipper, 'log'):
+            assert module_zipper._zip_module(str(source), str(zip_path)) is True
+
+        with zipfile.ZipFile(zip_path) as zf:
+            names = zf.namelist()
+        assert 'modules/a.py' in names
+        assert 'modules/a.pyo' not in names
+
+    def test_egg_info_dir_excluded(self, tmp_path):
+        """*.egg-info directories are excluded."""
+        source = tmp_path / "modules"
+        source.mkdir()
+        (source / "a.py").write_text("a")
+        egg = source / "pkg.egg-info"
+        egg.mkdir()
+        (egg / "PKG-INFO").write_text("info")
+
+        zip_path = tmp_path / "out.zip"
+
+        with patch.object(module_zipper, 'log'):
+            assert module_zipper._zip_module(str(source), str(zip_path)) is True
+
+        with zipfile.ZipFile(zip_path) as zf:
+            names = zf.namelist()
+        assert 'modules/a.py' in names
+        assert not any('egg-info' in n for n in names)
+
+    def test_thumbs_db_excluded(self, tmp_path):
+        """Thumbs.db files are excluded."""
+        source = tmp_path / "modules"
+        source.mkdir()
+        (source / "a.py").write_text("a")
+        (source / "Thumbs.db").write_bytes(b"\x00")
+
+        zip_path = tmp_path / "out.zip"
+
+        with patch.object(module_zipper, 'log'):
+            assert module_zipper._zip_module(str(source), str(zip_path)) is True
+
+        with zipfile.ZipFile(zip_path) as zf:
+            names = zf.namelist()
+        assert 'modules/a.py' in names
+        assert 'modules/Thumbs.db' not in names
+
+    def test_pytest_cache_excluded(self, tmp_path):
+        """.pytest_cache directories are excluded."""
+        source = tmp_path / "modules"
+        source.mkdir()
+        (source / "a.py").write_text("a")
+        cache = source / ".pytest_cache"
+        cache.mkdir()
+        (cache / "CACHEDIR.TAG").write_text("tag")
+
+        zip_path = tmp_path / "out.zip"
+
+        with patch.object(module_zipper, 'log'):
+            assert module_zipper._zip_module(str(source), str(zip_path)) is True
+
+        with zipfile.ZipFile(zip_path) as zf:
+            names = zf.namelist()
+        assert 'modules/a.py' in names
+        assert not any('.pytest_cache' in n for n in names)
 
 
 class TestZipModuleInternalGuard:

--- a/tools/bulk_executor/tests/client/utils/test_utils_init.py
+++ b/tools/bulk_executor/tests/client/utils/test_utils_init.py
@@ -243,6 +243,21 @@ class TestGlueJobArguments:
         with pytest.raises(SystemExit):
             parser.parse_known_args(['--XTimeout', '99999'])
 
+    def test_parses_idle_timeout_via_validator(self):
+        parser = glue_job_arguments()
+        ns, _ = parser.parse_known_args(['--XIdleTimeout', '10'])
+        assert ns.XIdleTimeout == 10
+
+    def test_idle_timeout_validation_rejects_out_of_range(self, capsys):
+        parser = glue_job_arguments()
+        with pytest.raises(SystemExit):
+            parser.parse_known_args(['--XIdleTimeout', '99999'])
+
+    def test_idle_timeout_validation_rejects_zero(self, capsys):
+        parser = glue_job_arguments()
+        with pytest.raises(SystemExit):
+            parser.parse_known_args(['--XIdleTimeout', '0'])
+
     def test_parses_number_of_workers(self):
         parser = glue_job_arguments()
         ns, _ = parser.parse_known_args(['--XNumberOfWorkers', '50'])


### PR DESCRIPTION
## Summary
Eight client-side improvements spanning UX, validation, and startup performance.

### Issues addressed
- #174 — Limit what can end up in python_modules.zip
- #179 — "Load" should require pitr enabled
- #82 — Check any passed-in custom role has required minimum permissions
- #137 — Commands with bad parameter errors encountered in the driver code should report errors without stack traces and with a failed job
- #84 — Force built-in role refresh on version mismatch
- #88 — Consider a shorter Glue `IdleTimeout` for cost optimization
- #91 — Enable `faker` only for `fill` to speed up startup
- #130 — Allow bootstrap to specify an existing S3 bucket

### Changes
1. **fix:** exclude __pycache__ and dev cruft from python_modules.zip
2. **fix:** require PITR enabled for load command (safety gate)
3. **feat:** warn if custom --XRole lacks minimum permissions
4. **fix:** show clean error messages instead of stack traces
5. **feat:** force built-in role refresh on version mismatch
6. **feat:** add --XIdleTimeout for Glue cost optimization
7. **perf:** install faker only for fill verb to speed worker startup
8. **feat:** add --XExistingBucket parameter to bootstrap

### Files touched
- `client/src/` (infrastructure/, python_modules/, runner.py, utils/)
- `tests/client/` (test_bootstrap, test_runner, test_bulk_driver_error_handling, utils/)
- `bulk` (CLI entrypoint)

### Test plan
- [x] Client tests pass (441 passed)
- [x] No overlap with other open PRs

> Independently mergeable — no ordering dependency with other bulk_executor PRs.