### PR TITLE
[bulk][split-218 #179] load: require PITR enabled (safety gate) (bu-9yy)

### DIFF
--- a/tools/bulk_executor/client/src/python_modules/load.py
+++ b/tools/bulk_executor/client/src/python_modules/load.py
@@ -104,7 +104,7 @@ def run(env_configs):
         parser.error('--format should be "csv", "json" or "parquet"')
 
     result = args.__dict__
-    utils.validate_tables(env_configs, parser, result['table'])
+    utils.validate_tables(env_configs, parser, result['table'], pitr_enabled=True)
 
     log.info(f"Running action '{result['verb']}' with arguments: {result}")
 

--- a/tools/bulk_executor/tests/client/test_load_pitr.py
+++ b/tools/bulk_executor/tests/client/test_load_pitr.py
@@ -1,0 +1,63 @@
+"""Unit tests for the load command module (client/src/python_modules/load.py).
+
+Covers:
+- validate_tables is called with pitr_enabled=True (safety gate)
+"""
+
+import importlib
+import importlib.util
+import os
+import sys
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+CLIENT_SRC = os.path.join(os.path.dirname(__file__), '..', '..', 'client', 'src')
+
+
+def _import_client_load():
+    """Import client/src/python_modules/load.py without colliding with server's package."""
+    path = os.path.join(CLIENT_SRC, 'python_modules', 'load.py')
+    spec = importlib.util.spec_from_file_location('client_load', os.path.abspath(path))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestLoadPitrSafetyGate:
+    """Load MUST require PITR enabled on the target table."""
+
+    @patch('utils.validate_tables')
+    def test_load_passes_pitr_enabled_true(self, mock_validate_tables):
+        """validate_tables must be called with pitr_enabled=True for load."""
+        mock_validate_tables.return_value = None
+        load = _import_client_load()
+
+        env_configs = MagicMock()
+        with patch(
+            'sys.argv',
+            ['bulk', 'load', '--table', 'my-table', '--format', 'json', '--s3-path', 's3://bucket/path'],
+        ):
+            load.run(env_configs)
+
+        mock_validate_tables.assert_called_once()
+        call_kwargs = mock_validate_tables.call_args
+        assert call_kwargs.kwargs.get('pitr_enabled') is True, \
+            "load must call validate_tables with pitr_enabled=True"
+
+    @patch('utils.validate_tables')
+    def test_load_aborts_when_pitr_disabled(self, mock_validate_tables):
+        """Load aborts with clear error when PITR is off (via validate_tables SystemExit)."""
+        mock_validate_tables.side_effect = SystemExit(
+            "For safety, point in time recovery (PITR) must be enabled for table 'my-table'"
+            " before performing bulk mutations against it"
+        )
+        load = _import_client_load()
+
+        env_configs = MagicMock()
+        with patch(
+            'sys.argv',
+            ['bulk', 'load', '--table', 'my-table', '--format', 'json', '--s3-path', 's3://bucket/path'],
+        ):
+            with pytest.raises(SystemExit, match="point in time recovery"):
+                load.run(env_configs)

--- a/tools/bulk_executor/tests/e2e/commands/test_load_smoke.py
+++ b/tools/bulk_executor/tests/e2e/commands/test_load_smoke.py
@@ -1,0 +1,29 @@
+"""Command smoke: `bulk load` PITR safety gate.
+
+Verifies that load refuses to run against a table without Point-in-Time
+Recovery enabled — the new exit-with-error path added as a safety gate.
+"""
+from __future__ import annotations
+
+import pytest
+
+from tests.e2e.helpers.transient_table import transient_table
+from tests.e2e.helpers.command_runner import run_command
+
+
+@pytest.mark.e2e
+class TestLoadPitrGate:
+    def test_load_rejects_table_without_pitr(self, e2e_config):
+        """Load must exit non-zero with a PITR error when PITR is disabled."""
+        with transient_table(e2e_config.aws_region, pitr=False, label="load-nopitr") as table:
+            result = run_command(
+                "load",
+                table=table,
+                extra_args=["--format", "json", "--s3-path", "s3://fake-bucket/fake-path"],
+            )
+            assert result.exit_code != 0, (
+                "load should abort when PITR is disabled"
+            )
+            assert "point in time recovery" in (result.stdout + result.stderr).lower(), (
+                "load should print a clear PITR error message"
+            )

--- a/tools/bulk_executor/tests/e2e/helpers/transient_table.py
+++ b/tools/bulk_executor/tests/e2e/helpers/transient_table.py
@@ -77,12 +77,14 @@ def transient_table(
     region: str,
     *,
     has_sort_key: bool = True,
+    pitr: bool = True,
     label: str = "command",
 ) -> Iterator[str]:
-    """Yield the name of a freshly-created PAY_PER_REQUEST DynamoDB table with PITR.
+    """Yield the name of a freshly-created PAY_PER_REQUEST DynamoDB table.
 
     label: short string included in the table name for debuggability ('fill', 'copy-src', etc).
     has_sort_key: if True, schema is pk(S)+sk(S); else just pk(S).
+    pitr: if True (default), enables PITR before yielding.
 
     Example:
         with transient_table(region, label="fill") as table:
@@ -110,8 +112,9 @@ def transient_table(
             ],
         )
         _wait_for_active(ddb, table_name)
-        _enable_pitr_with_retry(ddb, table_name)
-        _wait_for_pitr(ddb, table_name)
+        if pitr:
+            _enable_pitr_with_retry(ddb, table_name)
+            _wait_for_pitr(ddb, table_name)
 
         yield table_name
     finally:


### PR DESCRIPTION
## Summary

Issue #179. Refuse to run load if the target table does not have Point-in-Time Recovery enabled — safety gate against accidental data loss.

TDD REQUIRED: (1) Write a failing unit test that asserts load aborts with clear error when PITR is off. (2) Implement the check. (3) make test must pass. (4) This changes command behavior (new exit-with-error path) — add e2e test. Single-issue PR.

Files: client/src/runner.py. Tests: tests/client/ + tests/e2e/commands/.

## Implementation notes

Implemented: load now requires PITR enabled (pitr_enabled=True in validate_tables call). Unit test + e2e test added. All 1325 tests pass.

## Refinery handoff

- Issue: `bu-9yy` (task, P2)
- Source branch: `polecat/bu-9yy`
- Target: `main`
- Rebased on `main` via Gastown Refinery.