### PR TITLE
[bulk][split-218 #137] Clean error messages instead of stack traces (bu-9jr)

### DIFF
--- a/tools/bulk_executor/client/src/runner.py
+++ b/tools/bulk_executor/client/src/runner.py
@@ -483,7 +483,11 @@ You can run the script with the --XWaitForDPU parameter in order to print the us
         job_run_state = self._get_job_run_state(job_run_id)
         job_run_error_message = self._get_job_run_error_message(job_run_id)
 
+        # Only SUCCEEDED is a clean exit; every other terminal state is a
+        # failure the caller must be able to detect via the process exit code
+        # (issue #137: a failed job must "show the effort failed", not exit 0).
         job_end_message = None
+        job_failed = True
         if job_run_state == STOPPING_STATE:
             job_end_message = "Job is stopping."
         elif job_run_state == STOPPED_STATE:
@@ -494,6 +498,7 @@ You can run the script with the --XWaitForDPU parameter in order to print the us
             job_end_message = "Job timed out."
         elif job_run_state == SUCCEEDED_STATE:
             job_end_message = "Job completed successfully."
+            job_failed = False
         else:
             log.error(f"Unhandled Job State: {job_run_state}")
 
@@ -511,3 +516,8 @@ You can run the script with the --XWaitForDPU parameter in order to print the us
 
         if job_run_error_message:
             log.error(job_run_error_message)
+
+        # Propagate failure to the process exit code so callers (and the shell)
+        # can detect it. The Glue-side error message has already been printed.
+        if job_failed:
+            sys.exit(1)

--- a/tools/bulk_executor/client/src/runner.py
+++ b/tools/bulk_executor/client/src/runner.py
@@ -417,6 +417,15 @@ class BulkDynamoDbRunner:
                 time.sleep(1)
                 job_run_state = self._get_job_run_state(job_run_id)
 
+    def _clean_error_message(self, exception):
+        """Extract a human-readable message from an exception without traceback noise."""
+        if hasattr(exception, 'response'):
+            error_info = exception.response.get('Error', {})
+            message = error_info.get('Message') or str(exception)
+        else:
+            message = str(exception)
+        return message
+
     def run(self, args, script_args):
         log.debug(f"XArgs: {args}")
         log.debug(f"Script args: {script_args}")
@@ -430,6 +439,18 @@ class BulkDynamoDbRunner:
             log.info("Job not executed.")
             return
 
+        try:
+            self._execute_job(glue_job_arguments, args)
+        except SystemExit:
+            raise
+        except KeyboardInterrupt:
+            raise
+        except Exception as e:
+            error_message = self._clean_error_message(e)
+            log.error(error_message)
+            sys.exit(f"Error: {error_message}")
+
+    def _execute_job(self, glue_job_arguments, args):
         log.info("""
 
 The bulk executor job cost consists of DynamoDB and Glue costs

--- a/tools/bulk_executor/server/src/python_modules/find.py
+++ b/tools/bulk_executor/server/src/python_modules/find.py
@@ -12,6 +12,7 @@ from pyspark.sql.functions import asc, desc
 
 # Custom Library Imports
 sys.path.append('/server/src')
+from python_modules.shared.bulk_executor_error import BulkExecutorError
 from python_modules.shared.errors import *
 from python_modules.shared.pricing import PricingUtility
 from python_modules.shared.rate_limiter import (
@@ -118,13 +119,13 @@ def run(job, spark_context, glue_context, parsed_args):
             try:
                 records = records.filter(WHERE)
             except Exception as e:
-                raise Exception("Invalid 'where': " + get_error_message(e)) from None
+                raise BulkExecutorError("Invalid 'where': " + get_error_message(e)) from None
         if ORDERBY:
             try:
                 records = records.orderBy(ORDERBY)
                 needsRepartitioning = True
             except Exception as e:
-                raise Exception("Invalid 'orderby': " + get_error_message(e)) from None
+                raise BulkExecutorError("Invalid 'orderby': " + get_error_message(e)) from None
         if LIMIT:
             try:
                 limit = int(LIMIT)
@@ -132,7 +133,7 @@ def run(job, spark_context, glue_context, parsed_args):
                 if limit > 1000: # Don't bother for tiny sizes
                     needsRepartitioning = True
             except Exception as e:
-                raise Exception("Invalid 'limit': " + get_error_message(e)) from None
+                raise BulkExecutorError("Invalid 'limit': " + get_error_message(e)) from None
 
         def get_table_keys(table_name):
             client = boto3.client('dynamodb')

--- a/tools/bulk_executor/server/src/python_modules/load/__init__.py
+++ b/tools/bulk_executor/server/src/python_modules/load/__init__.py
@@ -5,6 +5,7 @@ import re
 import sys
 from awsglue.transforms import Filter, Map
 from botocore.exceptions import ClientError
+from python_modules.shared.bulk_executor_error import BulkExecutorError
 from python_modules.shared.errors import *
 from python_modules.shared.logger import log
 from python_modules.shared.pricing import PricingUtility
@@ -78,8 +79,7 @@ def run(job, spark_context, glue_context, parsed_args):
     s3_path = parsed_args.get('s3_path')
 
     if not check_s3_file_exists(s3_path):
-        log.error("The S3 uri provided doesn't exist / is not a file")
-        return
+        raise BulkExecutorError(f"The S3 path '{s3_path}' doesn't exist or is not accessible")
 
     dynamicFrame = read_data(glue_context, s3_path, parsed_args)
 
@@ -138,13 +138,20 @@ def check_s3_file_exists(s3_uri):
         s3.head_object(Bucket=bucket_name, Key=key)
         return True
     except ClientError as e:
-        if e.response['Error']['Code'] == '404':
+        error_code = e.response['Error']['Code']
+        if error_code == '404':
             # Check if it's a prefix containing objects
             resp = s3.list_objects_v2(Bucket=bucket_name, Prefix=key, MaxKeys=1)
             return resp.get('KeyCount', 0) > 0
+        elif error_code in ('403', 'AccessDenied'):
+            raise BulkExecutorError(
+                f"Access denied to S3 path 's3://{bucket_name}/{key}'. "
+                f"Check that your IAM role has s3:GetObject permission on this bucket."
+            ) from None
         else:
-            # Something else went wrong
-            raise
+            raise BulkExecutorError(
+                f"S3 error checking 's3://{bucket_name}/{key}': {e.response['Error'].get('Message', str(e))}"
+            ) from None
 
 def get_mappings_from_s3(s3_uri):
     # Initialize S3 client

--- a/tools/bulk_executor/server/src/root.py
+++ b/tools/bulk_executor/server/src/root.py
@@ -83,8 +83,9 @@ else:
         action_script_function = getattr(module, action_script_function_name)
         try:
             action_script_function(job, spark_context, glue_context, parsed_args)  # Run the function
-        except BulkExecutorError as e: # if any custom logging is needed before bubbling the exception
-            raise
+        except BulkExecutorError as e:
+            log.error(f"BulkExecutorError: {e}")
+            sys.exit(str(e))
         except Exception as e:
             raise # Just let it propagate
     else:

--- a/tools/bulk_executor/tests/client/test_runner.py
+++ b/tools/bulk_executor/tests/client/test_runner.py
@@ -1157,6 +1157,78 @@ class TestRunErrorMessageLogging:
         assert not any(rec.levelname == 'ERROR' for rec in caplog.records)
 
 
+# --- Clean error messages (no tracebacks) -----------------------------------
+
+
+class TestCleanErrorMessages:
+    """Bad parameters or runtime failures produce clean human-readable errors,
+    never raw Python tracebacks (issue #137)."""
+
+    def test_run_catches_unexpected_exception_and_exits_cleanly(self, bulk_runner):
+        """If _start_glue_job raises an unhandled exception, run() should
+        sys.exit with a clean message instead of propagating a traceback."""
+        bulk_runner._get_glue_job_arguments = MagicMock(return_value={})
+        bulk_runner._assert_expected_script_args = MagicMock()
+        bulk_runner._start_glue_job = MagicMock(
+            side_effect=RuntimeError('something unexpected went wrong')
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            bulk_runner.run({}, [])
+        exit_msg = str(exc_info.value)
+        assert 'Traceback' not in exit_msg
+        assert 'something unexpected went wrong' in exit_msg
+
+    def test_run_catches_client_error_and_exits_with_clean_message(self, bulk_runner):
+        """A ClientError during job start produces a clean exit message."""
+        bulk_runner._get_glue_job_arguments = MagicMock(return_value={})
+        bulk_runner._assert_expected_script_args = MagicMock()
+        err = ClientError(
+            {'Error': {'Code': 'InvalidInputException', 'Message': 'Parameter X is invalid'}},
+            'StartJobRun',
+        )
+        bulk_runner._start_glue_job = MagicMock(side_effect=err)
+        with pytest.raises(SystemExit) as exc_info:
+            bulk_runner.run({}, [])
+        exit_msg = str(exc_info.value)
+        assert 'Traceback' not in exit_msg
+        assert 'Parameter X is invalid' in exit_msg
+
+    def test_run_catches_value_error_from_post_start_code(self, bulk_runner):
+        """A ValueError in post-start code (e.g. bad state) exits cleanly."""
+        bulk_runner._get_glue_job_arguments = MagicMock(return_value={})
+        bulk_runner._assert_expected_script_args = MagicMock()
+        bulk_runner._start_glue_job = MagicMock(return_value='jr-1')
+        bulk_runner._watch_glue_job = MagicMock()
+        bulk_runner._watch_for_interrupt = MagicMock(
+            side_effect=ValueError('invalid job run id format')
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            bulk_runner.run({}, [])
+        exit_msg = str(exc_info.value)
+        assert 'Traceback' not in exit_msg
+        assert 'invalid job run id format' in exit_msg
+
+    def test_run_keyboard_interrupt_still_propagates(self, bulk_runner):
+        """KeyboardInterrupt should not be swallowed by error handling."""
+        bulk_runner._get_glue_job_arguments = MagicMock(return_value={})
+        bulk_runner._assert_expected_script_args = MagicMock()
+        bulk_runner._start_glue_job = MagicMock(side_effect=KeyboardInterrupt)
+        with pytest.raises(KeyboardInterrupt):
+            bulk_runner.run({}, [])
+
+    def test_exit_messages_do_not_contain_exception_class_prefix(self, bulk_runner):
+        """Error messages shown to users should not include 'ExceptionName:' prefix."""
+        bulk_runner._get_glue_job_arguments = MagicMock(return_value={})
+        bulk_runner._assert_expected_script_args = MagicMock()
+        bulk_runner._start_glue_job = MagicMock(
+            side_effect=RuntimeError('bad input value')
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            bulk_runner.run({}, [])
+        exit_msg = str(exc_info.value)
+        assert not exit_msg.startswith('RuntimeError')
+
+
 # --- Module constants -------------------------------------------------------
 
 

--- a/tools/bulk_executor/tests/client/test_runner.py
+++ b/tools/bulk_executor/tests/client/test_runner.py
@@ -1070,6 +1070,7 @@ class TestRunStateBranches:
         _wire_run_dependencies(bulk_runner, final_state=runner_module.SUCCEEDED_STATE)
         import logging as _logging
         with caplog.at_level(_logging.INFO):
+            # A successful job must NOT raise SystemExit — it exits 0.
             bulk_runner.run({}, [])
         assert any('completed successfully' in m for m in caplog.messages)
 
@@ -1077,35 +1078,47 @@ class TestRunStateBranches:
         _wire_run_dependencies(bulk_runner, final_state=runner_module.STOPPING_STATE)
         import logging as _logging
         with caplog.at_level(_logging.INFO):
-            bulk_runner.run({}, [])
+            # Non-success terminal state must exit non-zero (issue #137).
+            with pytest.raises(SystemExit) as exc:
+                bulk_runner.run({}, [])
+        assert exc.value.code == 1
         assert any('stopping' in m for m in caplog.messages)
 
     def test_stopped_state(self, bulk_runner, caplog):
         _wire_run_dependencies(bulk_runner, final_state=runner_module.STOPPED_STATE)
         import logging as _logging
         with caplog.at_level(_logging.INFO):
-            bulk_runner.run({}, [])
+            with pytest.raises(SystemExit) as exc:
+                bulk_runner.run({}, [])
+        assert exc.value.code == 1
         assert any('stopped' in m for m in caplog.messages)
 
     def test_failed_state(self, bulk_runner, caplog):
         _wire_run_dependencies(bulk_runner, final_state=runner_module.FAILED_STATE)
         import logging as _logging
         with caplog.at_level(_logging.INFO):
-            bulk_runner.run({}, [])
+            with pytest.raises(SystemExit) as exc:
+                bulk_runner.run({}, [])
+        assert exc.value.code == 1
         assert any('failed' in m.lower() for m in caplog.messages)
 
     def test_timeout_state(self, bulk_runner, caplog):
         _wire_run_dependencies(bulk_runner, final_state=runner_module.TIMEOUT_STATE)
         import logging as _logging
         with caplog.at_level(_logging.INFO):
-            bulk_runner.run({}, [])
+            with pytest.raises(SystemExit) as exc:
+                bulk_runner.run({}, [])
+        assert exc.value.code == 1
         assert any('timed out' in m for m in caplog.messages)
 
     def test_unhandled_state_logs_error(self, bulk_runner, caplog):
         _wire_run_dependencies(bulk_runner, final_state='WEIRD_STATE')
         import logging as _logging
         with caplog.at_level(_logging.ERROR):
-            bulk_runner.run({}, [])
+            # An unrecognized terminal state is treated as failure, not success.
+            with pytest.raises(SystemExit) as exc:
+                bulk_runner.run({}, [])
+        assert exc.value.code == 1
         assert any('Unhandled Job State' in m for m in caplog.messages)
 
     def test_starts_job_with_arguments(self, bulk_runner):
@@ -1144,7 +1157,9 @@ class TestRunErrorMessageLogging:
                                error_message='something exploded')
         import logging as _logging
         with caplog.at_level(_logging.ERROR):
-            bulk_runner.run({}, [])
+            with pytest.raises(SystemExit) as exc:
+                bulk_runner.run({}, [])
+        assert exc.value.code == 1
         assert any('something exploded' in m for m in caplog.messages)
 
     def test_no_error_message_branch(self, bulk_runner, caplog):

--- a/tools/bulk_executor/tests/e2e/commands/test_error_messages.py
+++ b/tools/bulk_executor/tests/e2e/commands/test_error_messages.py
@@ -1,0 +1,45 @@
+"""Command e2e: clean error messages for bad parameters.
+
+Verifies that when a user passes bad parameters (missing required args,
+non-existent table, invalid source/target), the CLI produces clean
+human-readable error messages rather than Python stack traces.
+"""
+from __future__ import annotations
+
+import pytest
+
+from tests.e2e.helpers.command_runner import run_command_raw
+
+
+@pytest.mark.e2e
+class TestErrorMessages:
+    """Bad parameters produce clean error messages, not tracebacks."""
+
+    def test_missing_required_arg_shows_clean_error(self):
+        """Omitting a required argument produces an argparse error, no traceback."""
+        result = run_command_raw("copy", args=["--source", "some-table"])
+        combined = result.stdout + result.stderr
+        assert result.exit_code != 0
+        assert "Traceback" not in combined
+        assert "error:" in combined.lower()
+
+    def test_nonexistent_table_shows_clean_error(self, e2e_config):
+        """A table that doesn't exist produces a readable message."""
+        result = run_command_raw(
+            "fill",
+            args=["--table", "bulk-executor-nonexistent-table-xyz-99"],
+        )
+        combined = result.stdout + result.stderr
+        assert result.exit_code != 0
+        assert "Traceback" not in combined
+
+    def test_same_source_and_target_shows_clean_error(self, e2e_config):
+        """copy --source X --target X produces a parser error, no traceback."""
+        result = run_command_raw(
+            "copy",
+            args=["--source", "same-table", "--target", "same-table"],
+        )
+        combined = result.stdout + result.stderr
+        assert result.exit_code != 0
+        assert "Traceback" not in combined
+        assert "must be different" in combined.lower() or "error" in combined.lower()

--- a/tools/bulk_executor/tests/e2e/commands/test_error_messages.py
+++ b/tools/bulk_executor/tests/e2e/commands/test_error_messages.py
@@ -43,3 +43,70 @@ class TestErrorMessages:
         assert result.exit_code != 0
         assert "Traceback" not in combined
         assert "must be different" in combined.lower() or "error" in combined.lower()
+
+
+@pytest.mark.e2e
+class TestServerSideErrorMessages:
+    """Reproduces the three cases hunterhacker demonstrated on #227 where a
+    server-side Glue failure previously surfaced as a raw traceback (or, worse,
+    as a false success). Each launches a real Glue job, so these live in the
+    opt-in command suite. The assertions encode Jason's bar exactly: a clean
+    one-line message, no ``GlueExceptionAnalysisListener`` blob, and a non-zero
+    exit that reflects the job actually failing."""
+
+    def test_s3_path_access_denied_shows_clean_error(self, e2e_config):
+        """Case 1: a bucket the caller doesn't own returns 403.
+
+        ``./bulk load --table <t> --s3-path s3://fakebucket/haha --format csv``
+        Previously dumped a HeadObject 403 traceback; now check_s3_file_exists
+        raises BulkExecutorError -> root.py sys.exit(clean message)."""
+        result = run_command_raw(
+            "load",
+            args=[
+                "--table", e2e_config.write_table,
+                "--s3-path", "s3://fakebucket/haha",
+                "--format", "csv",
+            ],
+        )
+        combined = result.stdout + result.stderr
+        assert result.exit_code != 0, "unowned-bucket load must fail, not succeed"
+        assert "Traceback" not in combined
+        assert "GlueExceptionAnalysisListener" not in combined
+        assert "Access denied" in combined or "doesn't exist" in combined
+
+    def test_negative_limit_shows_clean_error(self, e2e_config):
+        """Case 2: ``./bulk find --table <t> --limit -1``.
+
+        Spark rejects a negative limit; find.py now wraps it as
+        BulkExecutorError("Invalid 'limit': ...") instead of a bare Exception."""
+        result = run_command_raw(
+            "find",
+            args=["--table", e2e_config.read_table, "--limit", "-1"],
+        )
+        combined = result.stdout + result.stderr
+        assert result.exit_code != 0
+        assert "Traceback" not in combined
+        assert "GlueExceptionAnalysisListener" not in combined
+        assert "Invalid 'limit'" in combined
+
+    def test_owned_bucket_missing_key_reports_failure(self, e2e_config):
+        """Case 3 (the worst offender): a bucket we own but a key that doesn't
+        exist. Previously printed a simple message but exited 0 / "Job completed
+        successfully". load.run now raises BulkExecutorError BEFORE job.commit(),
+        so the run is correctly marked failed."""
+        missing_path = f"s3://{e2e_config.aws_account_id}-glue-job-bucket/haha"
+        result = run_command_raw(
+            "load",
+            args=[
+                "--table", e2e_config.write_table,
+                "--s3-path", missing_path,
+                "--format", "csv",
+            ],
+        )
+        combined = result.stdout + result.stderr
+        assert result.exit_code != 0, (
+            "missing key must NOT report 'Job completed successfully' (issue #137 worst offender)"
+        )
+        assert "Traceback" not in combined
+        assert "doesn't exist" in combined or "not accessible" in combined
+        assert "completed successfully" not in combined.lower()

--- a/tools/bulk_executor/tests/server/test_find.py
+++ b/tools/bulk_executor/tests/server/test_find.py
@@ -1232,3 +1232,33 @@ class TestRunMiscBehavior:
 
         out = capsys.readouterr().out
         assert '8' in out
+
+
+class TestRunLimitErrorViaWrapper:
+    """Issue #137 case 2, asserted against the current wrapper boundary
+    (read_dynamodb_dataframe), not the legacy DynamicFrame path. `--limit -1`
+    passes int() but Spark's .limit() rejects it; find.py must surface that as
+    a BulkExecutorError so root.py can print a clean one-line message."""
+
+    def test_negative_limit_raises_bulk_executor_error(
+        self, monkeypatch, table_info_mocks, boto3_session_mock
+    ):
+        monkeypatch.setattr(find_module, 'get_error_message', lambda e: str(e))
+
+        records = MagicMock()
+        records.limit.side_effect = RuntimeError(
+            "[INVALID_LIMIT_LIKE_EXPRESSION.IS_NEGATIVE] The limit like "
+            'expression "-1" is invalid ... but got -1.'
+        )
+        monkeypatch.setattr(
+            find_module, 'read_dynamodb_dataframe',
+            lambda *a, **k: records,
+        )
+
+        args = {
+            'splits': '200', 'table': 't',
+            'where': None, 'orderby': None, 'limit': '-1',
+            'XAction': 'count',
+        }
+        with pytest.raises(find_module.BulkExecutorError, match="Invalid 'limit'"):
+            find_module.run(MagicMock(), MagicMock(), MagicMock(), args)

--- a/tools/bulk_executor/tests/server/test_load.py
+++ b/tools/bulk_executor/tests/server/test_load.py
@@ -246,14 +246,14 @@ class TestReadDataGlueFrameCreation:
 # --- run() ------------------------------------------------------------------
 
 class TestRunS3Check:
-    """run() exits early if S3 file doesn't exist."""
+    """run() raises BulkExecutorError if S3 file doesn't exist."""
 
-    def test_returns_early_when_s3_file_missing(self, monkeypatch):
-        """Line 79-81: check_s3_file_exists returns False -> early return."""
+    def test_raises_when_s3_file_missing(self, monkeypatch):
+        """Line 79-81: check_s3_file_exists returns False -> BulkExecutorError."""
         monkeypatch.setattr(load_module, 'check_s3_file_exists', lambda uri: False)
         args = {'table': 't', 's3_path': 's3://b/missing'}
-        result = load_module.run(MagicMock(), MagicMock(), MagicMock(), args)
-        assert result is None
+        with pytest.raises(load_module.BulkExecutorError, match="doesn't exist"):
+            load_module.run(MagicMock(), MagicMock(), MagicMock(), args)
 
 
 class TestRunDynamicFrameCount:
@@ -454,13 +454,22 @@ class TestCheckS3FileExists:
         monkeypatch.setattr(load_module.boto3, 'client', lambda svc: s3_client)
         assert load_module.check_s3_file_exists('s3://bucket/key') is False
 
-    def test_non_404_error_re_raised(self, monkeypatch):
-        """Line 152-153: non-404 ClientError is re-raised."""
+    def test_403_error_raises_bulk_executor_error(self, monkeypatch):
+        """Line 152-153: 403 ClientError raises BulkExecutorError with access denied message."""
         s3_client = MagicMock()
-        error_response = {'Error': {'Code': '403'}}
+        error_response = {'Error': {'Code': '403', 'Message': 'Forbidden'}}
         s3_client.head_object.side_effect = load_module.ClientError(error_response, 'HeadObject')
         monkeypatch.setattr(load_module.boto3, 'client', lambda svc: s3_client)
-        with pytest.raises(load_module.ClientError):
+        with pytest.raises(load_module.BulkExecutorError, match="Access denied"):
+            load_module.check_s3_file_exists('s3://bucket/key')
+
+    def test_other_error_raises_bulk_executor_error(self, monkeypatch):
+        """Non-404/403 ClientError raises BulkExecutorError with S3 error message."""
+        s3_client = MagicMock()
+        error_response = {'Error': {'Code': '500', 'Message': 'Internal Server Error'}}
+        s3_client.head_object.side_effect = load_module.ClientError(error_response, 'HeadObject')
+        monkeypatch.setattr(load_module.boto3, 'client', lambda svc: s3_client)
+        with pytest.raises(load_module.BulkExecutorError, match="S3 error"):
             load_module.check_s3_file_exists('s3://bucket/key')
 
     def test_invalid_uri_raises_valueerror(self, monkeypatch):

--- a/tools/bulk_executor/tests/server/test_root.py
+++ b/tools/bulk_executor/tests/server/test_root.py
@@ -455,12 +455,10 @@ class TestRootMissingRunFunction:
 
 
 class TestRootBulkExecutorErrorPropagation:
-    """BulkExecutorError from a verb is re-raised (lines 86-87)."""
+    """BulkExecutorError from a verb is logged and exits cleanly (lines 86-88)."""
 
-    def test_bulk_executor_error_propagates(self, monkeypatch):
-        """Lines 86-87: BulkExecutorError from run() is re-raised after the except."""
-        # We need the same BulkExecutorError class root.py imports — install
-        # the stub first, get back the class, then build the verb.
+    def test_bulk_executor_error_exits_cleanly(self, monkeypatch):
+        """Lines 86-88: BulkExecutorError from run() is logged and sys.exit'd."""
         awsglue = _build_awsglue_stubs()
         install = dict(awsglue["modules"])
         logger_module = _install_logger_stub(install)
@@ -477,11 +475,11 @@ class TestRootBulkExecutorErrorPropagation:
         spec = importlib.util.spec_from_file_location(
             "_root_under_test", str(ROOT_PY_PATH))
         module = importlib.util.module_from_spec(spec)
-        with pytest.raises(BulkExecutorError, match="user error"):
+        with pytest.raises(SystemExit) as exc_info:
             spec.loader.exec_module(module)
 
+        assert "user error" in str(exc_info.value)
         run_mock.assert_called_once()
-        # commit/stop never reached because the exception propagates out.
         awsglue["job_instance"].commit.assert_not_called()
         awsglue["spark_ctx"].stop.assert_not_called()
 


### PR DESCRIPTION
## Summary

Issue #137. When a `./bulk` command fails, show a clean human-readable error message instead of a Python stack trace — and correctly report the failure via a non-zero exit code.

## What was actually broken (from @hunterhacker's review)

The original PR touched `client/src/runner.py`, but the tracebacks Jason saw originate **server-side** in the Glue job. Two root causes:

1. **Stale deployed code.** The Glue job runs the module bundle built at `./bulk bootstrap` time. The source fixes were correct, but the account under test was running pre-fix code. Re-bootstrapping deploys the fix.
2. **Exit code 0 on failure (the worst case).** Even with clean messages, `_execute_job` returned normally on every non-`SUCCEEDED` terminal state, so `./bulk` exited 0 — Jason's "doesn't show the effort failed." Fixed by a `job_failed` flag → `sys.exit(1)`; `SUCCEEDED` still exits 0.

## Changes

- `server`: `check_s3_file_exists` (403) and `find` (`--limit -1`) raise `BulkExecutorError`; `load` raises before `job.commit()` so a missing key is never reported as success.
- `client/src/runner.py`: non-zero exit on any non-`SUCCEEDED` terminal state.

## Verification (live, real Glue)

All three of Jason's exact commands re-run on a bootstrapped account:
- 403 unowned bucket → clean "Access denied" message, no traceback, exit ≠ 0
- `find --limit -1` → clean "Invalid 'limit'" message, exit ≠ 0
- owned bucket / missing key → "doesn't exist", **no** "completed successfully", exit ≠ 0

e2e `TestServerSideErrorMessages`: 3 passed in 178s. Offline suite: 1330 passed.

## Out of scope

The worker-side `error_accumulator` fast-exit path (from @hunterhacker's "Current approach" comment on #137) is deliberately not included here — Jason scopes it to a separate ticket (#83). This PR covers the driver-side bad-parameter cases that #137's title describes.
