### PR TITLE
[bulk_executor] fix(diff): skip writing empty segment files to S3

### DIFF
--- a/tools/bulk_executor/server/src/python_modules/diff.py
+++ b/tools/bulk_executor/server/src/python_modules/diff.py
@@ -282,7 +282,8 @@ def diff_segment(stream_a_name, stream_b_name, monitor_options_a, monitor_option
         rate_limiter_worker_b.shutdown()
 
     if use_s3:
-        boto3.client('s3').put_object(Body="\n".join(diff), Bucket=bucket, Key=f"{job_id}/{segment}.txt")
+        if diff:
+            boto3.client('s3').put_object(Body="\n".join(diff), Bucket=bucket, Key=f"{job_id}/{segment}.txt")
         return len(diff)
 
     return diff[0:PRINT_LIMIT]


### PR DESCRIPTION
### Issues addressed
- #183 — The diff command does not need to output empty files in S3

---

When a segment produces no diff results, skip writing the empty file to S3. Reduces S3 clutter and avoids confusing empty-file artifacts.

All tests pass (1 file changed, 2 lines).