### PR TITLE
[bulk][split-218 #84] Force built-in role refresh on version mismatch (bu-b6f)

### DIFF
--- a/tools/bulk_executor/client/src/infrastructure/bootstrap.py
+++ b/tools/bulk_executor/client/src/infrastructure/bootstrap.py
@@ -180,7 +180,14 @@ class BootstrapInfrastructure:
         deployed_version = job_details['Job']['DefaultArguments'].get('--bulk-dynamodb-version')
         if not deployed_version:
             return True
-        return deployed_version != VERSION
+        if deployed_version != VERSION:
+            log.warning(
+                f"Version mismatch detected: deployed Glue job is v{deployed_version} "
+                f"but local bulk_executor is v{VERSION}. "
+                f"Refreshing IAM role policies to ensure required permissions are up to date."
+            )
+            return True
+        return False
 
     def _is_existing_role(self, role_name):
         try:

--- a/tools/bulk_executor/client/src/infrastructure/bootstrap.py
+++ b/tools/bulk_executor/client/src/infrastructure/bootstrap.py
@@ -130,7 +130,8 @@ class BootstrapInfrastructure:
             log.debug(f'Role ARN: {response["Role"]["Arn"]}')
         except self.iam_client.exceptions.EntityAlreadyExistsException as e:
             log.info(f"Found Bulk Executor Glue Job Role: {role_name}")
-            return # Roles exists. No additional actions needed.
+            if not self._needs_role_refresh():
+                return
         except Exception as e:
             log.error(f'Unexpected error: {e}')
             exit(1)
@@ -171,6 +172,15 @@ class BootstrapInfrastructure:
         except Exception as e:
             log.error(f'Unexpected error: {e}')
             exit(1)
+
+    def _needs_role_refresh(self):
+        job_details = self._get_glue_job_details()
+        if not job_details:
+            return True
+        deployed_version = job_details['Job']['DefaultArguments'].get('--bulk-dynamodb-version')
+        if not deployed_version:
+            return True
+        return deployed_version != VERSION
 
     def _is_existing_role(self, role_name):
         try:

--- a/tools/bulk_executor/client/src/infrastructure/bootstrap.py
+++ b/tools/bulk_executor/client/src/infrastructure/bootstrap.py
@@ -132,6 +132,19 @@ class BootstrapInfrastructure:
             log.info(f"Found Bulk Executor Glue Job Role: {role_name}")
             if not self._needs_role_refresh():
                 return
+            # The role already exists, so create_role (which sets the trust
+            # policy) was skipped. Re-apply the trust policy on refresh so the
+            # role ends up with the same AssumeRolePolicyDocument a fresh
+            # bootstrap would create, not the one baked in when it was first made.
+            try:
+                self.iam_client.update_assume_role_policy(
+                    RoleName=role_name,
+                    PolicyDocument=json.dumps(trust_policy)
+                )
+                log.debug(f'Refreshed trust policy on role {role_name}')
+            except Exception as e:
+                log.error(f'Unexpected error: {e}')
+                exit(1)
         except Exception as e:
             log.error(f'Unexpected error: {e}')
             exit(1)

--- a/tools/bulk_executor/client/src/infrastructure/bootstrap.py
+++ b/tools/bulk_executor/client/src/infrastructure/bootstrap.py
@@ -182,9 +182,10 @@ class BootstrapInfrastructure:
             return True
         if deployed_version != VERSION:
             log.warning(
-                f"Version mismatch detected: deployed Glue job is v{deployed_version} "
-                f"but local bulk_executor is v{VERSION}. "
-                f"Refreshing IAM role policies to ensure required permissions are up to date."
+                f"Version mismatch: deployed Glue job is v{deployed_version}, "
+                f"but you are running v{VERSION} locally. "
+                f"IAM policies will be re-applied to ensure the role has permissions "
+                f"required by v{VERSION}. To resolve this mismatch, redeploy the Glue job."
             )
             return True
         return False

--- a/tools/bulk_executor/tests/client/test_bootstrap.py
+++ b/tools/bulk_executor/tests/client/test_bootstrap.py
@@ -259,11 +259,83 @@ class TestAddGlueJobRole:
         )
         bootstrap.iam_client.create_role.side_effect = EntityAlreadyExistsException()
 
+        # Version matches — no refresh needed
+        from __version__ import __version__ as VERSION
+        bootstrap._get_glue_job_details = MagicMock(return_value={
+            'Job': {'DefaultArguments': {'--bulk-dynamodb-version': VERSION}}
+        })
+
         bootstrap._add_glue_job_role({'XRole': ROLE_TYPE_READ_ONLY})
 
         # Early return — no policy attachments
         bootstrap.iam_client.attach_role_policy.assert_not_called()
         bootstrap.iam_client.put_role_policy.assert_not_called()
+
+    def test_role_already_exists_refreshes_policies_on_version_mismatch(self, bootstrap):
+        from infrastructure.constants import ROLE_TYPE_READ_ONLY
+        bootstrap._prompt_for_role = MagicMock()
+
+        class EntityAlreadyExistsException(Exception):
+            pass
+        bootstrap.iam_client.exceptions.EntityAlreadyExistsException = (
+            EntityAlreadyExistsException
+        )
+        bootstrap.iam_client.create_role.side_effect = EntityAlreadyExistsException()
+
+        # Simulate a version mismatch: Glue job has an older version
+        bootstrap._get_glue_job_details = MagicMock(return_value={
+            'Job': {'DefaultArguments': {'--bulk-dynamodb-version': '0'}}
+        })
+
+        bootstrap._add_glue_job_role({'XRole': ROLE_TYPE_READ_ONLY})
+
+        # Despite the role already existing, policies MUST be refreshed
+        # because the version changed.
+        bootstrap.iam_client.attach_role_policy.assert_called()
+        bootstrap.iam_client.put_role_policy.assert_called()
+
+    def test_role_already_exists_skips_refresh_when_version_matches(self, bootstrap):
+        from infrastructure.constants import ROLE_TYPE_READ_ONLY
+        bootstrap._prompt_for_role = MagicMock()
+
+        class EntityAlreadyExistsException(Exception):
+            pass
+        bootstrap.iam_client.exceptions.EntityAlreadyExistsException = (
+            EntityAlreadyExistsException
+        )
+        bootstrap.iam_client.create_role.side_effect = EntityAlreadyExistsException()
+
+        # Simulate version match: Glue job has same version as local
+        from __version__ import __version__ as VERSION
+        bootstrap._get_glue_job_details = MagicMock(return_value={
+            'Job': {'DefaultArguments': {'--bulk-dynamodb-version': VERSION}}
+        })
+
+        bootstrap._add_glue_job_role({'XRole': ROLE_TYPE_READ_ONLY})
+
+        # Version matches — no need to refresh policies
+        bootstrap.iam_client.attach_role_policy.assert_not_called()
+        bootstrap.iam_client.put_role_policy.assert_not_called()
+
+    def test_role_already_exists_refreshes_when_no_deployed_version(self, bootstrap):
+        from infrastructure.constants import ROLE_TYPE_READ_ONLY
+        bootstrap._prompt_for_role = MagicMock()
+
+        class EntityAlreadyExistsException(Exception):
+            pass
+        bootstrap.iam_client.exceptions.EntityAlreadyExistsException = (
+            EntityAlreadyExistsException
+        )
+        bootstrap.iam_client.create_role.side_effect = EntityAlreadyExistsException()
+
+        # No Glue job exists yet (first bootstrap with pre-existing role)
+        bootstrap._get_glue_job_details = MagicMock(return_value=None)
+
+        bootstrap._add_glue_job_role({'XRole': ROLE_TYPE_READ_ONLY})
+
+        # No deployed version to compare → must refresh to be safe
+        bootstrap.iam_client.attach_role_policy.assert_called()
+        bootstrap.iam_client.put_role_policy.assert_called()
 
     def test_unexpected_create_role_error_exits(self, bootstrap):
         from infrastructure.constants import ROLE_TYPE_READ_ONLY

--- a/tools/bulk_executor/tests/client/test_bootstrap.py
+++ b/tools/bulk_executor/tests/client/test_bootstrap.py
@@ -319,6 +319,14 @@ class TestAddGlueJobRole:
             f"Expected a warning mentioning deployed version '0.old' and local version '{VERSION}', "
             f"got: {warning_messages}"
         )
+        # Reviewer feedback: warning must clearly explain what will happen and why
+        msg = next(m for m in warning_messages if '0.old' in m)
+        assert 'IAM policies will be re-applied' in msg, (
+            f"Warning must explain that IAM policies will be re-applied, got: {msg}"
+        )
+        assert 'redeploy' in msg.lower(), (
+            f"Warning must suggest redeploying the Glue job to resolve, got: {msg}"
+        )
 
     def test_role_already_exists_skips_refresh_when_version_matches(self, bootstrap):
         from infrastructure.constants import ROLE_TYPE_READ_ONLY

--- a/tools/bulk_executor/tests/client/test_bootstrap.py
+++ b/tools/bulk_executor/tests/client/test_bootstrap.py
@@ -351,6 +351,37 @@ class TestAddGlueJobRole:
         bootstrap.iam_client.attach_role_policy.assert_not_called()
         bootstrap.iam_client.put_role_policy.assert_not_called()
 
+    def test_refresh_updates_trust_policy_to_match_fresh_bootstrap(self, bootstrap):
+        # Reviewer feedback: on a version-mismatch refresh of an existing role,
+        # the code re-applies attached/inline policies but the trust policy
+        # (AssumeRolePolicyDocument) is only set at create_role time. If the
+        # trust_policy definition changes and the version is bumped, a refreshed
+        # role would keep its stale trust policy — NOT matching a fresh
+        # bootstrap. The refresh must also update the assume-role (trust) policy.
+        from infrastructure.constants import ROLE_TYPE_READ_ONLY
+        bootstrap._prompt_for_role = MagicMock()
+
+        class EntityAlreadyExistsException(Exception):
+            pass
+        bootstrap.iam_client.exceptions.EntityAlreadyExistsException = (
+            EntityAlreadyExistsException
+        )
+        bootstrap.iam_client.create_role.side_effect = EntityAlreadyExistsException()
+
+        # Version mismatch → refresh path.
+        bootstrap._get_glue_job_details = MagicMock(return_value={
+            'Job': {'DefaultArguments': {'--bulk-dynamodb-version': '0.old'}}
+        })
+
+        bootstrap._add_glue_job_role({'XRole': ROLE_TYPE_READ_ONLY})
+
+        # The trust policy must be re-applied so the refreshed role ends up with
+        # the same trust policy a fresh bootstrap would create.
+        bootstrap.iam_client.update_assume_role_policy.assert_called_once()
+        kwargs = bootstrap.iam_client.update_assume_role_policy.call_args.kwargs
+        trust = json.loads(kwargs['PolicyDocument'])
+        assert trust['Statement'][0]['Principal']['Service'] == 'glue.amazonaws.com'
+
     def test_role_already_exists_refreshes_when_no_deployed_version(self, bootstrap):
         from infrastructure.constants import ROLE_TYPE_READ_ONLY
         bootstrap._prompt_for_role = MagicMock()

--- a/tools/bulk_executor/tests/client/test_bootstrap.py
+++ b/tools/bulk_executor/tests/client/test_bootstrap.py
@@ -294,6 +294,32 @@ class TestAddGlueJobRole:
         bootstrap.iam_client.attach_role_policy.assert_called()
         bootstrap.iam_client.put_role_policy.assert_called()
 
+    def test_version_mismatch_logs_warning_with_both_versions(self, bootstrap, caplog):
+        import logging
+        from infrastructure.constants import ROLE_TYPE_READ_ONLY
+        from __version__ import __version__ as VERSION
+        bootstrap._prompt_for_role = MagicMock()
+
+        class EntityAlreadyExistsException(Exception):
+            pass
+        bootstrap.iam_client.exceptions.EntityAlreadyExistsException = (
+            EntityAlreadyExistsException
+        )
+        bootstrap.iam_client.create_role.side_effect = EntityAlreadyExistsException()
+
+        bootstrap._get_glue_job_details = MagicMock(return_value={
+            'Job': {'DefaultArguments': {'--bulk-dynamodb-version': '0.old'}}
+        })
+
+        with caplog.at_level(logging.WARNING):
+            bootstrap._add_glue_job_role({'XRole': ROLE_TYPE_READ_ONLY})
+
+        warning_messages = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+        assert any('0.old' in m and VERSION in m for m in warning_messages), (
+            f"Expected a warning mentioning deployed version '0.old' and local version '{VERSION}', "
+            f"got: {warning_messages}"
+        )
+
     def test_role_already_exists_skips_refresh_when_version_matches(self, bootstrap):
         from infrastructure.constants import ROLE_TYPE_READ_ONLY
         bootstrap._prompt_for_role = MagicMock()


### PR DESCRIPTION
## Summary

Issue #84. When the bulk_executor version changes, force-refresh the built-in IAM role to pick up any new permissions.

TDD REQUIRED: (1) Write a failing unit test that asserts role refresh triggers on version mismatch. (2) Implement the check. (3) make test must pass. Single-issue PR.

Files: client/src/infrastructure/. Tests: tests/client/.

## Implementation notes

Implemented: force-refresh IAM role policies when deployed version != local VERSION

## Refinery handoff

- Issue: `bu-b6f` (task, P2)
- Source branch: `polecat/bu-b6f`
- Target: `main`
- Rebased on `main` via Gastown Refinery.