### PR TITLE
[bulk][split-217 #89] Expand rate warnings for too-high/too-low values (bu-9w5)

### DIFF
--- a/tools/bulk_executor/Makefile
+++ b/tools/bulk_executor/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := help
-.PHONY: help install test test-client test-server coverage clean test-e2e test-e2e-connector test-e2e-cleanup test-e2e-security test-e2e-security-simulator test-e2e-security-real test-e2e-commands test-e2e-whole-system test-e2e-max-rate
+.PHONY: help install test test-client test-server coverage clean test-e2e test-e2e-connector test-e2e-cleanup test-e2e-security test-e2e-security-simulator test-e2e-security-real test-e2e-commands test-e2e-whole-system test-e2e-max-rate test-e2e-capacity-warnings
 
 VENV := .venv
 PIP := $(VENV)/bin/pip
@@ -27,6 +27,7 @@ help:
 	@echo "  make test-e2e-commands              Bulk-command smokes against transient tables"
 	@echo "  make test-e2e-whole-system          True e2e: 60k load round-trip + observed rate enforcement"
 	@echo "  make test-e2e-max-rate              EXPENSIVE: prove load beats the old 60k connector ceiling (~\$$ per run)"
+	@echo "  make test-e2e-capacity-warnings     #89 rate-vs-capacity warnings, proven live (~5 short jobs)"
 	@echo "  make test-e2e-cleanup               Delete orphaned items left by a crashed e2e run"
 
 install:
@@ -114,6 +115,19 @@ test-e2e-max-rate:
 	  --override-ini="testpaths=tests/e2e" \
 	  -m "max_rate" \
 	  --e2e-suite="max-rate (beats legacy 60k ceiling)"
+
+# Issue #89 capacity/rate warnings, proven LIVE. Runs the four transient-table
+# scenarios (whole_system) and the missing-permission degradation (security)
+# serially in one process. Serial is required: the missing-perm test flips the
+# shared job's role and restores it in a finally, so it must not overlap the
+# write-capable scenarios. Each warning fires at throughput-config setup, so
+# fixtures are tiny — cost is ~5 short Glue jobs, not a max-rate run.
+test-e2e-capacity-warnings:
+	$(PYTEST) tests/e2e/whole_system/test_capacity_warnings.py \
+	  tests/e2e/security/test_capacity_warning_missing_perm.py \
+	  -s -v --tb=short --no-cov \
+	  --override-ini="testpaths=tests/e2e" \
+	  --e2e-suite="capacity warnings (#89, live)"
 
 test-e2e-cleanup:
 	$(VENV)/bin/python -m tests.e2e.helpers.cleanup

--- a/tools/bulk_executor/README.md
+++ b/tools/bulk_executor/README.md
@@ -1,8 +1,8 @@
 # Bulk Executor for Amazon DynamoDB
 
-![tests](https://img.shields.io/badge/tests-1392%20passing-brightgreen)
+![tests](https://img.shields.io/badge/tests-1395%20passing-brightgreen)
 ![line coverage](https://img.shields.io/badge/line%20coverage-94.6%25-brightgreen)
-![branch coverage](https://img.shields.io/badge/branch%20coverage-90.5%25-brightgreen)
+![branch coverage](https://img.shields.io/badge/branch%20coverage-90.4%25-brightgreen)
 
 Bulk Executor for Amazon DynamoDB lets you efficiently run bulk commands against even large tables. It:
 
@@ -327,6 +327,7 @@ If you provide a custom IAM role for your AWS Glue job:
 * Attach the managed policy `AWSGlueServiceRole` to grant Glue its baseline execution permissions.
 * Attach `ServiceQuotasReadOnlyAccess` to allow the job to read service quota information (used to detect account-level read/write limits), or for maximum lockdown allow the `pricing:GetProducts` action.
 * Attach `AWSPriceListServiceFullAccess` to allow the job to query AWS pricing APIs (used to estimate DynamoDB operation costs), or for maximum lockdown allow the `servicequotas:GetServiceQuota` and `servicequotas:GetAWSDefaultServiceQuota` actions.
+* Allow the `application-autoscaling:DescribeScalableTargets` action (used to detect a provisioned table's autoscaling maximum when warning that a requested rate exceeds the table's capacity). This action does not support resource-level scoping, so it must be granted on `"Resource": "*"`. If the role lacks this permission the job still runs — it simply skips the autoscaling-aware capacity warning and logs that it is proceeding without visibility into the table's autoscaling settings.
 * Add custom IAM permissions for DynamoDB access. You may attach `AmazonDynamoDBReadOnlyAccess` or `AmazonDynamoDBFullAccess`, or define a more restrictive policy targeting specific tables.
 
 ### Security: Consider adjusting S3 bucket behaviors

--- a/tools/bulk_executor/README.md
+++ b/tools/bulk_executor/README.md
@@ -1,8 +1,8 @@
 # Bulk Executor for Amazon DynamoDB
 
-![tests](https://img.shields.io/badge/tests-1330%20passing-brightgreen)
-![line coverage](https://img.shields.io/badge/line%20coverage-94.1%25-brightgreen)
-![branch coverage](https://img.shields.io/badge/branch%20coverage-91.7%25-brightgreen)
+![tests](https://img.shields.io/badge/tests-1392%20passing-brightgreen)
+![line coverage](https://img.shields.io/badge/line%20coverage-94.6%25-brightgreen)
+![branch coverage](https://img.shields.io/badge/branch%20coverage-90.5%25-brightgreen)
 
 Bulk Executor for Amazon DynamoDB lets you efficiently run bulk commands against even large tables. It:
 

--- a/tools/bulk_executor/README.md
+++ b/tools/bulk_executor/README.md
@@ -1,6 +1,6 @@
 # Bulk Executor for Amazon DynamoDB
 
-![tests](https://img.shields.io/badge/tests-1395%20passing-brightgreen)
+![tests](https://img.shields.io/badge/tests-1396%20passing-brightgreen)
 ![line coverage](https://img.shields.io/badge/line%20coverage-94.6%25-brightgreen)
 ![branch coverage](https://img.shields.io/badge/branch%20coverage-90.4%25-brightgreen)
 
@@ -626,6 +626,7 @@ The e2e harness has these suites:
 | Security  | `make test-e2e-security`  | the documented bootstrap IAM policy actually bootstraps (and is minimal) |
 | Whole-system | `make test-e2e-whole-system` | true end-to-end: 60k `load` round-trip fidelity + observed write-rate enforcement from CloudWatch |
 | Max-rate | `make test-e2e-max-rate` | **expensive, opt-in:** proves `load` sustains a write rate above the old connector's 60k WCU/s ceiling (millions of items + pre-warmed table) |
+| Capacity warnings | `make test-e2e-capacity-warnings` | issue #89: `load --XMaxWriteRate` above a table's ceiling emits the right warning live (provisioned / autoscaling-max / autoscaling-soft-note / on-demand-max), plus the missing-`DescribeScalableTargets` visibility degradation — asserted in the real Glue job's log stream |
 
 Each command/connector smoke creates its own short-lived table (`bulk-e2e-<command>-<random>`, tagged `ephemeral=true`) and **tears it down in a `finally` block** even on failure — the suite never touches your existing tables. If a run is hard-killed mid-test, sweep any orphans with `make test-e2e-cleanup`. The first e2e run prompts once for account/region/test-table config and caches it in `tests/e2e/.e2e-config` (gitignored, per-developer).
 

--- a/tools/bulk_executor/README.md
+++ b/tools/bulk_executor/README.md
@@ -1,8 +1,8 @@
 # Bulk Executor for Amazon DynamoDB
 
-![tests](https://img.shields.io/badge/tests-1396%20passing-brightgreen)
+![tests](https://img.shields.io/badge/tests-1412%20passing-brightgreen)
 ![line coverage](https://img.shields.io/badge/line%20coverage-94.6%25-brightgreen)
-![branch coverage](https://img.shields.io/badge/branch%20coverage-90.4%25-brightgreen)
+![branch coverage](https://img.shields.io/badge/branch%20coverage-90.6%25-brightgreen)
 
 Bulk Executor for Amazon DynamoDB lets you efficiently run bulk commands against even large tables. It:
 
@@ -596,6 +596,8 @@ If you set a very low maximum read rate (below say 200) the effective maximum ma
 These are provided as `--X` flags even though they're actually implemented inside the scripts, using libraries provided by the harness.
 
 With `diff` which reads from two tables, the max read rate is applied per table.
+
+At the start of a run the effective rate is also checked against the table's size: if moving the table's data at that rate would take longer than the Glue job timeout (`--XTimeout`, default 60 minutes), a warning is logged that the job will likely time out before finishing — raise the rate or the timeout. The check applies whether the rate was set explicitly or derived from the table's capacity, and is observational only (it never blocks the run). Conversely, a rate below the recommended minimum, or above what the table can actually deliver (its provisioned/autoscaling/on-demand ceiling), is warned about too.
 
 ## Cost management
 

--- a/tools/bulk_executor/__version__.py
+++ b/tools/bulk_executor/__version__.py
@@ -1,1 +1,1 @@
-__version__ = '1'
+__version__ = '2'

--- a/tools/bulk_executor/client/src/infrastructure/bootstrap.py
+++ b/tools/bulk_executor/client/src/infrastructure/bootstrap.py
@@ -118,6 +118,23 @@ class BootstrapInfrastructure:
             ]
         }
 
+        # Read-only visibility into a table's autoscaling configuration so the
+        # job can tell whether autoscaling would lift a provisioned table's
+        # ceiling above a user-requested rate (issue #89). DescribeScalableTargets
+        # does not support resource-level scoping, so the resource must be "*".
+        autoscaling_policy = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": [
+                        "application-autoscaling:DescribeScalableTargets"
+                    ],
+                    "Resource": "*"
+                }
+            ]
+        }
+
         # Create the role
         try:
             response = self.iam_client.create_role(
@@ -181,6 +198,14 @@ class BootstrapInfrastructure:
                 PolicyDocument=json.dumps(quotas_policy)
             )
             log.debug(f'Attached quotas policy to role {role_name}')
+
+            # Give read-only access to autoscaling targets (issue #89 rate warnings)
+            self.iam_client.put_role_policy(
+                RoleName=role_name,
+                PolicyName='MinimalAutoScalingAccess',
+                PolicyDocument=json.dumps(autoscaling_policy)
+            )
+            log.debug(f'Attached autoscaling policy to role {role_name}')
         except Exception as e:
             log.error(f'Unexpected error: {e}')
             exit(1)

--- a/tools/bulk_executor/server/src/python_modules/shared/table_info.py
+++ b/tools/bulk_executor/server/src/python_modules/shared/table_info.py
@@ -1,5 +1,6 @@
 import math
 import os
+import time
 
 import boto3
 import botocore.exceptions
@@ -14,6 +15,22 @@ MIN_RECOMMENDED_WRITE_RATE = 100
 # Glue's default job timeout (minutes). Mirrors client GlueJobDefaults.Timeout;
 # used only as a fallback for the duration estimate when --XTimeout is unset.
 DEFAULT_JOB_TIMEOUT_MINUTES = 60
+
+# Monotonic reference captured when this module is first imported, which on a
+# Glue worker is at job startup (root.py imports the verb, which imports this).
+# The #89 check-1 timeout estimate races the next phase against the time
+# *remaining* before the job timeout, not the raw timeout: multi-phase verbs
+# (e.g. delete = scan then write) resolve a later phase's rate only after an
+# earlier phase has already consumed part of the budget, so that phase must
+# look at what's left. Using elapsed here needs no extra IAM (no glue:GetJobRun)
+# and no per-verb plumbing — every verb resolves its rate when the phase begins,
+# so a late phase automatically sees a shrunken budget.
+_JOB_START_MONOTONIC = time.monotonic()
+
+
+def _job_elapsed_minutes():
+    """Minutes elapsed since the job started (module import), never negative."""
+    return max(0.0, (time.monotonic() - _JOB_START_MONOTONIC) / 60.0)
 
 def get_quota_value(quota_name, region_name):
     """
@@ -445,15 +462,21 @@ def _warn_if_rate_exceeds_capacity(table_name, dimension, user_rate, table_desc,
         )
 
 
-def _warn_if_job_may_timeout(table_name, dimension, rate, table_desc, timeout_minutes):
-    """Warn when the effective rate is too low to finish before the job times out.
+def _warn_if_job_may_timeout(table_name, dimension, rate, table_desc, remaining_minutes):
+    """Warn when the effective rate is too low to finish in the time remaining.
 
     Implements issue #89 check 1: estimate how long moving the table's data will
-    take at `rate` capacity units/second and, if that exceeds the Glue job
-    timeout (default 60 min), warn that the job will likely time out before the
-    work completes. The rate may be user-specified or table-derived — either way
-    a rate that is technically valid but too small for the table's size is worth
-    surfacing.
+    take at `rate` capacity units/second and, if that exceeds the time *remaining*
+    before the Glue job times out, warn that the job will likely time out before
+    the work completes. The rate may be user-specified or table-derived — either
+    way a rate that is technically valid but too small for the table's size is
+    worth surfacing.
+
+    `remaining_minutes` is the budget for THIS phase — the job timeout minus the
+    time already elapsed — not the raw timeout. Multi-phase verbs (e.g. delete's
+    scan phase then write phase) call this as each phase begins, so a later phase
+    is measured against the time actually left, per Jason's PR #231 review. We
+    deliberately do not predict what future phases will need.
 
     Uses the same unit formulas as the cost estimators:
     - read  → ceil(size_bytes / 8096) read units for a full scan
@@ -484,15 +507,15 @@ def _warn_if_job_may_timeout(table_name, dimension, rate, table_desc, timeout_mi
         return
 
     estimated_seconds = total_units / rate
-    timeout_seconds = timeout_minutes * 60
-    if estimated_seconds > timeout_seconds:
+    remaining_seconds = max(0.0, remaining_minutes * 60)
+    if estimated_seconds > remaining_seconds:
         estimated_minutes = estimated_seconds / 60
         log.warning(
             f"[{table_name}] Estimated {dimension} time of ~{estimated_minutes:,.0f} min "
             f"at {rate:,} units/sec for ~{total_units:,} {dimension} units exceeds the "
-            f"job timeout of {timeout_minutes:,} min; the job will likely time out before "
-            f"finishing. Increase the rate (e.g. --XMax{dimension.capitalize()}Rate) or the "
-            f"timeout (--XTimeout)."
+            f"~{remaining_minutes:,.0f} min remaining before the job timeout; the job will "
+            f"likely time out before finishing. Increase the rate "
+            f"(e.g. --XMax{dimension.capitalize()}Rate) or the timeout (--XTimeout)."
         )
 
 
@@ -508,11 +531,15 @@ def get_dynamodb_throughput_configs(args, table_name, modes=None, format="connec
     DEFAULT_ON_DEMAND_CAPACITY = 40000
 
     # Job timeout drives the "will this finish in time?" estimate (#89 check 1).
+    # We race the next phase against the time REMAINING (timeout minus elapsed),
+    # not the raw timeout: this function is called when each phase begins, so a
+    # late phase (e.g. delete's write after its scan) sees a shrunken budget.
     timeout_minutes = args.get('XTimeout', DEFAULT_JOB_TIMEOUT_MINUTES)
     try:
         timeout_minutes = int(timeout_minutes)
     except (TypeError, ValueError):
         timeout_minutes = DEFAULT_JOB_TIMEOUT_MINUTES
+    remaining_minutes = timeout_minutes - _job_elapsed_minutes()
 
     # Get table description to determine if it's on-demand or provisioned
     read_rate = args.get('XMaxReadRate', None)   # User set read rate
@@ -575,7 +602,7 @@ def get_dynamodb_throughput_configs(args, table_name, modes=None, format="connec
 
         if read_rate is not None:
             _warn_if_job_may_timeout(
-                table_name, "read", read_rate, table_desc, timeout_minutes,
+                table_name, "read", read_rate, table_desc, remaining_minutes,
             )
 
     # Handle write throughput
@@ -619,7 +646,7 @@ def get_dynamodb_throughput_configs(args, table_name, modes=None, format="connec
 
         if write_rate is not None:
             _warn_if_job_may_timeout(
-                table_name, "write", write_rate, table_desc, timeout_minutes,
+                table_name, "write", write_rate, table_desc, remaining_minutes,
             )
 
     if format == "connector":

--- a/tools/bulk_executor/server/src/python_modules/shared/table_info.py
+++ b/tools/bulk_executor/server/src/python_modules/shared/table_info.py
@@ -11,6 +11,10 @@ from .pricing import PricingUtility
 MIN_RECOMMENDED_READ_RATE = 100
 MIN_RECOMMENDED_WRITE_RATE = 100
 
+# Glue's default job timeout (minutes). Mirrors client GlueJobDefaults.Timeout;
+# used only as a fallback for the duration estimate when --XTimeout is unset.
+DEFAULT_JOB_TIMEOUT_MINUTES = 60
+
 def get_quota_value(quota_name, region_name):
     """
     Get the value of a specific DynamoDB quota from Service Quotas API.
@@ -441,6 +445,57 @@ def _warn_if_rate_exceeds_capacity(table_name, dimension, user_rate, table_desc,
         )
 
 
+def _warn_if_job_may_timeout(table_name, dimension, rate, table_desc, timeout_minutes):
+    """Warn when the effective rate is too low to finish before the job times out.
+
+    Implements issue #89 check 1: estimate how long moving the table's data will
+    take at `rate` capacity units/second and, if that exceeds the Glue job
+    timeout (default 60 min), warn that the job will likely time out before the
+    work completes. The rate may be user-specified or table-derived — either way
+    a rate that is technically valid but too small for the table's size is worth
+    surfacing.
+
+    Uses the same unit formulas as the cost estimators:
+    - read  → ceil(size_bytes / 8096) read units for a full scan
+    - write → item_count * ceil(avg_item_size / 1024) write units
+
+    Estimation is best-effort; missing/zero metadata simply skips the check.
+    """
+    try:
+        rate = int(rate)
+    except (TypeError, ValueError):
+        return
+    if rate <= 0:
+        return
+
+    size_bytes = int(table_desc.get('TableSizeBytes', 0) or 0)
+    item_count = int(table_desc.get('ItemCount', 0) or 0)
+
+    if dimension == "read":
+        total_units = math.ceil(size_bytes / 8096) if size_bytes else 0
+    else:
+        if item_count <= 0 or size_bytes <= 0:
+            total_units = 0
+        else:
+            avg_units_per_item = math.ceil((size_bytes / item_count) / 1024)
+            total_units = item_count * avg_units_per_item
+
+    if total_units <= 0:
+        return
+
+    estimated_seconds = total_units / rate
+    timeout_seconds = timeout_minutes * 60
+    if estimated_seconds > timeout_seconds:
+        estimated_minutes = estimated_seconds / 60
+        log.warning(
+            f"[{table_name}] Estimated {dimension} time of ~{estimated_minutes:,.0f} min "
+            f"at {rate:,} units/sec for ~{total_units:,} {dimension} units exceeds the "
+            f"job timeout of {timeout_minutes:,} min; the job will likely time out before "
+            f"finishing. Increase the rate (e.g. --XMax{dimension.capitalize()}Rate) or the "
+            f"timeout (--XTimeout)."
+        )
+
+
 def get_dynamodb_throughput_configs(args, table_name, modes=None, format="connector"):
     region_name = _region_from_table_ref(table_name) or _default_region()
     if not region_name:
@@ -451,6 +506,13 @@ def get_dynamodb_throughput_configs(args, table_name, modes=None, format="connec
         modes = ("read", "write")
 
     DEFAULT_ON_DEMAND_CAPACITY = 40000
+
+    # Job timeout drives the "will this finish in time?" estimate (#89 check 1).
+    timeout_minutes = args.get('XTimeout', DEFAULT_JOB_TIMEOUT_MINUTES)
+    try:
+        timeout_minutes = int(timeout_minutes)
+    except (TypeError, ValueError):
+        timeout_minutes = DEFAULT_JOB_TIMEOUT_MINUTES
 
     # Get table description to determine if it's on-demand or provisioned
     read_rate = args.get('XMaxReadRate', None)   # User set read rate
@@ -511,6 +573,11 @@ def get_dynamodb_throughput_configs(args, table_name, modes=None, format="connec
                 is_on_demand_table, region_name,
             )
 
+        if read_rate is not None:
+            _warn_if_job_may_timeout(
+                table_name, "read", read_rate, table_desc, timeout_minutes,
+            )
+
     # Handle write throughput
     if "write" in modes:
         if write_rate:
@@ -548,6 +615,11 @@ def get_dynamodb_throughput_configs(args, table_name, modes=None, format="connec
             _warn_if_rate_exceeds_capacity(
                 table_name, "write", user_write_rate, table_desc,
                 is_on_demand_table, region_name,
+            )
+
+        if write_rate is not None:
+            _warn_if_job_may_timeout(
+                table_name, "write", write_rate, table_desc, timeout_minutes,
             )
 
     if format == "connector":

--- a/tools/bulk_executor/server/src/python_modules/shared/table_info.py
+++ b/tools/bulk_executor/server/src/python_modules/shared/table_info.py
@@ -382,9 +382,17 @@ def _effective_capacity_ceiling(table_desc, is_on_demand, region_name, table_nam
         autoscaling_max = _autoscaling_max_capacity(table_name, region_name, dimension)
     except Exception as e:
         # Can't tell whether autoscaling would lift the ceiling; skip the
-        # warning rather than emit a false "exceeds provisioned" for a table
-        # that may well autoscale above the request.
-        log.info(f"[{table_name}] Warning: Could not retrieve autoscaling settings: {str(e)}")
+        # capacity warning rather than emit a false "exceeds provisioned" for a
+        # table that may well autoscale above the request. This is the expected
+        # path when the Glue role lacks application-autoscaling:DescribeScalableTargets
+        # (issue #89) — proceed, but surface that we're doing so without
+        # visibility into the table's autoscaling settings.
+        log.warning(
+            f"[{table_name}] Could not read autoscaling settings for the {dimension} "
+            f"dimension ({str(e)}); proceeding without knowledge of the table's "
+            f"autoscaling metrics, so the requested-rate capacity check is skipped. "
+            f"Grant application-autoscaling:DescribeScalableTargets to enable it."
+        )
         return None, None, None
     if autoscaling_max is not None:
         return autoscaling_max, "autoscaling maximum", provisioned

--- a/tools/bulk_executor/server/src/python_modules/shared/table_info.py
+++ b/tools/bulk_executor/server/src/python_modules/shared/table_info.py
@@ -127,34 +127,48 @@ def get_and_print_dynamodb_table_info(table_name, index_name=None, quiet=False):
             ]
 
         if not quiet:
-            for dimension in scalable_dimensions:
-                scalable_target = autoscaling.describe_scalable_targets(
-                    ServiceNamespace='dynamodb',
-                    ResourceIds=[resource_id],
-                    ScalableDimension=dimension
-                )
-
-                if scalable_target['ScalableTargets']:
-                    target = scalable_target['ScalableTargets'][0]
-                    min_capacity = target['MinCapacity']
-                    max_capacity = target['MaxCapacity']
-                    log.info(f"- {dimension.split(':')[-1]}:")
-                    log.info(f"  Auto Scaling Enabled: Yes")
-                    log.info(f"  Min Capacity: {min_capacity:,}")
-                    log.info(f"  Max Capacity: {max_capacity:,}")
-
-                    # Get scaling policies
-                    policies = autoscaling.describe_scaling_policies(
+            # This is a best-effort DIAGNOSTIC print. The autoscaling lookup
+            # must never crash the job (issue #89): if the Glue role lacks
+            # application-autoscaling:DescribeScalableTargets, note that we
+            # couldn't read the settings and move on — the actual load/read
+            # proceeds and the capacity check in get_dynamodb_throughput_configs
+            # degrades separately. An unguarded call here previously took the
+            # whole job down at info-print time, before any data moved.
+            try:
+                for dimension in scalable_dimensions:
+                    scalable_target = autoscaling.describe_scalable_targets(
                         ServiceNamespace='dynamodb',
-                        ResourceId=resource_id,
+                        ResourceIds=[resource_id],
                         ScalableDimension=dimension
                     )
-                    for policy in policies['ScalingPolicies']:
-                        target_value = policy['TargetTrackingScalingPolicyConfiguration']['TargetValue']
-                        log.info(f"  Target Value: {target_value}")
-                else:
-                    log.info(f"- {dimension.split(':')[-1]}:")
-                    log.info(f"  Auto Scaling Enabled: No")
+
+                    if scalable_target['ScalableTargets']:
+                        target = scalable_target['ScalableTargets'][0]
+                        min_capacity = target['MinCapacity']
+                        max_capacity = target['MaxCapacity']
+                        log.info(f"- {dimension.split(':')[-1]}:")
+                        log.info(f"  Auto Scaling Enabled: Yes")
+                        log.info(f"  Min Capacity: {min_capacity:,}")
+                        log.info(f"  Max Capacity: {max_capacity:,}")
+
+                        # Get scaling policies
+                        policies = autoscaling.describe_scaling_policies(
+                            ServiceNamespace='dynamodb',
+                            ResourceId=resource_id,
+                            ScalableDimension=dimension
+                        )
+                        for policy in policies['ScalingPolicies']:
+                            target_value = policy['TargetTrackingScalingPolicyConfiguration']['TargetValue']
+                            log.info(f"  Target Value: {target_value}")
+                    else:
+                        log.info(f"- {dimension.split(':')[-1]}:")
+                        log.info(f"  Auto Scaling Enabled: No")
+            except Exception as e:
+                log.info(
+                    f"- Could not read autoscaling settings ({str(e)}); skipping "
+                    f"this diagnostic. Grant application-autoscaling:"
+                    f"DescribeScalableTargets to the Glue role to see them."
+                )
 
     else:
         if index_name:

--- a/tools/bulk_executor/server/src/python_modules/shared/table_info.py
+++ b/tools/bulk_executor/server/src/python_modules/shared/table_info.py
@@ -298,6 +298,127 @@ def get_and_print_table_copy_write_cost(source_info, target_info):
         return od_cost
     return 0
 
+def _bare_table_name(table_ref):
+    """Return the plain table name for a table ref that may be an ARN.
+
+    Autoscaling resource IDs need the bare name (`table/<name>`), whereas the
+    caller may hand us a full ARN (from which we also derive the region).
+    """
+    if table_ref and table_ref.startswith("arn:"):
+        try:
+            resource = _parse_arn(table_ref).get("resource", "")
+        except ValueError:
+            return table_ref
+        if resource.startswith("table/"):
+            # resource may carry a trailing /index/... or :stream:...; the
+            # table name is the first path segment after "table/".
+            return resource[len("table/"):].split("/")[0].split(":")[0]
+        return table_ref
+    return table_ref
+
+
+def _autoscaling_max_capacity(table_name, region_name, dimension):
+    """Return the autoscaling MaxCapacity for a provisioned table dimension.
+
+    `dimension` is 'read' or 'write'. Returns None when the table genuinely
+    has no autoscaling target on that dimension. Raises on API failure so the
+    caller can distinguish "no autoscaling" (safe to treat as hard-provisioned)
+    from "unknown" (must skip the capacity warning to avoid a false positive).
+    """
+    scalable_dimension = (
+        'dynamodb:table:ReadCapacityUnits' if dimension == 'read'
+        else 'dynamodb:table:WriteCapacityUnits'
+    )
+    autoscaling = boto3.client('application-autoscaling', region_name=region_name)
+    resource_id = f'table/{_bare_table_name(table_name)}'
+    response = autoscaling.describe_scalable_targets(
+        ServiceNamespace='dynamodb',
+        ResourceIds=[resource_id],
+        ScalableDimension=scalable_dimension,
+    )
+    targets = response.get('ScalableTargets', [])
+    if targets:
+        return int(targets[0]['MaxCapacity'])
+    return None
+
+
+def _effective_capacity_ceiling(table_desc, is_on_demand, region_name, table_name, dimension):
+    """Resolve the effective throughput ceiling for a user-requested rate.
+
+    Returns a (ceiling, source, soft_floor) tuple describing the most the
+    table can actually deliver on `dimension` ('read' or 'write'):
+
+    - Provisioned, no autoscaling  → (provisioned CU, "provisioned capacity", None)
+    - Provisioned with autoscaling → (autoscaling max, "autoscaling maximum", provisioned CU)
+    - On-demand with a table max    → (table max, "table's on-demand maximum", None)
+    - On-demand, no table max       → (account quota, "account quota", None)
+
+    `soft_floor` is the current provisioned level when autoscaling can climb
+    above it — a request between the floor and ceiling gets a gentler note
+    rather than a hard warning. `ceiling` is None when it can't be determined
+    (e.g. quota lookup failed), signalling the caller to skip the warning.
+    """
+    if is_on_demand:
+        on_demand_throughput = table_desc.get('OnDemandThroughput', {})
+        key = 'MaxReadRequestUnits' if dimension == 'read' else 'MaxWriteRequestUnits'
+        table_max = on_demand_throughput.get(key)
+        if isinstance(table_max, (int, float)) and table_max:
+            return int(table_max), "table's on-demand maximum", None
+        quota_name = (
+            "Table-level read throughput limit" if dimension == 'read'
+            else "Table-level write throughput limit"
+        )
+        quota = get_quota_value(quota_name, region_name)
+        if quota is not None:
+            return int(quota), "account quota", None
+        return None, None, None
+
+    key = 'ReadCapacityUnits' if dimension == 'read' else 'WriteCapacityUnits'
+    provisioned = table_desc.get('ProvisionedThroughput', {}).get(key)
+    if not (isinstance(provisioned, (int, float)) and provisioned):
+        return None, None, None
+    provisioned = int(provisioned)
+    try:
+        autoscaling_max = _autoscaling_max_capacity(table_name, region_name, dimension)
+    except Exception as e:
+        # Can't tell whether autoscaling would lift the ceiling; skip the
+        # warning rather than emit a false "exceeds provisioned" for a table
+        # that may well autoscale above the request.
+        log.info(f"[{table_name}] Warning: Could not retrieve autoscaling settings: {str(e)}")
+        return None, None, None
+    if autoscaling_max is not None:
+        return autoscaling_max, "autoscaling maximum", provisioned
+    return provisioned, "provisioned capacity", None
+
+
+def _warn_if_rate_exceeds_capacity(table_name, dimension, user_rate, table_desc,
+                                    is_on_demand, region_name):
+    """Warn when a user-specified rate exceeds what the table can deliver.
+
+    Implements issue #89 checks 2-5: a hard warning when the request is above
+    the effective ceiling (provisioned/autoscaling-max/on-demand-max/quota),
+    and a softer note when autoscaling can scale up from the current
+    provisioned level to meet the request.
+    """
+    ceiling, source, soft_floor = _effective_capacity_ceiling(
+        table_desc, is_on_demand, region_name, table_name, dimension
+    )
+    if ceiling is None:
+        return
+    user_rate = int(user_rate)
+    if user_rate > ceiling:
+        log.warning(
+            f"[{table_name}] Requested {dimension} rate {user_rate} exceeds the "
+            f"table's {source} of {ceiling}; the table cannot deliver this rate."
+        )
+    elif soft_floor is not None and user_rate > soft_floor:
+        log.warning(
+            f"[{table_name}] Requested {dimension} rate {user_rate} is above the "
+            f"current provisioned {dimension} capacity of {soft_floor}; autoscaling "
+            f"will need to scale up (toward its maximum of {ceiling}) to meet it."
+        )
+
+
 def get_dynamodb_throughput_configs(args, table_name, modes=None, format="connector"):
     region_name = _region_from_table_ref(table_name) or _default_region()
     if not region_name:
@@ -312,6 +433,12 @@ def get_dynamodb_throughput_configs(args, table_name, modes=None, format="connec
     # Get table description to determine if it's on-demand or provisioned
     read_rate = args.get('XMaxReadRate', None)   # User set read rate
     write_rate = args.get('XMaxWriteRate', None) # User set write rate
+
+    # Preserve the raw user-specified rates before the branches below may
+    # overwrite read_rate/write_rate with table-derived values; only these
+    # user requests can meaningfully exceed the table's capacity (#89).
+    user_read_rate = read_rate
+    user_write_rate = write_rate
 
     try:
         response = dynamodb.describe_table(TableName=table_name)
@@ -354,7 +481,13 @@ def get_dynamodb_throughput_configs(args, table_name, modes=None, format="connec
                 log.info(f"[{table_name}] Max read rate set internally by Glue (no provisioned level found)") # shouldn't happen
 
         if read_rate is not None and int(read_rate) < MIN_RECOMMENDED_READ_RATE:
-            log.warn(f"[{table_name}] Read rate {read_rate} less than recommended value of {MIN_RECOMMENDED_READ_RATE}.")
+            log.warning(f"[{table_name}] Read rate {read_rate} less than recommended value of {MIN_RECOMMENDED_READ_RATE}.")
+
+        if user_read_rate:
+            _warn_if_rate_exceeds_capacity(
+                table_name, "read", user_read_rate, table_desc,
+                is_on_demand_table, region_name,
+            )
 
     # Handle write throughput
     if "write" in modes:
@@ -387,7 +520,13 @@ def get_dynamodb_throughput_configs(args, table_name, modes=None, format="connec
                 log.info(f"[{table_name}] Max write rate set internally by Glue (no provisioned level found)")
 
         if write_rate is not None and int(write_rate) < MIN_RECOMMENDED_WRITE_RATE:
-            log.warn(f"[{table_name}] Write rate {write_rate} less than recommended value of {MIN_RECOMMENDED_WRITE_RATE}.")
+            log.warning(f"[{table_name}] Write rate {write_rate} less than recommended value of {MIN_RECOMMENDED_WRITE_RATE}.")
+
+        if user_write_rate:
+            _warn_if_rate_exceeds_capacity(
+                table_name, "write", user_write_rate, table_desc,
+                is_on_demand_table, region_name,
+            )
 
     if format == "connector":
         connection_options = {}

--- a/tools/bulk_executor/tests/client/test_bootstrap.py
+++ b/tools/bulk_executor/tests/client/test_bootstrap.py
@@ -224,13 +224,34 @@ class TestAddGlueJobRole:
         assert 'arn:aws:iam::aws:policy/AmazonDynamoDBReadOnlyAccess' in attached
         assert 'arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess' not in attached
 
-        # Inline policies for pricing + quotas
+        # Inline policies for pricing + quotas + autoscaling
         inline_names = [
             c.kwargs['PolicyName']
             for c in bootstrap.iam_client.put_role_policy.call_args_list
         ]
         assert 'MinimalPricingAccess' in inline_names
         assert 'MinimalQuotasAccess' in inline_names
+        assert 'MinimalAutoScalingAccess' in inline_names
+
+    def test_autoscaling_policy_grants_describe_scalable_targets(self, bootstrap):
+        from infrastructure.constants import ROLE_TYPE_READ_ONLY
+        bootstrap._prompt_for_role = MagicMock()
+        bootstrap.iam_client.create_role.return_value = {
+            'Role': {'Arn': 'arn:aws:iam::123456789012:role/test'}
+        }
+
+        bootstrap._add_glue_job_role({'XRole': ROLE_TYPE_READ_ONLY})
+
+        autoscaling_calls = [
+            c for c in bootstrap.iam_client.put_role_policy.call_args_list
+            if c.kwargs['PolicyName'] == 'MinimalAutoScalingAccess'
+        ]
+        assert len(autoscaling_calls) == 1
+        doc = json.loads(autoscaling_calls[0].kwargs['PolicyDocument'])
+        stmt = doc['Statement'][0]
+        assert stmt['Action'] == ['application-autoscaling:DescribeScalableTargets']
+        # DescribeScalableTargets does not support resource-level scoping.
+        assert stmt['Resource'] == '*'
 
     def test_creates_role_and_attaches_read_write_policies(self, bootstrap):
         from infrastructure.constants import ROLE_TYPE_READ_WRITE

--- a/tools/bulk_executor/tests/e2e/README.md
+++ b/tools/bulk_executor/tests/e2e/README.md
@@ -88,6 +88,7 @@ collapsing them:
 | `test_iam_policy_live.py` | policy | The documented policy *actually* bootstraps a real account (temp IAM user, real `bulk bootstrap`), **and the built-in role is created with the right shape** (not just exit 0 — see invariant #1). Random-negative rotation removes one action per run and asserts bootstrap fails. | Yes — bootstraps/tears-down the shared `bulk_dynamodb` job; guarded by `preserve_shared_glue_job`. |
 | `test_glue_role_shape.py` | role | The **real** `AWSGlueServiceRoleBulkDynamoDB-*` role exists *right now* with the fresh-bootstrap trust policy + required managed policies. Pure read. | No (read-only) |
 | `test_glue_role_refresh.py` | role | The version-mismatch **role-refresh logic** converges a stale trust policy to the fresh-bootstrap shape, against real IAM. | No — runs on a **throwaway** role it creates and deletes. |
+| `test_capacity_warning_missing_perm.py` | role | Issue #89: when the Glue role lacks `application-autoscaling:DescribeScalableTargets`, a live `load` emits the *visibility* warning and the job **still SUCCEEDS** (the paren-form `(AccessDeniedException)` must not trip the wrapper's colon-form early-terminate). | Yes — points the shared job at a **throwaway** role missing only the autoscaling policy, then restores the original role in its own `finally` (backstopped by `preserve_shared_glue_job`). Runs serially, never alongside write smokes. |
 
 **Why the split (the key tradeoff):** the refresh test uses a *throwaway* role
 so it has zero blast radius (safe under parallel runs and during a live Glue
@@ -104,6 +105,31 @@ The shared assertion `assert_builtin_role_shape(region, access)` lives in
 policies rather than importing them from `client/src` — so if bootstrap's own
 constants drift, the test still checks the contract we expect and the mismatch
 surfaces as a failure.
+
+### Capacity-warning coverage (`make test-e2e-capacity-warnings`)
+
+Issue #89 makes `load` warn when a requested `--XMaxReadRate`/`--XMaxWriteRate`
+exceeds what the table can actually deliver. The warning fires at
+**throughput-config setup** — before any data moves — so these tests use tiny
+(~20-row) fixtures and assert the exact warning substring in the **live Glue
+job's log stream** (LiveTail → `result.stdout`), after confirming
+`JobRunState == SUCCEEDED`. This is the E2E proof that the unit-tested warning
+logic actually surfaces on a real job.
+
+| Scenario | Table shape | Request | Expected live warning |
+|----------|-------------|---------|-----------------------|
+| provisioned, no autoscaling | PROVISIONED 5 WCU | 500 | hard: *exceeds the table's provisioned capacity* |
+| provisioned + autoscaling, above max | PROVISIONED + AS max 100 | 1000 | hard: *exceeds the table's autoscaling maximum* |
+| provisioned + autoscaling, within range | PROVISIONED 5 + AS max 100 | ~52 | soft: *autoscaling will need to scale up* (not the hard warn) |
+| on-demand table max | PAY_PER_REQUEST, MaxWriteRequestUnits 100 | 1000 | hard: *on-demand maximum* |
+| missing autoscaling permission | PROVISIONED, Glue role without `DescribeScalableTargets` | 500 | visibility: *the requested-rate capacity check is skipped* — job still SUCCEEDS |
+
+The first four live in `whole_system/test_capacity_warnings.py` (transient
+tables, own throughput shape). The missing-permission scenario lives in
+`security/test_capacity_warning_missing_perm.py` because it must repoint the
+shared job's execution role (see the security table above). The Makefile target
+runs both files serially in one process so the role-flip never overlaps the
+write-capable scenarios.
 
 ## Cleanup
 

--- a/tools/bulk_executor/tests/e2e/README.md
+++ b/tools/bulk_executor/tests/e2e/README.md
@@ -108,13 +108,13 @@ surfaces as a failure.
 
 ### Capacity-warning coverage (`make test-e2e-capacity-warnings`)
 
-Issue #89 makes `load` warn when a requested `--XMaxReadRate`/`--XMaxWriteRate`
-exceeds what the table can actually deliver. The warning fires at
-**throughput-config setup** — before any data moves — so these tests use tiny
-(~20-row) fixtures and assert the exact warning substring in the **live Glue
-job's log stream** (LiveTail → `result.stdout`), after confirming
-`JobRunState == SUCCEEDED`. This is the E2E proof that the unit-tested warning
-logic actually surfaces on a real job.
+Issue #89 makes bulk warn when a requested `--XMaxReadRate`/`--XMaxWriteRate`
+(or the effective table-derived rate) is too high or too low for the table. The
+warnings fire at **throughput-config setup** — before any data moves — so these
+tests use tiny fixtures (checks 2-5) or a read-only `count` (check 1) and assert
+the exact warning substring in the **live Glue job's log stream** (LiveTail),
+after confirming `JobRunState == SUCCEEDED`. This is the E2E proof that the
+unit-tested warning logic actually surfaces on a real job.
 
 | Scenario | Table shape | Request | Expected live warning |
 |----------|-------------|---------|-----------------------|
@@ -122,10 +122,17 @@ logic actually surfaces on a real job.
 | provisioned + autoscaling, above max | PROVISIONED + AS max 100 | 1000 | hard: *exceeds the table's autoscaling maximum* |
 | provisioned + autoscaling, within range | PROVISIONED 5 + AS max 100 | ~52 | soft: *autoscaling will need to scale up* (not the hard warn) |
 | on-demand table max | PAY_PER_REQUEST, MaxWriteRequestUnits 100 | 1000 | hard: *on-demand maximum* |
+| rate too slow for job timeout (check 1) | persistent `write_table` (millions of existing items), tiny `load` | `--XMaxWriteRate 100` | *the job will likely time out before finishing* — job still SUCCEEDS |
 | missing autoscaling permission | PROVISIONED, Glue role without `DescribeScalableTargets` | 500 | visibility: *the requested-rate capacity check is skipped* — job still SUCCEEDS |
 
-The first four live in `whole_system/test_capacity_warnings.py` (transient
-tables, own throughput shape). The missing-permission scenario lives in
+The first five live in `whole_system/test_capacity_warnings.py`. Scenarios 1-4
+use transient tables (own throughput shape); scenario 5 (check 1) loads a tiny
+CSV into the persistent `write_table`, because the timeout estimate keys off
+DescribeTable's `ItemCount` (which reads 0 for ~6h after a fresh fill — a
+transient table would false-green). Only ~20 rows are actually written, so the
+estimate warns on the target's millions of existing items while the job still
+finishes fast; it guards with an explicit item-count assertion and refuses to
+pass on a too-small table. The missing-permission scenario lives in
 `security/test_capacity_warning_missing_perm.py` because it must repoint the
 shared job's execution role (see the security table above). The Makefile target
 runs both files serially in one process so the role-flip never overlaps the

--- a/tools/bulk_executor/tests/e2e/helpers/command_runner.py
+++ b/tools/bulk_executor/tests/e2e/helpers/command_runner.py
@@ -41,6 +41,18 @@ class CommandResult:
     def succeeded(self) -> bool:
         return self.exit_code == 0
 
+    @property
+    def output(self) -> str:
+        """stdout + stderr combined.
+
+        Glue's LiveTail routes ``log.info`` to stdout but ``log.warning`` to
+        stderr, so a warning-substring assertion must look at both streams or it
+        will spuriously miss a warning that genuinely fired (observed with the
+        #89 autoscaling-degradation warnings). Assert on this, not ``stdout``,
+        whenever the thing under test is a warning/error log line.
+        """
+        return self.stdout + "\n" + self.stderr
+
 
 def run_command(
     command: str,

--- a/tools/bulk_executor/tests/e2e/helpers/transient_table.py
+++ b/tools/bulk_executor/tests/e2e/helpers/transient_table.py
@@ -109,8 +109,10 @@ def transient_table(
     warm_write_units: int | None = None,
     warm_read_units: int | None = None,
     wait_for_warm: bool = False,
+    provisioned: tuple[int, int] | None = None,
+    on_demand_max_write_units: int | None = None,
 ) -> Iterator[str]:
-    """Yield the name of a freshly-created PAY_PER_REQUEST DynamoDB table.
+    """Yield the name of a freshly-created transient DynamoDB table.
 
     label: short string included in the table name for debuggability ('fill', 'copy-src', etc).
     has_sort_key: if True, schema is pk(S)+sk(S); else just pk(S).
@@ -121,11 +123,24 @@ def transient_table(
         while the table exists — use only for throughput tests.
     wait_for_warm: if True (and warm_write_units set), block until the warm
         write throughput reaches the requested level (bounded, best-effort).
+    provisioned: (read_capacity, write_capacity) — when set, the table is
+        created BillingMode=PROVISIONED at those levels instead of
+        PAY_PER_REQUEST. Needed to exercise the #89 provisioned-capacity and
+        autoscaling capacity warnings, which only apply to provisioned tables.
+    on_demand_max_write_units: sets OnDemandThroughput.MaxWriteRequestUnits on
+        a PAY_PER_REQUEST table, giving it a table-level write ceiling. Needed
+        for the #89 "on-demand table maximum" warning. Mutually exclusive with
+        ``provisioned`` (on-demand max only applies to PAY_PER_REQUEST).
 
     Example:
         with transient_table(region, label="fill") as table:
             run_command("fill", table=table, extra_args=["--numitems", "100", "--generator", "default"])
     """
+    if provisioned is not None and on_demand_max_write_units is not None:
+        raise ValueError(
+            "provisioned and on_demand_max_write_units are mutually exclusive: "
+            "on-demand max applies only to PAY_PER_REQUEST tables."
+        )
     ddb = boto3.client("dynamodb", region_name=region)
     suffix = uuid.uuid4().hex[:8]
     table_name = f"bulk-e2e-{label}-{suffix}"
@@ -140,12 +155,24 @@ def transient_table(
         TableName=table_name,
         AttributeDefinitions=attrs,
         KeySchema=keys,
-        BillingMode="PAY_PER_REQUEST",
         Tags=[
             {"Key": "purpose", "Value": "bulk_executor e2e command test"},
             {"Key": "ephemeral", "Value": "true"},
         ],
     )
+    if provisioned is not None:
+        read_cap, write_cap = provisioned
+        create_kwargs["BillingMode"] = "PROVISIONED"
+        create_kwargs["ProvisionedThroughput"] = {
+            "ReadCapacityUnits": int(read_cap),
+            "WriteCapacityUnits": int(write_cap),
+        }
+    else:
+        create_kwargs["BillingMode"] = "PAY_PER_REQUEST"
+        if on_demand_max_write_units is not None:
+            create_kwargs["OnDemandThroughput"] = {
+                "MaxWriteRequestUnits": int(on_demand_max_write_units),
+            }
     if warm_write_units is not None or warm_read_units is not None:
         warm = {}
         if warm_read_units is not None:
@@ -167,3 +194,47 @@ def transient_table(
     finally:
         with contextlib.suppress(ClientError):
             ddb.delete_table(TableName=table_name)
+
+
+@contextlib.contextmanager
+def autoscaling_target(
+    region: str,
+    table_name: str,
+    *,
+    min_write: int,
+    max_write: int,
+) -> Iterator[int]:
+    """Register an application-autoscaling write target on a provisioned table.
+
+    Exercises the #89 autoscaling-aware capacity warnings, which consult
+    ``application-autoscaling:DescribeScalableTargets`` to learn the table's
+    autoscaling MaxCapacity. Registers a scalable target on the write
+    dimension with the given Min/Max and deregisters it in ``finally`` so a
+    failing test still tears the target down.
+
+    Yields ``max_write`` (the ceiling the connector should read back), so the
+    caller can pick a request above it (hard warn) or between the provisioned
+    floor and it (soft note).
+
+    The table must already be BillingMode=PROVISIONED (create it with
+    ``transient_table(..., provisioned=(r, w))``).
+    """
+    aas = boto3.client("application-autoscaling", region_name=region)
+    resource_id = f"table/{table_name}"
+    scalable_dimension = "dynamodb:table:WriteCapacityUnits"
+    try:
+        aas.register_scalable_target(
+            ServiceNamespace="dynamodb",
+            ResourceId=resource_id,
+            ScalableDimension=scalable_dimension,
+            MinCapacity=int(min_write),
+            MaxCapacity=int(max_write),
+        )
+        yield int(max_write)
+    finally:
+        with contextlib.suppress(ClientError):
+            aas.deregister_scalable_target(
+                ServiceNamespace="dynamodb",
+                ResourceId=resource_id,
+                ScalableDimension=scalable_dimension,
+            )

--- a/tools/bulk_executor/tests/e2e/security/test_capacity_warning_missing_perm.py
+++ b/tools/bulk_executor/tests/e2e/security/test_capacity_warning_missing_perm.py
@@ -1,0 +1,322 @@
+"""Tier 2 e2e for #89: the missing-autoscaling-permission degradation, live.
+
+PR #231's intent is graceful degradation: when the Glue job's role lacks
+``application-autoscaling:DescribeScalableTargets``, bulk must NOT crash — it
+skips the autoscaling-aware capacity check, logs a visibility warning naming the
+missing permission, and the operation proceeds to SUCCEEDED.
+
+There are TWO call sites that read autoscaling settings on a provisioned table,
+and #231 has to cover both or the "job proceeds" promise is false:
+
+1. ``_effective_capacity_ceiling`` — the capacity *warning* path. Already
+   caught the AccessDenied and logged the visibility warning.
+2. ``get_and_print_dynamodb_table_info`` — the Auto Scaling Settings *diagnostic
+   print* that runs earlier (``load/__init__.py`` calls it before the write).
+   This describe was UNGUARDED (pre-existing, commit 5a933d1), so a provisioned
+   ``load`` with the permission denied crashed here at info-print time, before
+   any data moved — verified live 2026-07-15 (jr_83361690...). The traceback
+   pointed at the ``except`` re-raise (load/__init__.py:117) because ``from
+   None`` masked the real origin; the true crash was the diagnostic describe.
+   Now guarded: on denial it logs "Could not read autoscaling settings ...
+   skipping this diagnostic" and continues.
+
+This test proves the full graceful-degradation path live: a provisioned ``load``
+whose role is explicitly denied the permission emits the visibility warning AND
+reaches SUCCEEDED (no crash at either call site).
+
+**Why this lives in security/ and not whole_system/:** to make a live job run
+without the autoscaling permission we must point the shared ``bulk_dynamodb``
+job at a role that lacks it — i.e. mutate the shared job's execution role. That
+is exactly what the security suite's autouse ``preserve_shared_glue_job`` guard
+(``job_state_guard.py``) snapshots and restores. Running this in a suite
+*without* that guard would silently strand the shared job on a crippled role.
+Per AGENTS.md invariant #3, role-mutating tests belong here and run isolated.
+
+**Isolation (invariant #6):** we build a THROWAWAY role (unique uuid suffix)
+that mirrors a real bootstrap role — trust policy, AWSGlueServiceRole,
+AmazonDynamoDBFullAccess, pricing, quotas — plus an explicit *Deny* on
+application-autoscaling:DescribeScalableTargets (a plain omission is
+insufficient — AmazonDynamoDBFullAccess itself grants the action, so only an
+explicit Deny actually removes it). We point the shared job at it for the
+duration of the test, then restore the job's original role (Job.Role, directly)
+in our own finally before deleting the throwaway role and its policies.
+
+Cost: one live Glue job (~2 min) + IAM. Runtime: ~3-4 min incl. propagation.
+"""
+from __future__ import annotations
+
+import csv
+import io
+import json
+import sys
+import time
+import uuid
+from pathlib import Path
+
+import boto3
+import pytest
+
+from tests.e2e.helpers.assertions import assert_glue_succeeded
+from tests.e2e.helpers.command_runner import run_command
+from tests.e2e.helpers.glue_bucket import discover_bucket
+from tests.e2e.helpers.perf import GLUE_JOB_NAME
+from tests.e2e.helpers.transient_table import transient_table
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "client" / "src"))
+
+NUM_ITEMS = 20
+PK_PREFIX = "sec-cap-noperm"
+# #231 graceful degradation: when the perm is denied, bulk names it and proceeds.
+# The capacity-warning path's visibility note:
+WARN_CAPACITY_SKIPPED = "the requested-rate capacity check is skipped"
+# The diagnostic-print path's skip note (the call site that previously crashed):
+WARN_DIAGNOSTIC_SKIPPED = "Could not read autoscaling settings"
+# Both notes name the missing permission so the user knows what to grant.
+MISSING_PERM = "DescribeScalableTargets"
+
+_TRUST_POLICY = {
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {"Service": "glue.amazonaws.com"},
+            "Action": "sts:AssumeRole",
+        }
+    ],
+}
+_PRICING_POLICY = {
+    "Version": "2012-10-17",
+    "Statement": [
+        {"Effect": "Allow", "Action": ["pricing:GetProducts"], "Resource": "*"}
+    ],
+}
+_QUOTAS_POLICY = {
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "servicequotas:GetServiceQuota",
+                "servicequotas:GetAWSDefaultServiceQuota",
+            ],
+            "Resource": "arn:aws:servicequotas:*:*:dynamodb/*",
+        }
+    ],
+}
+_MANAGED = [
+    "arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole",
+    "arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess",
+]
+# AmazonDynamoDBFullAccess ITSELF grants application-autoscaling:* — so simply
+# omitting the bootstrap's MinimalAutoScalingAccess inline policy does NOT
+# remove the permission (the first live run proved this: the job read
+# autoscaling settings fine and emitted the provisioned warning instead of the
+# visibility warning). An explicit Deny overrides any Allow regardless of which
+# policy granted it, which is the faithful way to model "this role cannot read
+# autoscaling targets."
+_DENY_AUTOSCALING_POLICY = {
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Deny",
+            "Action": ["application-autoscaling:DescribeScalableTargets"],
+            "Resource": "*",
+        }
+    ],
+}
+
+
+def _build_csv(run_id: str) -> str:
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(["pk", "sk", "payload"])
+    for i in range(NUM_ITEMS):
+        writer.writerow([f"{PK_PREFIX}-{run_id}", f"item-{i:04d}", f"data-{i}"])
+    return buf.getvalue()
+
+
+def _upload_fixture(run_id: str, region: str) -> str:
+    bucket = discover_bucket(region)
+    key = f"e2e/sec-cap-noperm/{run_id}.csv"
+    boto3.client("s3", region_name=region).put_object(
+        Bucket=bucket, Key=key, Body=_build_csv(run_id).encode("utf-8")
+    )
+    return f"s3://{bucket}/{key}"
+
+
+def _create_role_without_autoscaling(iam, role_name: str) -> str:
+    """Create a bootstrap-shaped role that CANNOT read autoscaling targets.
+
+    Mirrors BootstrapInfrastructure._add_glue_job_role (trust, managed policies,
+    pricing, quotas) but replaces the autoscaling *Allow* with an explicit
+    *Deny* on application-autoscaling:DescribeScalableTargets. A plain omission
+    is insufficient because AmazonDynamoDBFullAccess grants that action anyway;
+    the explicit Deny is what actually makes the job hit AccessDenied on the
+    autoscaling lookup. Returns the role ARN.
+    """
+    resp = iam.create_role(
+        RoleName=role_name,
+        AssumeRolePolicyDocument=json.dumps(_TRUST_POLICY),
+        Tags=[
+            # IAM tag values forbid '#' (pattern [\p{L}\p{Z}\p{N}_.:/=+\-@]*),
+            # so spell out "issue 89" rather than "#89".
+            {"Key": "purpose", "Value": "bulk_executor e2e issue 89 missing-perm test"},
+            {"Key": "ephemeral", "Value": "true"},
+        ],
+    )
+    for arn in _MANAGED:
+        iam.attach_role_policy(RoleName=role_name, PolicyArn=arn)
+    iam.put_role_policy(
+        RoleName=role_name, PolicyName="MinimalPricingAccess",
+        PolicyDocument=json.dumps(_PRICING_POLICY),
+    )
+    iam.put_role_policy(
+        RoleName=role_name, PolicyName="MinimalQuotasAccess",
+        PolicyDocument=json.dumps(_QUOTAS_POLICY),
+    )
+    # Explicit Deny on the autoscaling lookup — overrides the Allow that
+    # AmazonDynamoDBFullAccess carries. This is what makes the job hit
+    # AccessDenied and take the #89 visibility-warning degradation path.
+    iam.put_role_policy(
+        RoleName=role_name, PolicyName="DenyAutoScalingDescribe",
+        PolicyDocument=json.dumps(_DENY_AUTOSCALING_POLICY),
+    )
+    return resp["Role"]["Arn"]
+
+
+def _delete_role(iam, role_name: str) -> None:
+    try:
+        for p in iam.list_attached_role_policies(RoleName=role_name)["AttachedPolicies"]:
+            iam.detach_role_policy(RoleName=role_name, PolicyArn=p["PolicyArn"])
+        for name in iam.list_role_policies(RoleName=role_name)["PolicyNames"]:
+            iam.delete_role_policy(RoleName=role_name, PolicyName=name)
+        iam.delete_role(RoleName=role_name)
+    except iam.exceptions.NoSuchEntityException:
+        pass
+
+
+def _snapshot_job_role_arn(glue) -> str:
+    """Return the shared job's current execution-role ARN (Job.Role).
+
+    NOTE: this is deliberately NOT job_state_guard.snapshot_job_role — that one
+    reads the ``--glue-job-role-name`` DefaultArgument, which this test does not
+    change. We mutate ``Job.Role`` directly, so we must snapshot and restore
+    that exact field, or the restore is a silent no-op and the shared job is
+    left pointing at the throwaway role after we delete it (a real bug the first
+    live run hit). The autouse preserve_shared_glue_job guard is a backstop, but
+    it too keys off the argument, so this test owns its own Job.Role restore.
+    """
+    return glue.get_job(JobName=GLUE_JOB_NAME)["Job"]["Role"]
+
+
+def _point_shared_job_at_role(glue, role_arn: str) -> None:
+    """Repoint the shared bulk_dynamodb Glue job's execution role (Job.Role)."""
+    glue.update_job(
+        JobName=GLUE_JOB_NAME,
+        JobUpdate={"Role": role_arn} | _existing_job_update_fields(glue),
+    )
+
+
+def _existing_job_update_fields(glue) -> dict:
+    """Glue UpdateJob requires the full JobUpdate; copy the current command +
+    args so we change ONLY the role."""
+    job = glue.get_job(JobName=GLUE_JOB_NAME)["Job"]
+    fields = {"Command": job["Command"]}
+    for key in ("DefaultArguments", "GlueVersion", "WorkerType",
+                "NumberOfWorkers", "MaxRetries", "Timeout", "ExecutionProperty",
+                "Connections"):
+        if key in job:
+            fields[key] = job[key]
+    return fields
+
+
+@pytest.mark.e2e
+def test_missing_autoscaling_perm_degrades_gracefully_and_job_succeeds(e2e_config):
+    """A live load against a PROVISIONED table, run by a Glue role explicitly
+    denied application-autoscaling:DescribeScalableTargets, must degrade
+    gracefully per #231: bulk names the missing permission at BOTH autoscaling
+    call sites (the diagnostic Auto Scaling Settings print AND the capacity
+    check) and the job still reaches SUCCEEDED — no crash at either site."""
+    region = e2e_config.aws_region
+    iam = boto3.client("iam")
+    glue = boto3.client("glue", region_name=region)
+    run_id = f"{int(time.time())}-{uuid.uuid4().hex[:8]}"
+    role_name = f"AWSGlueServiceRole-bulk-e2e-noAS-{uuid.uuid4().hex[:8]}"
+
+    s3_path = _upload_fixture(run_id, region)
+
+    # Snapshot the shared job's ACTUAL execution-role ARN (Job.Role) so this
+    # test restores it in its OWN finally — before deleting the throwaway role.
+    # We must snapshot Job.Role directly, not the --glue-job-role-name argument
+    # (job_state_guard.snapshot_job_role): we mutate Job.Role, so an
+    # argument-based restore would be a no-op and leave the shared job pointing
+    # at the deleted throwaway role. Restore-then-delete closes that window.
+    original_job_role_arn = _snapshot_job_role_arn(glue)
+
+    try:
+        role_arn = _create_role_without_autoscaling(iam, role_name)
+        # IAM is eventually consistent; let the role settle before Glue assumes it.
+        for _ in range(15):
+            try:
+                iam.get_role(RoleName=role_name)
+                break
+            except iam.exceptions.NoSuchEntityException:
+                time.sleep(1)
+        time.sleep(10)  # propagation to STS/Glue assume-role
+
+        _point_shared_job_at_role(glue, role_arn)
+
+        # A provisioned table so the capacity path *tries* to read autoscaling
+        # (and gets denied) — on-demand wouldn't consult autoscaling at all.
+        with transient_table(
+            region, has_sort_key=True, label="cap-noperm", provisioned=(5, 5)
+        ) as table:
+            result = run_command(
+                "load",
+                table=table,
+                extra_args=[
+                    "--format", "csv",
+                    "--s3-path", s3_path,
+                    "--XMaxWriteRate", "500",
+                ],
+            )
+
+            # These are log.warning lines, which Glue LiveTail routes to stderr
+            # (not stdout), so assert on the combined stream — see
+            # CommandResult.output. Asserting on .stdout alone spuriously misses
+            # them even though they fired (observed 2026-07-15, jr_3ea58597...).
+            out = result.output
+
+            # ISC-8: the DIAGNOSTIC-print path degraded gracefully. This is the
+            # call site (get_and_print_dynamodb_table_info) that previously
+            # crashed the whole job at info-print time; it must now log the skip
+            # note naming the permission instead.
+            assert WARN_DIAGNOSTIC_SKIPPED in out, (
+                "expected the #89 diagnostic-print skip note "
+                f"({WARN_DIAGNOSTIC_SKIPPED!r}) in the live Glue output — the "
+                "Auto Scaling Settings print must degrade, not crash. "
+                f"output tail:\n{out[-2500:]}"
+            )
+            # ISC-8b: the CAPACITY-check path also degraded gracefully, naming
+            # the same missing permission.
+            assert WARN_CAPACITY_SKIPPED in out, (
+                "expected the #89 capacity-check skip note "
+                f"({WARN_CAPACITY_SKIPPED!r}) in the live Glue output; not found. "
+                f"output tail:\n{out[-2500:]}"
+            )
+            assert MISSING_PERM in out, (
+                f"expected the missing permission {MISSING_PERM!r} to be named in "
+                f"the live Glue output. output tail:\n{out[-2500:]}"
+            )
+            # ISC-10 + ISC-9: with both autoscaling call sites guarded, the job
+            # proceeds to SUCCEEDED — the #231 graceful-degradation promise held
+            # end-to-end. (An unguarded describe previously took it down FAILED.)
+            assert_glue_succeeded("load", result, region)
+    finally:
+        # Restore the shared job's Job.Role to the exact ARN we snapshotted,
+        # BEFORE deleting the throwaway, so the job is never left pointing at a
+        # deleted role. Direct Job.Role restore — see _snapshot_job_role_arn.
+        try:
+            _point_shared_job_at_role(glue, original_job_role_arn)
+        finally:
+            _delete_role(iam, role_name)

--- a/tools/bulk_executor/tests/e2e/whole_system/test_capacity_warnings.py
+++ b/tools/bulk_executor/tests/e2e/whole_system/test_capacity_warnings.py
@@ -15,12 +15,17 @@ table's topology, regardless of how many rows follow. Each scenario therefore
 loads only a handful of rows and asserts the specific warning substring in the
 live LiveTail stdout, after confirming the Glue job truly SUCCEEDED.
 
-The four scenarios here run against **transient tables** (own data + own
-throughput shape, torn down in finally), safe under parallel runs. The
-missing-permission degradation (#89 check when the Glue role lacks
-``application-autoscaling:DescribeScalableTargets``) needs to flip the *shared*
-job's role, so it lives in ``security/test_capacity_warning_missing_perm.py``
-under the security-suite guard — not here.
+Scenarios 1-4 (checks 2-5) run against **transient tables** (own data + own
+throughput shape, torn down in finally), safe under parallel runs. Scenario 5
+(check 1, the job-timeout estimate) loads a tiny CSV into the persistent,
+already-large ``write_table``: the write estimate keys off the target's existing
+ItemCount (which reads 0 for ~6h after a fresh fill, so a transient table would
+false-green) while only ~20 rows are actually written, so the warning fires yet
+the job finishes fast. The missing-permission degradation (#89 check when the
+Glue role lacks ``application-autoscaling:DescribeScalableTargets``) needs to
+flip the *shared* job's role, so it lives in
+``security/test_capacity_warning_missing_perm.py`` under the security-suite
+guard — not here.
 """
 from __future__ import annotations
 
@@ -52,6 +57,15 @@ WARN_PROVISIONED = "exceeds the table's provisioned capacity of"
 WARN_AUTOSCALING_MAX = "exceeds the table's autoscaling maximum of"
 WARN_SOFT_SCALE_UP = "autoscaling will need to scale up"
 WARN_ON_DEMAND_MAX = "on-demand maximum of"
+# Emitted by table_info._warn_if_job_may_timeout (issue #89 check 1).
+WARN_JOB_TIMEOUT = "the job will likely time out before finishing"
+
+# A deliberately low write rate: against the write_table's millions of existing
+# items the config-time estimate (item_count / rate) predicts a multi-hour run
+# and warns, while the actual load only writes the ~20-row CSV and finishes in
+# the usual ~2 min. That gap is what lets the warning fire on a job that still
+# SUCCEEDS — see test_slow_rate_predicted_timeout_warns_load.
+SLOW_WRITE_RATE = 100
 
 
 def _build_csv(run_id: str) -> str:
@@ -204,3 +218,66 @@ class TestCapacityWarningsLive:
                 dpu_seconds=perf.dpu_seconds if perf else None,
                 items=NUM_ITEMS,
             ))
+
+    def test_slow_rate_predicted_timeout_warns_load(
+        self, e2e_config, ws_perf_collector
+    ):
+        """Scenario 5 (issue #89 check 1) — a write rate too slow to move the
+        target table's data before the job timeout emits the 'will likely time
+        out' warning, and the job still SUCCEEDS.
+
+        The trick that decouples "warns" from "runs slow": the write estimate
+        keys off the *target table's existing size* (DescribeTable ItemCount),
+        but the actual load only writes the tiny input CSV. So we load ~20 rows
+        into the persistent, already-large write_table: the estimate sees
+        millions of items at a slow --XMaxWriteRate and predicts a multi-hour
+        run (warns), while only 20 rows are actually written and the job
+        finishes in the usual ~2 min. A read-based version can't decouple these
+        — throttling the rate to trip the estimate also throttles the real scan.
+
+        write_table (not a transient one) is required: the estimate reads
+        DescribeTable's ItemCount, which is 0 for ~6h after a fresh fill, so a
+        just-created transient table would false-green. write_table has real,
+        long-settled metadata. The 20-row append is a negligible, idempotent-ish
+        addition to an already-populated smoke table (same table the load smoke
+        writes to).
+        """
+        region = e2e_config.aws_region
+        table = e2e_config.write_table
+        run_id = f"{int(time.time())}-{uuid.uuid4().hex[:8]}"
+        s3_path = _upload_fixture(run_id, region)
+
+        # Vacuous-pass guard (invariant #1 / whole_system rule): confirm the
+        # target's real item count forces the write estimate past the 60-min
+        # default timeout at our slow rate BEFORE trusting a pass. The write
+        # estimate is item_count * ceil(avg_item_size/1024) units; for the small
+        # items here that is ~1 unit/item, so item_count is the floor on units.
+        desc = boto3.client("dynamodb", region_name=region).describe_table(
+            TableName=table
+        )["Table"]
+        item_count = int(desc.get("ItemCount", 0) or 0)
+        min_estimated_minutes = (item_count / SLOW_WRITE_RATE) / 60
+        assert min_estimated_minutes > 60, (
+            f"write_table {table!r} is too small to force the #89 timeout warning: "
+            f"~{item_count:,} items at {SLOW_WRITE_RATE} u/s is only "
+            f"~{min_estimated_minutes:,.1f} min, under the 60-min default timeout. "
+            f"This scenario needs a larger, settled write_table (DescribeTable "
+            f"ItemCount must be non-zero and sizeable) or it proves nothing — "
+            f"refusing to false-green."
+        )
+
+        result = _run_load(table, s3_path, write_rate=SLOW_WRITE_RATE)
+        perf = assert_glue_succeeded("load", result, region)
+        # log.warning → stderr on Glue LiveTail, so assert on combined output.
+        assert WARN_JOB_TIMEOUT in result.output, (
+            f"[slow-rate-timeout] expected #89 check-1 warning fragment "
+            f"{WARN_JOB_TIMEOUT!r} in the live Glue job output, not found. "
+            f"output tail:\n{result.output[-2500:]}"
+        )
+
+        ws_perf_collector.add(PerfRow(
+            command="load #89 slow-rate timeout warning",
+            wall_seconds=result.wall_seconds,
+            dpu_seconds=perf.dpu_seconds if perf else None,
+            items=NUM_ITEMS,
+        ))

--- a/tools/bulk_executor/tests/e2e/whole_system/test_capacity_warnings.py
+++ b/tools/bulk_executor/tests/e2e/whole_system/test_capacity_warnings.py
@@ -1,0 +1,206 @@
+"""Whole-system e2e for #89: `load --XMaxWriteRate` capacity warnings fire live.
+
+PR #231's source + unit tests prove the warning *logic* in isolation
+(``tests/server/test_rate_capacity_warnings.py``). This suite proves the
+warnings actually **surface on a real Glue job** against a real DynamoDB table
+of the right billing topology — the E2E-is-the-proof rule: a connector-path
+change is not "done" until it's watched succeed live.
+
+Unlike the #182 rate-*enforcement* test (``test_load_rate_roundtrip.py``, which
+needs a 60k fixture so the ceiling has time to bind), the #89 capacity
+*warnings* fire at throughput-config setup — *before* any data moves
+(``get_dynamodb_throughput_configs``). So a tiny fixture is enough: the warning
+is emitted the moment the connector resolves the requested rate against the
+table's topology, regardless of how many rows follow. Each scenario therefore
+loads only a handful of rows and asserts the specific warning substring in the
+live LiveTail stdout, after confirming the Glue job truly SUCCEEDED.
+
+The four scenarios here run against **transient tables** (own data + own
+throughput shape, torn down in finally), safe under parallel runs. The
+missing-permission degradation (#89 check when the Glue role lacks
+``application-autoscaling:DescribeScalableTargets``) needs to flip the *shared*
+job's role, so it lives in ``security/test_capacity_warning_missing_perm.py``
+under the security-suite guard — not here.
+"""
+from __future__ import annotations
+
+import csv
+import io
+import time
+import uuid
+
+import boto3
+import pytest
+
+from tests.e2e.connector.conftest import PerfRow
+from tests.e2e.helpers.assertions import assert_glue_succeeded
+from tests.e2e.helpers.command_runner import run_command
+from tests.e2e.helpers.glue_bucket import discover_bucket
+from tests.e2e.helpers.transient_table import autoscaling_target, transient_table
+
+# The warnings fire at config-time, so the fixture only needs enough rows to
+# make the load a real (SUCCEEDED) job. Keep it tiny — this is NOT an
+# enforcement test.
+NUM_ITEMS = 20
+PK_PREFIX = "ws-cap-warn"
+
+# Exact substrings emitted by table_info._warn_if_rate_exceeds_capacity /
+# _effective_capacity_ceiling. Assert on distinctive fragments (not whole
+# sentences) so trivial wording tweaks don't break the test, but the fragment
+# is specific enough that only the intended branch produces it.
+WARN_PROVISIONED = "exceeds the table's provisioned capacity of"
+WARN_AUTOSCALING_MAX = "exceeds the table's autoscaling maximum of"
+WARN_SOFT_SCALE_UP = "autoscaling will need to scale up"
+WARN_ON_DEMAND_MAX = "on-demand maximum of"
+
+
+def _build_csv(run_id: str) -> str:
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(["pk", "sk", "payload"])
+    for i in range(NUM_ITEMS):
+        writer.writerow([f"{PK_PREFIX}-{run_id}", f"item-{i:04d}", f"data-{i}"])
+    return buf.getvalue()
+
+
+def _upload_fixture(run_id: str, region: str) -> str:
+    bucket = discover_bucket(region)
+    key = f"e2e/ws-cap-warn/{run_id}.csv"
+    boto3.client("s3", region_name=region).put_object(
+        Bucket=bucket, Key=key, Body=_build_csv(run_id).encode("utf-8")
+    )
+    return f"s3://{bucket}/{key}"
+
+
+def _run_load(table: str, s3_path: str, write_rate: int):
+    return run_command(
+        "load",
+        table=table,
+        extra_args=[
+            "--format", "csv",
+            "--s3-path", s3_path,
+            "--XMaxWriteRate", str(write_rate),
+        ],
+    )
+
+
+def _assert_warning(result, substring: str, scenario: str) -> None:
+    assert substring in result.stdout, (
+        f"[{scenario}] expected #89 capacity warning fragment "
+        f"{substring!r} in the live Glue job stdout, not found. "
+        f"stdout tail:\n{result.stdout[-2500:]}"
+    )
+
+
+@pytest.mark.e2e
+class TestCapacityWarningsLive:
+    def test_provisioned_no_autoscaling_request_exceeds_warns(
+        self, e2e_config, ws_perf_collector
+    ):
+        """Scenario 1 — provisioned table, no autoscaling: a write rate above
+        the provisioned WCU produces the hard 'exceeds provisioned' warning."""
+        region = e2e_config.aws_region
+        run_id = f"{int(time.time())}-{uuid.uuid4().hex[:8]}"
+        s3_path = _upload_fixture(run_id, region)
+
+        # Provisioned at 5 WCU; request 500 → well above the ceiling.
+        with transient_table(
+            region, has_sort_key=True, label="cap-prov", provisioned=(5, 5)
+        ) as table:
+            result = _run_load(table, s3_path, write_rate=500)
+            perf = assert_glue_succeeded("load", result, region)
+            _assert_warning(result, WARN_PROVISIONED, "provisioned-no-AS")
+
+            ws_perf_collector.add(PerfRow(
+                command="load #89 provisioned-exceeds warning",
+                wall_seconds=result.wall_seconds,
+                dpu_seconds=perf.dpu_seconds if perf else None,
+                items=NUM_ITEMS,
+            ))
+
+    def test_provisioned_autoscaling_above_max_hard_warns(
+        self, e2e_config, ws_perf_collector
+    ):
+        """Scenario 2 — provisioned + autoscaling: a write rate above the
+        autoscaling MaxCapacity produces the hard 'exceeds autoscaling
+        maximum' warning (not the provisioned one)."""
+        region = e2e_config.aws_region
+        run_id = f"{int(time.time())}-{uuid.uuid4().hex[:8]}"
+        s3_path = _upload_fixture(run_id, region)
+
+        with transient_table(
+            region, has_sort_key=True, label="cap-asmax", provisioned=(5, 5)
+        ) as table:
+            # Autoscaling can climb to 100; request 1000 → above the max.
+            with autoscaling_target(
+                region, table, min_write=5, max_write=100
+            ) as as_max:
+                result = _run_load(table, s3_path, write_rate=as_max * 10)
+                perf = assert_glue_succeeded("load", result, region)
+                _assert_warning(result, WARN_AUTOSCALING_MAX, "provisioned+AS-above-max")
+
+                ws_perf_collector.add(PerfRow(
+                    command="load #89 autoscaling-max-exceeds warning",
+                    wall_seconds=result.wall_seconds,
+                    dpu_seconds=perf.dpu_seconds if perf else None,
+                    items=NUM_ITEMS,
+                ))
+
+    def test_provisioned_autoscaling_between_floor_and_max_soft_note(
+        self, e2e_config, ws_perf_collector
+    ):
+        """Scenario 3 — provisioned + autoscaling: a write rate between the
+        provisioned floor and the autoscaling max produces the SOFT
+        'autoscaling will need to scale up' note, distinct from a hard warn."""
+        region = e2e_config.aws_region
+        run_id = f"{int(time.time())}-{uuid.uuid4().hex[:8]}"
+        s3_path = _upload_fixture(run_id, region)
+
+        with transient_table(
+            region, has_sort_key=True, label="cap-soft", provisioned=(5, 5)
+        ) as table:
+            # Floor 5, max 100; request 50 → between floor and max → soft note.
+            with autoscaling_target(
+                region, table, min_write=5, max_write=100
+            ) as as_max:
+                request = (5 + as_max) // 2  # 52, comfortably between 5 and 100
+                result = _run_load(table, s3_path, write_rate=request)
+                perf = assert_glue_succeeded("load", result, region)
+                _assert_warning(result, WARN_SOFT_SCALE_UP, "provisioned+AS-soft-note")
+                # And it must NOT be the hard 'exceeds' warning.
+                assert WARN_AUTOSCALING_MAX not in result.stdout, (
+                    "soft-note scenario wrongly emitted the hard "
+                    "'exceeds autoscaling maximum' warning"
+                )
+
+                ws_perf_collector.add(PerfRow(
+                    command="load #89 autoscaling-soft-note",
+                    wall_seconds=result.wall_seconds,
+                    dpu_seconds=perf.dpu_seconds if perf else None,
+                    items=NUM_ITEMS,
+                ))
+
+    def test_on_demand_table_max_request_exceeds_warns(
+        self, e2e_config, ws_perf_collector
+    ):
+        """Scenario 4 — on-demand table with MaxWriteRequestUnits set: a write
+        rate above that table max produces the 'on-demand maximum' warning."""
+        region = e2e_config.aws_region
+        run_id = f"{int(time.time())}-{uuid.uuid4().hex[:8]}"
+        s3_path = _upload_fixture(run_id, region)
+
+        # On-demand with a table-level write ceiling of 100; request 1000.
+        with transient_table(
+            region, has_sort_key=True, label="cap-odmax",
+            on_demand_max_write_units=100,
+        ) as table:
+            result = _run_load(table, s3_path, write_rate=1000)
+            perf = assert_glue_succeeded("load", result, region)
+            _assert_warning(result, WARN_ON_DEMAND_MAX, "on-demand-table-max")
+
+            ws_perf_collector.add(PerfRow(
+                command="load #89 on-demand-max-exceeds warning",
+                wall_seconds=result.wall_seconds,
+                dpu_seconds=perf.dpu_seconds if perf else None,
+                items=NUM_ITEMS,
+            ))

--- a/tools/bulk_executor/tests/server/test_rate_capacity_warnings.py
+++ b/tools/bulk_executor/tests/server/test_rate_capacity_warnings.py
@@ -10,19 +10,27 @@ can actually deliver. Maps to Jason's review checks on PR #231:
 - Check #4: on-demand, request > table's OnDemandThroughput max -> hard warn
 - Check #5: on-demand, no table max, request > account quota -> hard warn
 - Check #1: effective rate too low to move the table's data before the job
-  timeout (default 60 min) -> "will likely time out" warn. The rate may be
-  user-specified or table-derived; the estimate uses the table metadata
-  already read here, so it lives in table_info alongside checks 2-5.
+  runs out of time -> "will likely time out" warn. The budget is the time
+  *remaining* before the job timeout (timeout minus elapsed since job start),
+  NOT the raw timeout: multi-phase verbs (e.g. delete = scan then write)
+  resolve a later phase's rate only after an earlier phase has already
+  consumed part of the timeout, so that phase must race the time left. The
+  rate may be user-specified or table-derived; the estimate uses the table
+  metadata already read here, so it lives in table_info alongside checks 2-5.
 
 Functions/branches exercised:
 - _bare_table_name: plain name, ARN, ARN+index, malformed ARN
 - _autoscaling_max_capacity: target present, absent, lookup raises
 - _effective_capacity_ceiling: all four billing-mode branches + None fallbacks
 - _warn_if_rate_exceeds_capacity: hard warn, soft note, at/under ceiling silent
-- _warn_if_job_may_timeout: read scan-units, write item-units, under/over
-  timeout, custom --XTimeout, zero/missing metadata, non-numeric rate.
+- _job_elapsed_minutes: zero at import, grows with the monotonic clock, clamped
+  non-negative.
+- _warn_if_job_may_timeout: read scan-units, write item-units, under/over the
+  remaining budget, small-remaining vs full-timeout, zero/negative remaining,
+  zero/missing metadata, non-numeric rate.
 - get_dynamodb_throughput_configs: read+write wiring, user-only rates,
-  graceful degradation, return value unchanged, timeout wiring.
+  graceful degradation, return value unchanged, and that the timeout check
+  uses time remaining (timeout minus elapsed) rather than the raw timeout.
 """
 
 import importlib.util
@@ -446,6 +454,31 @@ class TestOnDemandQuotaWarning:
 # --- Wiring guarantees ------------------------------------------------------
 
 
+# --- _job_elapsed_minutes ---------------------------------------------------
+
+
+class TestJobElapsedMinutes:
+    """Elapsed wall-clock since the Glue job started, from the monotonic clock
+    reference captured at module import. Drives 'time remaining' for check #1."""
+
+    def test_zero_at_start(self, monkeypatch):
+        monkeypatch.setattr(table_info, '_JOB_START_MONOTONIC', 1000.0)
+        monkeypatch.setattr(table_info.time, 'monotonic', lambda: 1000.0)
+        assert table_info._job_elapsed_minutes() == 0.0
+
+    def test_grows_with_the_clock(self, monkeypatch):
+        monkeypatch.setattr(table_info, '_JOB_START_MONOTONIC', 1000.0)
+        monkeypatch.setattr(table_info.time, 'monotonic', lambda: 1000.0 + 120.0)
+        assert table_info._job_elapsed_minutes() == pytest.approx(2.0)
+
+    def test_clamped_non_negative_if_clock_regresses(self, monkeypatch):
+        # A monotonic clock should not go backwards, but never report negative
+        # elapsed (which would inflate the remaining budget past the timeout).
+        monkeypatch.setattr(table_info, '_JOB_START_MONOTONIC', 1000.0)
+        monkeypatch.setattr(table_info.time, 'monotonic', lambda: 999.0)
+        assert table_info._job_elapsed_minutes() == 0.0
+
+
 # --- _warn_if_job_may_timeout (check #1) ------------------------------------
 
 
@@ -529,6 +562,38 @@ class TestWarnIfJobMayTimeout:
         records = [r for r in caplog.records if 'will likely time out' in r.getMessage()]
         assert records and all(r.levelno == logging.WARNING for r in records)
 
+    def test_last_arg_is_remaining_budget_not_raw_timeout(self, caplog):
+        # A read that comfortably fits a full 60-min timeout (~17 min at
+        # 1000 u/s for 1M units) must still warn when only 10 min remain,
+        # because the budget is the time LEFT, not the original timeout.
+        table_desc = {'TableSizeBytes': 8096 * 1_000_000, 'ItemCount': 1_000_000}
+        with caplog.at_level(logging.DEBUG):
+            table_info._warn_if_job_may_timeout('t', 'read', 1000, table_desc, 10)
+        assert _timeout_warnings(caplog)
+
+    def test_same_rate_no_warn_with_full_budget(self, caplog):
+        # Same rate/table as above but the full 60 min available -> fits, quiet.
+        table_desc = {'TableSizeBytes': 8096 * 1_000_000, 'ItemCount': 1_000_000}
+        with caplog.at_level(logging.DEBUG):
+            table_info._warn_if_job_may_timeout('t', 'read', 1000, table_desc, 60)
+        assert _timeout_warnings(caplog) == []
+
+    def test_zero_remaining_budget_warns_when_work_left(self, caplog):
+        # No time left but data still to move -> always a timeout warning.
+        table_desc = {'TableSizeBytes': 8096 * 1_000_000, 'ItemCount': 1_000_000}
+        with caplog.at_level(logging.DEBUG):
+            table_info._warn_if_job_may_timeout('t', 'read', 100_000, table_desc, 0)
+        assert _timeout_warnings(caplog)
+
+    def test_warning_names_remaining_time(self, caplog):
+        # The message must frame the budget as time remaining, not the timeout,
+        # so a reader mid-job understands why a "fast enough" rate is flagged.
+        table_desc = {'TableSizeBytes': 8096 * 1_000_000, 'ItemCount': 1_000_000}
+        with caplog.at_level(logging.DEBUG):
+            table_info._warn_if_job_may_timeout('t', 'read', 1000, table_desc, 10)
+        warns = _timeout_warnings(caplog)
+        assert warns and 'remaining' in warns[0].lower()
+
 
 # --- check #1 wiring inside get_dynamodb_throughput_configs -----------------
 
@@ -585,6 +650,47 @@ class TestTimeoutWiring:
                 args={}, table_name='t', modes=['read']
             )
         assert opts == {'dynamodb.throughput.read': '100'}
+
+    def _fast_enough_for_full_timeout(self):
+        # 1M read units at 2000 RCU = ~8.3 min; fits a 60-min job comfortably,
+        # so with a full budget this must NOT warn.
+        return {
+            'Table': {
+                'BillingModeSummary': {'BillingMode': 'PROVISIONED'},
+                'ProvisionedThroughput': {
+                    'ReadCapacityUnits': 2000,
+                    'WriteCapacityUnits': 2000,
+                },
+                'TableSizeBytes': 8096 * 1_000_000,
+                'ItemCount': 1_000_000,
+            }
+        }
+
+    def test_elapsed_time_shrinks_the_budget(self, boto3_mock, monkeypatch, caplog):
+        # THE #89 check-1 regression: a rate that fits the full 60-min timeout
+        # must warn once most of the timeout is already gone. This is the
+        # multi-phase delete case — the write rate is resolved only after the
+        # scan has burned ~55 min, leaving ~5 min for an ~8-min job.
+        boto3_mock.dynamodb_client.describe_table.return_value = self._fast_enough_for_full_timeout()
+        _no_autoscaling(boto3_mock)
+        monkeypatch.setattr(table_info, '_job_elapsed_minutes', lambda: 55.0)
+        with caplog.at_level(logging.DEBUG):
+            table_info.get_dynamodb_throughput_configs(
+                args={'XTimeout': 60}, table_name='t', modes=['read']
+            )
+        assert _timeout_warnings(caplog)
+
+    def test_no_warning_when_little_elapsed(self, boto3_mock, monkeypatch, caplog):
+        # Same rate/table/timeout, but early in the job: the full budget is
+        # available, the ~8-min job fits 60 min, so no warning.
+        boto3_mock.dynamodb_client.describe_table.return_value = self._fast_enough_for_full_timeout()
+        _no_autoscaling(boto3_mock)
+        monkeypatch.setattr(table_info, '_job_elapsed_minutes', lambda: 0.0)
+        with caplog.at_level(logging.DEBUG):
+            table_info.get_dynamodb_throughput_configs(
+                args={'XTimeout': 60}, table_name='t', modes=['read']
+            )
+        assert _timeout_warnings(caplog) == []
 
 
 class TestWiringGuarantees:

--- a/tools/bulk_executor/tests/server/test_rate_capacity_warnings.py
+++ b/tools/bulk_executor/tests/server/test_rate_capacity_warnings.py
@@ -1,0 +1,518 @@
+"""Unit tests for issue #89 capacity-vs-request warnings in table_info.
+
+Covers the helpers and the wiring inside get_dynamodb_throughput_configs that
+warn when a user-specified XMaxReadRate / XMaxWriteRate exceeds what the table
+can actually deliver. Maps to Jason's review checks on PR #231:
+
+- Check #2: provisioned, NO autoscaling, request > provisioned  -> hard warn
+- Check #3: provisioned, WITH autoscaling, request > autoscaling max -> hard warn
+- #89 nuance: provisioned < request <= autoscaling max -> softer "will scale up" note
+- Check #4: on-demand, request > table's OnDemandThroughput max -> hard warn
+- Check #5: on-demand, no table max, request > account quota -> hard warn
+
+Explicitly OUT OF SCOPE here (follow-up PR): check #1, the timeout /
+time-remaining warning, which needs runner/phase context, not table_info.
+
+Functions/branches exercised:
+- _bare_table_name: plain name, ARN, ARN+index, malformed ARN
+- _autoscaling_max_capacity: target present, absent, lookup raises
+- _effective_capacity_ceiling: all four billing-mode branches + None fallbacks
+- _warn_if_rate_exceeds_capacity: hard warn, soft note, at/under ceiling silent
+- get_dynamodb_throughput_configs: read+write wiring, user-only rates,
+  graceful degradation, return value unchanged.
+"""
+
+import importlib.util
+import logging
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import botocore.exceptions
+import pytest
+
+# Load the real table_info module (same pattern as test_table_info.py): the
+# repo conftest mocks python_modules.shared.table_info so verb modules import
+# cleanly, but here we want the real implementation loaded from disk.
+sys.modules.pop('python_modules.shared.table_info', None)
+sys.modules.pop('shared.table_info', None)
+
+_TABLE_INFO_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "server/src/python_modules/shared/table_info.py"
+)
+_spec = importlib.util.spec_from_file_location(
+    "python_modules.shared.table_info", str(_TABLE_INFO_PATH)
+)
+table_info = importlib.util.module_from_spec(_spec)
+sys.modules['python_modules.shared.table_info'] = table_info
+_spec.loader.exec_module(table_info)
+
+
+# --- Fixtures ---------------------------------------------------------------
+
+
+@pytest.fixture
+def boto3_mock(monkeypatch):
+    """Dispatching boto3 mock exposing per-service client mocks."""
+    mock = MagicMock()
+    mock.Session.return_value.region_name = 'us-east-1'
+
+    dynamodb_client = MagicMock()
+    service_quotas_client = MagicMock()
+    autoscaling_client = MagicMock()
+
+    def client_factory(name, **kwargs):
+        if name == 'dynamodb':
+            return dynamodb_client
+        if name == 'service-quotas':
+            return service_quotas_client
+        if name == 'application-autoscaling':
+            return autoscaling_client
+        return MagicMock()
+
+    mock.client.side_effect = client_factory
+    mock.dynamodb_client = dynamodb_client
+    mock.service_quotas_client = service_quotas_client
+    mock.autoscaling_client = autoscaling_client
+
+    monkeypatch.setattr(table_info, 'boto3', mock)
+    return mock
+
+
+def _no_autoscaling(boto3_mock):
+    """Configure the autoscaling client to report no scalable targets."""
+    boto3_mock.autoscaling_client.describe_scalable_targets.return_value = {
+        'ScalableTargets': []
+    }
+
+
+def _autoscaling_max(boto3_mock, max_capacity):
+    """Configure the autoscaling client to report a target with MaxCapacity."""
+    boto3_mock.autoscaling_client.describe_scalable_targets.return_value = {
+        'ScalableTargets': [{'MaxCapacity': max_capacity, 'MinCapacity': 5}]
+    }
+
+
+@pytest.fixture
+def provisioned_table():
+    return {
+        'Table': {
+            'BillingModeSummary': {'BillingMode': 'PROVISIONED'},
+            'ProvisionedThroughput': {
+                'ReadCapacityUnits': 1000,
+                'WriteCapacityUnits': 500,
+            },
+        }
+    }
+
+
+@pytest.fixture
+def ondemand_table_with_limits():
+    return {
+        'Table': {
+            'BillingModeSummary': {'BillingMode': 'PAY_PER_REQUEST'},
+            'OnDemandThroughput': {
+                'MaxReadRequestUnits': 25000,
+                'MaxWriteRequestUnits': 15000,
+            },
+        }
+    }
+
+
+@pytest.fixture
+def ondemand_table_no_limits():
+    return {
+        'Table': {
+            'BillingModeSummary': {'BillingMode': 'PAY_PER_REQUEST'},
+        }
+    }
+
+
+def _capacity_warnings(caplog):
+    """Return log messages that are the #89 capacity warnings (hard or soft)."""
+    return [
+        m for m in caplog.messages
+        if 'exceeds the table' in m or 'autoscaling will need to scale up' in m.lower()
+    ]
+
+
+# --- _bare_table_name -------------------------------------------------------
+
+
+class TestBareTableName:
+    def test_plain_name_returned_unchanged(self):
+        assert table_info._bare_table_name('my-table') == 'my-table'
+
+    def test_arn_yields_table_name(self):
+        arn = 'arn:aws:dynamodb:us-east-1:123456789012:table/my-table'
+        assert table_info._bare_table_name(arn) == 'my-table'
+
+    def test_arn_with_index_yields_table_name(self):
+        arn = 'arn:aws:dynamodb:us-east-1:123456789012:table/my-table/index/gsi1'
+        assert table_info._bare_table_name(arn) == 'my-table'
+
+    def test_arn_with_stream_suffix_yields_table_name(self):
+        arn = 'arn:aws:dynamodb:us-east-1:1:table/my-table:stream:2024-01-01'
+        assert table_info._bare_table_name(arn) == 'my-table'
+
+    def test_non_table_arn_returned_unchanged(self):
+        arn = 'arn:aws:dynamodb:us-east-1:1:backup/foo'
+        assert table_info._bare_table_name(arn) == arn
+
+    def test_malformed_arn_returned_unchanged(self):
+        # startswith arn: but _parse_arn raises -> return as-is
+        assert table_info._bare_table_name('arn:broken') == 'arn:broken'
+
+    def test_none_returned_unchanged(self):
+        assert table_info._bare_table_name(None) is None
+
+
+# --- _autoscaling_max_capacity ----------------------------------------------
+
+
+class TestAutoscalingMaxCapacity:
+    def test_returns_max_when_target_present(self, boto3_mock):
+        _autoscaling_max(boto3_mock, 8000)
+        assert (
+            table_info._autoscaling_max_capacity('t', 'us-east-1', 'read') == 8000
+        )
+
+    def test_returns_none_when_no_target(self, boto3_mock):
+        _no_autoscaling(boto3_mock)
+        assert (
+            table_info._autoscaling_max_capacity('t', 'us-east-1', 'write') is None
+        )
+
+    def test_write_dimension_uses_write_scalable_dimension(self, boto3_mock):
+        _autoscaling_max(boto3_mock, 3000)
+        table_info._autoscaling_max_capacity('t', 'us-east-1', 'write')
+        _, kwargs = boto3_mock.autoscaling_client.describe_scalable_targets.call_args
+        assert kwargs['ScalableDimension'] == 'dynamodb:table:WriteCapacityUnits'
+
+    def test_read_dimension_uses_read_scalable_dimension(self, boto3_mock):
+        _autoscaling_max(boto3_mock, 3000)
+        table_info._autoscaling_max_capacity('t', 'us-east-1', 'read')
+        _, kwargs = boto3_mock.autoscaling_client.describe_scalable_targets.call_args
+        assert kwargs['ScalableDimension'] == 'dynamodb:table:ReadCapacityUnits'
+
+    def test_lookup_failure_raises(self, boto3_mock):
+        # The helper raises on API failure; the ceiling resolver catches it and
+        # skips the warning (distinguishing "no autoscaling" from "unknown").
+        boto3_mock.autoscaling_client.describe_scalable_targets.side_effect = (
+            RuntimeError('boom')
+        )
+        with pytest.raises(RuntimeError):
+            table_info._autoscaling_max_capacity('t', 'us-east-1', 'read')
+
+    def test_arn_table_name_stripped_for_resource_id(self, boto3_mock):
+        _autoscaling_max(boto3_mock, 8000)
+        arn = 'arn:aws:dynamodb:us-east-1:1:table/my-table'
+        table_info._autoscaling_max_capacity(arn, 'us-east-1', 'read')
+        _, kwargs = boto3_mock.autoscaling_client.describe_scalable_targets.call_args
+        assert kwargs['ResourceIds'] == ['table/my-table']
+
+
+# --- _effective_capacity_ceiling --------------------------------------------
+
+
+class TestEffectiveCapacityCeiling:
+    def test_provisioned_no_autoscaling(self, boto3_mock, provisioned_table):
+        _no_autoscaling(boto3_mock)
+        ceiling, source, floor = table_info._effective_capacity_ceiling(
+            provisioned_table['Table'], False, 'us-east-1', 't', 'read'
+        )
+        assert (ceiling, floor) == (1000, None)
+        assert 'provisioned' in source
+
+    def test_provisioned_with_autoscaling(self, boto3_mock, provisioned_table):
+        _autoscaling_max(boto3_mock, 9000)
+        ceiling, source, floor = table_info._effective_capacity_ceiling(
+            provisioned_table['Table'], False, 'us-east-1', 't', 'read'
+        )
+        assert (ceiling, floor) == (9000, 1000)
+        assert 'autoscaling' in source
+
+    def test_ondemand_table_max(self, boto3_mock, ondemand_table_with_limits):
+        ceiling, source, floor = table_info._effective_capacity_ceiling(
+            ondemand_table_with_limits['Table'], True, 'us-east-1', 't', 'write'
+        )
+        assert (ceiling, floor) == (15000, None)
+        assert 'on-demand' in source
+
+    def test_ondemand_falls_back_to_quota(self, boto3_mock, ondemand_table_no_limits):
+        boto3_mock.service_quotas_client.get_service_quota.return_value = {
+            'Quota': {'Value': 40000}
+        }
+        ceiling, source, floor = table_info._effective_capacity_ceiling(
+            ondemand_table_no_limits['Table'], True, 'us-east-1', 't', 'read'
+        )
+        assert (ceiling, floor) == (40000, None)
+        assert 'quota' in source
+
+    def test_ondemand_no_max_no_quota_returns_none(self, boto3_mock, ondemand_table_no_limits):
+        boto3_mock.service_quotas_client.get_service_quota.side_effect = (
+            RuntimeError('unavailable')
+        )
+        boto3_mock.service_quotas_client.get_aws_default_service_quota.side_effect = (
+            RuntimeError('unavailable')
+        )
+        ceiling, source, floor = table_info._effective_capacity_ceiling(
+            ondemand_table_no_limits['Table'], True, 'us-east-1', 't', 'read'
+        )
+        assert ceiling is None
+
+    def test_provisioned_missing_capacity_returns_none(self, boto3_mock):
+        ceiling, source, floor = table_info._effective_capacity_ceiling(
+            {}, False, 'us-east-1', 't', 'read'
+        )
+        assert ceiling is None
+
+    def test_ondemand_max_of_zero_falls_back_to_quota(self, boto3_mock):
+        # DynamoDB uses 0 / absent to mean "no table-level cap set", not a
+        # literal zero ceiling — must fall through to the account quota.
+        boto3_mock.service_quotas_client.get_service_quota.return_value = {
+            'Quota': {'Value': 40000}
+        }
+        table_desc = {
+            'BillingModeSummary': {'BillingMode': 'PAY_PER_REQUEST'},
+            'OnDemandThroughput': {'MaxReadRequestUnits': 0},
+        }
+        ceiling, source, floor = table_info._effective_capacity_ceiling(
+            table_desc, True, 'us-east-1', 't', 'read'
+        )
+        assert (ceiling, source) == (40000, "account quota")
+
+
+# --- Check #2: provisioned, no autoscaling ----------------------------------
+
+
+class TestProvisionedNoAutoscalingWarning:
+    def test_read_request_above_provisioned_warns(
+        self, boto3_mock, provisioned_table, caplog
+    ):
+        boto3_mock.dynamodb_client.describe_table.return_value = provisioned_table
+        _no_autoscaling(boto3_mock)
+        with caplog.at_level(logging.DEBUG):
+            table_info.get_dynamodb_throughput_configs(
+                args={'XMaxReadRate': '5000'}, table_name='t', modes=['read']
+            )
+        warnings = _capacity_warnings(caplog)
+        assert any(
+            'exceeds' in m and '1000' in m and 'read' in m for m in warnings
+        ), warnings
+
+    def test_write_request_above_provisioned_warns(
+        self, boto3_mock, provisioned_table, caplog
+    ):
+        boto3_mock.dynamodb_client.describe_table.return_value = provisioned_table
+        _no_autoscaling(boto3_mock)
+        with caplog.at_level(logging.DEBUG):
+            table_info.get_dynamodb_throughput_configs(
+                args={'XMaxWriteRate': '5000'}, table_name='t', modes=['write']
+            )
+        assert any(
+            'exceeds' in m and '500' in m and 'write' in m
+            for m in _capacity_warnings(caplog)
+        )
+
+    def test_request_at_provisioned_no_warning(
+        self, boto3_mock, provisioned_table, caplog
+    ):
+        boto3_mock.dynamodb_client.describe_table.return_value = provisioned_table
+        _no_autoscaling(boto3_mock)
+        with caplog.at_level(logging.DEBUG):
+            table_info.get_dynamodb_throughput_configs(
+                args={'XMaxReadRate': '1000'}, table_name='t', modes=['read']
+            )
+        assert _capacity_warnings(caplog) == []
+
+
+# --- Check #3 + #89 nuance: provisioned with autoscaling --------------------
+
+
+class TestProvisionedAutoscalingWarning:
+    def test_request_above_autoscaling_max_hard_warns(
+        self, boto3_mock, provisioned_table, caplog
+    ):
+        boto3_mock.dynamodb_client.describe_table.return_value = provisioned_table
+        _autoscaling_max(boto3_mock, 4000)
+        with caplog.at_level(logging.DEBUG):
+            table_info.get_dynamodb_throughput_configs(
+                args={'XMaxReadRate': '9000'}, table_name='t', modes=['read']
+            )
+        assert any(
+            'exceeds' in m and 'autoscaling maximum' in m and '4000' in m
+            for m in _capacity_warnings(caplog)
+        )
+
+    def test_request_between_floor_and_max_soft_note(
+        self, boto3_mock, provisioned_table, caplog
+    ):
+        # provisioned read = 1000, autoscaling max = 8000; request 4000 is
+        # above the floor but reachable via scaling -> softer note, not "exceeds".
+        boto3_mock.dynamodb_client.describe_table.return_value = provisioned_table
+        _autoscaling_max(boto3_mock, 8000)
+        with caplog.at_level(logging.DEBUG):
+            table_info.get_dynamodb_throughput_configs(
+                args={'XMaxReadRate': '4000'}, table_name='t', modes=['read']
+            )
+        warnings = _capacity_warnings(caplog)
+        assert any('scale up' in m.lower() for m in warnings), warnings
+        assert not any('exceeds' in m for m in warnings), warnings
+
+    def test_request_at_or_below_floor_no_warning(
+        self, boto3_mock, provisioned_table, caplog
+    ):
+        boto3_mock.dynamodb_client.describe_table.return_value = provisioned_table
+        _autoscaling_max(boto3_mock, 8000)
+        with caplog.at_level(logging.DEBUG):
+            table_info.get_dynamodb_throughput_configs(
+                args={'XMaxReadRate': '900'}, table_name='t', modes=['read']
+            )
+        assert _capacity_warnings(caplog) == []
+
+
+# --- Check #4: on-demand with table max -------------------------------------
+
+
+class TestOnDemandTableMaxWarning:
+    def test_read_request_above_table_max_warns(
+        self, boto3_mock, ondemand_table_with_limits, caplog
+    ):
+        boto3_mock.dynamodb_client.describe_table.return_value = ondemand_table_with_limits
+        with caplog.at_level(logging.DEBUG):
+            table_info.get_dynamodb_throughput_configs(
+                args={'XMaxReadRate': '30000'}, table_name='t', modes=['read']
+            )
+        assert any(
+            'exceeds' in m and '25000' in m and 'on-demand' in m
+            for m in _capacity_warnings(caplog)
+        )
+
+    def test_request_at_table_max_no_warning(
+        self, boto3_mock, ondemand_table_with_limits, caplog
+    ):
+        boto3_mock.dynamodb_client.describe_table.return_value = ondemand_table_with_limits
+        with caplog.at_level(logging.DEBUG):
+            table_info.get_dynamodb_throughput_configs(
+                args={'XMaxReadRate': '25000'}, table_name='t', modes=['read']
+            )
+        assert _capacity_warnings(caplog) == []
+
+
+# --- Check #5: on-demand, no table max, account quota -----------------------
+
+
+class TestOnDemandQuotaWarning:
+    def test_request_above_account_quota_warns(
+        self, boto3_mock, ondemand_table_no_limits, caplog
+    ):
+        boto3_mock.dynamodb_client.describe_table.return_value = ondemand_table_no_limits
+        boto3_mock.service_quotas_client.get_service_quota.return_value = {
+            'Quota': {'Value': 40000}
+        }
+        with caplog.at_level(logging.DEBUG):
+            table_info.get_dynamodb_throughput_configs(
+                args={'XMaxReadRate': '50000'}, table_name='t', modes=['read']
+            )
+        assert any(
+            'exceeds' in m and '40000' in m and 'quota' in m
+            for m in _capacity_warnings(caplog)
+        )
+
+    def test_request_below_quota_no_warning(
+        self, boto3_mock, ondemand_table_no_limits, caplog
+    ):
+        boto3_mock.dynamodb_client.describe_table.return_value = ondemand_table_no_limits
+        boto3_mock.service_quotas_client.get_service_quota.return_value = {
+            'Quota': {'Value': 40000}
+        }
+        with caplog.at_level(logging.DEBUG):
+            table_info.get_dynamodb_throughput_configs(
+                args={'XMaxReadRate': '30000'}, table_name='t', modes=['read']
+            )
+        assert _capacity_warnings(caplog) == []
+
+
+# --- Wiring guarantees ------------------------------------------------------
+
+
+class TestWiringGuarantees:
+    def test_no_warning_when_rate_table_derived(
+        self, boto3_mock, provisioned_table, caplog
+    ):
+        # No XMax* supplied: read_rate is derived from provisioned capacity and
+        # by definition cannot exceed it -> no capacity warning.
+        boto3_mock.dynamodb_client.describe_table.return_value = provisioned_table
+        _no_autoscaling(boto3_mock)
+        with caplog.at_level(logging.DEBUG):
+            table_info.get_dynamodb_throughput_configs(
+                args={}, table_name='t', modes=['read']
+            )
+        assert _capacity_warnings(caplog) == []
+
+    def test_both_dimensions_warn_independently(
+        self, boto3_mock, provisioned_table, caplog
+    ):
+        boto3_mock.dynamodb_client.describe_table.return_value = provisioned_table
+        _no_autoscaling(boto3_mock)
+        with caplog.at_level(logging.DEBUG):
+            table_info.get_dynamodb_throughput_configs(
+                args={'XMaxReadRate': '9000', 'XMaxWriteRate': '9000'},
+                table_name='t', modes=['read', 'write'],
+            )
+        warnings = _capacity_warnings(caplog)
+        assert any('read' in m and '1000' in m for m in warnings)
+        assert any('write' in m and '500' in m for m in warnings)
+
+    def test_autoscaling_lookup_failure_skips_warning(
+        self, boto3_mock, provisioned_table, caplog
+    ):
+        # If autoscaling lookup raises we can't tell whether the table could
+        # scale to meet the request, so we skip the warning entirely rather
+        # than emit a false "exceeds provisioned" — and never crash the job.
+        boto3_mock.dynamodb_client.describe_table.return_value = provisioned_table
+        boto3_mock.autoscaling_client.describe_scalable_targets.side_effect = (
+            RuntimeError('boom')
+        )
+        with caplog.at_level(logging.DEBUG):
+            opts = table_info.get_dynamodb_throughput_configs(
+                args={'XMaxReadRate': '5000'}, table_name='t', modes=['read']
+            )
+        assert opts == {'dynamodb.throughput.read': '5000'}
+        assert _capacity_warnings(caplog) == []
+
+    def test_return_value_unchanged_by_warning_logic(
+        self, boto3_mock, provisioned_table, caplog
+    ):
+        # The connector options must be exactly the user rate regardless of the
+        # capacity warning firing (warnings are observational only).
+        boto3_mock.dynamodb_client.describe_table.return_value = provisioned_table
+        _no_autoscaling(boto3_mock)
+        with caplog.at_level(logging.DEBUG):
+            opts = table_info.get_dynamodb_throughput_configs(
+                args={'XMaxReadRate': '9000', 'XMaxWriteRate': '9000'},
+                table_name='t', modes=['read', 'write'],
+            )
+        assert opts == {
+            'dynamodb.throughput.read': '9000',
+            'dynamodb.throughput.write': '9000',
+        }
+
+    def test_uses_log_warning_not_deprecated_warn(
+        self, boto3_mock, provisioned_table, monkeypatch, caplog
+    ):
+        # log.warn is deprecated; ensure the capacity warning path calls
+        # log.warning. We assert the record level is WARNING.
+        boto3_mock.dynamodb_client.describe_table.return_value = provisioned_table
+        _no_autoscaling(boto3_mock)
+        with caplog.at_level(logging.DEBUG):
+            table_info.get_dynamodb_throughput_configs(
+                args={'XMaxReadRate': '5000'}, table_name='t', modes=['read']
+            )
+        capacity_records = [
+            r for r in caplog.records if 'exceeds the table' in r.getMessage()
+        ]
+        assert capacity_records
+        assert all(r.levelno == logging.WARNING for r in capacity_records)

--- a/tools/bulk_executor/tests/server/test_rate_capacity_warnings.py
+++ b/tools/bulk_executor/tests/server/test_rate_capacity_warnings.py
@@ -470,7 +470,7 @@ class TestWiringGuarantees:
         self, boto3_mock, provisioned_table, caplog
     ):
         # If autoscaling lookup raises we can't tell whether the table could
-        # scale to meet the request, so we skip the warning entirely rather
+        # scale to meet the request, so we skip the capacity warning rather
         # than emit a false "exceeds provisioned" — and never crash the job.
         boto3_mock.dynamodb_client.describe_table.return_value = provisioned_table
         boto3_mock.autoscaling_client.describe_scalable_targets.side_effect = (
@@ -482,6 +482,28 @@ class TestWiringGuarantees:
             )
         assert opts == {'dynamodb.throughput.read': '5000'}
         assert _capacity_warnings(caplog) == []
+
+    def test_autoscaling_lookup_failure_warns_visibility_lost(
+        self, boto3_mock, provisioned_table, caplog
+    ):
+        # Jason's option (b): when the role can't read autoscaling targets we
+        # proceed, but must surface that we're doing so without visibility into
+        # the table's metrics (and point at the missing permission).
+        boto3_mock.dynamodb_client.describe_table.return_value = provisioned_table
+        boto3_mock.autoscaling_client.describe_scalable_targets.side_effect = (
+            RuntimeError('AccessDeniedException')
+        )
+        with caplog.at_level(logging.DEBUG):
+            table_info.get_dynamodb_throughput_configs(
+                args={'XMaxReadRate': '5000'}, table_name='t', modes=['read']
+            )
+        visibility = [
+            r for r in caplog.records
+            if r.levelno == logging.WARNING
+            and 'without knowledge of the table' in r.message
+            and 'DescribeScalableTargets' in r.message
+        ]
+        assert visibility, [r.message for r in caplog.records]
 
     def test_return_value_unchanged_by_warning_logic(
         self, boto3_mock, provisioned_table, caplog

--- a/tools/bulk_executor/tests/server/test_rate_capacity_warnings.py
+++ b/tools/bulk_executor/tests/server/test_rate_capacity_warnings.py
@@ -9,17 +9,20 @@ can actually deliver. Maps to Jason's review checks on PR #231:
 - #89 nuance: provisioned < request <= autoscaling max -> softer "will scale up" note
 - Check #4: on-demand, request > table's OnDemandThroughput max -> hard warn
 - Check #5: on-demand, no table max, request > account quota -> hard warn
-
-Explicitly OUT OF SCOPE here (follow-up PR): check #1, the timeout /
-time-remaining warning, which needs runner/phase context, not table_info.
+- Check #1: effective rate too low to move the table's data before the job
+  timeout (default 60 min) -> "will likely time out" warn. The rate may be
+  user-specified or table-derived; the estimate uses the table metadata
+  already read here, so it lives in table_info alongside checks 2-5.
 
 Functions/branches exercised:
 - _bare_table_name: plain name, ARN, ARN+index, malformed ARN
 - _autoscaling_max_capacity: target present, absent, lookup raises
 - _effective_capacity_ceiling: all four billing-mode branches + None fallbacks
 - _warn_if_rate_exceeds_capacity: hard warn, soft note, at/under ceiling silent
+- _warn_if_job_may_timeout: read scan-units, write item-units, under/over
+  timeout, custom --XTimeout, zero/missing metadata, non-numeric rate.
 - get_dynamodb_throughput_configs: read+write wiring, user-only rates,
-  graceful degradation, return value unchanged.
+  graceful degradation, return value unchanged, timeout wiring.
 """
 
 import importlib.util
@@ -135,6 +138,11 @@ def _capacity_warnings(caplog):
         m for m in caplog.messages
         if 'exceeds the table' in m or 'autoscaling will need to scale up' in m.lower()
     ]
+
+
+def _timeout_warnings(caplog):
+    """Return log messages that are the #89 check-1 job-timeout warnings."""
+    return [m for m in caplog.messages if 'will likely time out' in m]
 
 
 # --- _bare_table_name -------------------------------------------------------
@@ -436,6 +444,147 @@ class TestOnDemandQuotaWarning:
 
 
 # --- Wiring guarantees ------------------------------------------------------
+
+
+# --- _warn_if_job_may_timeout (check #1) ------------------------------------
+
+
+class TestWarnIfJobMayTimeout:
+    def test_read_slow_rate_warns(self, caplog):
+        # 1,000,000 read units (8096 * 1e6 bytes) at 100 u/s = ~166 min > 60 min.
+        table_desc = {'TableSizeBytes': 8096 * 1_000_000, 'ItemCount': 1_000_000}
+        with caplog.at_level(logging.DEBUG):
+            table_info._warn_if_job_may_timeout('t', 'read', 100, table_desc, 60)
+        warns = _timeout_warnings(caplog)
+        assert warns and 'read' in warns[0]
+
+    def test_read_fast_rate_no_warn(self, caplog):
+        table_desc = {'TableSizeBytes': 8096 * 1_000_000, 'ItemCount': 1_000_000}
+        with caplog.at_level(logging.DEBUG):
+            table_info._warn_if_job_may_timeout('t', 'read', 100_000, table_desc, 60)
+        assert _timeout_warnings(caplog) == []
+
+    def test_write_slow_rate_warns(self, caplog):
+        # 1,000,000 items * 1 write unit each at 100 u/s = ~166 min > 60 min.
+        table_desc = {'TableSizeBytes': 1024 * 1_000_000, 'ItemCount': 1_000_000}
+        with caplog.at_level(logging.DEBUG):
+            table_info._warn_if_job_may_timeout('t', 'write', 100, table_desc, 60)
+        warns = _timeout_warnings(caplog)
+        assert warns and 'write' in warns[0]
+
+    def test_write_large_items_multiply_units(self, caplog):
+        # 4KB items -> 4 write units each, so 100k items = 400k units; at 50 u/s
+        # that is 8000s = ~133 min > 60 min.
+        table_desc = {'TableSizeBytes': 4096 * 100_000, 'ItemCount': 100_000}
+        with caplog.at_level(logging.DEBUG):
+            table_info._warn_if_job_may_timeout('t', 'write', 50, table_desc, 60)
+        assert _timeout_warnings(caplog)
+
+    def test_custom_timeout_suppresses_warning(self, caplog):
+        # Same slow read that warns at 60 min stays quiet with a 7-day timeout.
+        table_desc = {'TableSizeBytes': 8096 * 1_000_000, 'ItemCount': 1_000_000}
+        with caplog.at_level(logging.DEBUG):
+            table_info._warn_if_job_may_timeout('t', 'read', 100, table_desc, 10080)
+        assert _timeout_warnings(caplog) == []
+
+    def test_zero_size_skips_read(self, caplog):
+        table_desc = {'TableSizeBytes': 0, 'ItemCount': 0}
+        with caplog.at_level(logging.DEBUG):
+            table_info._warn_if_job_may_timeout('t', 'read', 1, table_desc, 60)
+        assert _timeout_warnings(caplog) == []
+
+    def test_zero_items_skips_write(self, caplog):
+        table_desc = {'TableSizeBytes': 1024, 'ItemCount': 0}
+        with caplog.at_level(logging.DEBUG):
+            table_info._warn_if_job_may_timeout('t', 'write', 1, table_desc, 60)
+        assert _timeout_warnings(caplog) == []
+
+    def test_missing_metadata_skips(self, caplog):
+        with caplog.at_level(logging.DEBUG):
+            table_info._warn_if_job_may_timeout('t', 'read', 100, {}, 60)
+        assert _timeout_warnings(caplog) == []
+
+    def test_non_numeric_rate_skips(self, caplog):
+        table_desc = {'TableSizeBytes': 8096 * 1_000_000, 'ItemCount': 1_000_000}
+        with caplog.at_level(logging.DEBUG):
+            table_info._warn_if_job_may_timeout('t', 'read', 'abc', table_desc, 60)
+        assert _timeout_warnings(caplog) == []
+
+    def test_none_rate_skips(self, caplog):
+        table_desc = {'TableSizeBytes': 8096 * 1_000_000, 'ItemCount': 1_000_000}
+        with caplog.at_level(logging.DEBUG):
+            table_info._warn_if_job_may_timeout('t', 'read', None, table_desc, 60)
+        assert _timeout_warnings(caplog) == []
+
+    def test_zero_rate_skips(self, caplog):
+        table_desc = {'TableSizeBytes': 8096 * 1_000_000, 'ItemCount': 1_000_000}
+        with caplog.at_level(logging.DEBUG):
+            table_info._warn_if_job_may_timeout('t', 'read', 0, table_desc, 60)
+        assert _timeout_warnings(caplog) == []
+
+    def test_uses_log_warning_level(self, caplog):
+        table_desc = {'TableSizeBytes': 8096 * 1_000_000, 'ItemCount': 1_000_000}
+        with caplog.at_level(logging.DEBUG):
+            table_info._warn_if_job_may_timeout('t', 'read', 100, table_desc, 60)
+        records = [r for r in caplog.records if 'will likely time out' in r.getMessage()]
+        assert records and all(r.levelno == logging.WARNING for r in records)
+
+
+# --- check #1 wiring inside get_dynamodb_throughput_configs -----------------
+
+
+class TestTimeoutWiring:
+    def _big_provisioned(self):
+        return {
+            'Table': {
+                'BillingModeSummary': {'BillingMode': 'PROVISIONED'},
+                'ProvisionedThroughput': {
+                    'ReadCapacityUnits': 100,
+                    'WriteCapacityUnits': 100,
+                },
+                'TableSizeBytes': 8096 * 1_000_000,
+                'ItemCount': 1_000_000,
+            }
+        }
+
+    def test_table_derived_slow_rate_warns(self, boto3_mock, caplog):
+        # No XMax* given: read_rate derives from the 100 RCU provisioned level,
+        # which is far too slow for a 1M-read-unit table -> timeout warning.
+        boto3_mock.dynamodb_client.describe_table.return_value = self._big_provisioned()
+        _no_autoscaling(boto3_mock)
+        with caplog.at_level(logging.DEBUG):
+            table_info.get_dynamodb_throughput_configs(
+                args={}, table_name='t', modes=['read']
+            )
+        assert _timeout_warnings(caplog)
+
+    def test_custom_xtimeout_suppresses(self, boto3_mock, caplog):
+        boto3_mock.dynamodb_client.describe_table.return_value = self._big_provisioned()
+        _no_autoscaling(boto3_mock)
+        with caplog.at_level(logging.DEBUG):
+            table_info.get_dynamodb_throughput_configs(
+                args={'XTimeout': 10080}, table_name='t', modes=['read']
+            )
+        assert _timeout_warnings(caplog) == []
+
+    def test_non_numeric_xtimeout_falls_back_to_default(self, boto3_mock, caplog):
+        boto3_mock.dynamodb_client.describe_table.return_value = self._big_provisioned()
+        _no_autoscaling(boto3_mock)
+        with caplog.at_level(logging.DEBUG):
+            table_info.get_dynamodb_throughput_configs(
+                args={'XTimeout': 'garbage'}, table_name='t', modes=['read']
+            )
+        # Falls back to the 60-min default, under which the slow rate warns.
+        assert _timeout_warnings(caplog)
+
+    def test_return_value_unchanged_by_timeout_warning(self, boto3_mock, caplog):
+        boto3_mock.dynamodb_client.describe_table.return_value = self._big_provisioned()
+        _no_autoscaling(boto3_mock)
+        with caplog.at_level(logging.DEBUG):
+            opts = table_info.get_dynamodb_throughput_configs(
+                args={}, table_name='t', modes=['read']
+            )
+        assert opts == {'dynamodb.throughput.read': '100'}
 
 
 class TestWiringGuarantees:

--- a/tools/bulk_executor/tests/server/test_table_info.py
+++ b/tools/bulk_executor/tests/server/test_table_info.py
@@ -720,6 +720,37 @@ class TestGetAndPrintDynamoDBTableInfo:
         assert result['write_pricing_category'] == 'std_wcu_pricing'
         assert result['read_pricing_category'] == 'std_rcu_pricing'
 
+    def test_autoscaling_describe_denied_does_not_crash_print(
+        self, boto3_mock, full_provisioned_response, caplog
+    ):
+        # Issue #89: the Auto Scaling Settings block in the info-print is a
+        # best-effort DIAGNOSTIC. If the Glue role lacks
+        # application-autoscaling:DescribeScalableTargets, the describe call
+        # raises AccessDenied — this must NOT take the whole job down at
+        # info-print time (a provisioned load previously crashed here, before
+        # any data moved). Instead: log an honest "could not read ... skipping"
+        # note naming the permission, and still return the table metadata.
+        import logging
+        boto3_mock.dynamodb_client.describe_table.return_value = full_provisioned_response
+        boto3_mock.autoscaling_client.describe_scalable_targets.side_effect = (
+            RuntimeError(
+                'AccessDeniedException: not authorized to perform: '
+                'application-autoscaling:DescribeScalableTargets'
+            )
+        )
+        with caplog.at_level(logging.DEBUG):
+            result = table_info.get_and_print_dynamodb_table_info('my-table')
+        # Did not crash; metadata came back intact.
+        assert result['billing_mode'] == 'PROVISIONED'
+        assert result['item_count'] == 1000000
+        # Honest skip note, naming the missing permission.
+        skip = [
+            m for m in caplog.messages
+            if 'Could not read autoscaling settings' in m
+            and 'DescribeScalableTargets' in m
+        ]
+        assert skip, caplog.messages
+
     def test_provisioned_table_quiet_mode(
         self, boto3_mock, full_provisioned_response, caplog
     ):


### PR DESCRIPTION
## Summary

Issue #89. Warn when the requested or table-derived read/write rate is a poor fit for the table — too **high** for what the table can deliver, too **low** to finish in the time remaining before the job times out — so the job doesn't silently throttle against a ceiling the caller can't raise, or run past the Glue timeout without warning.

This is a **rework** to Jason's 5-point spec (see review thread). The first attempt only read the title of #89. It now implements **all five checks** (#1–#5) and expands the permission/degradation handling from review feedback.

## What it does

Billing-mode-aware capacity checks in `get_dynamodb_throughput_configs`:

- **Provisioned, no autoscaling, request > provisioned** → hard warn (we can't raise it) *(spec #2)*
- **Provisioned, autoscaling on, request > autoscaling max** → hard warn *(spec #3)*
- **Provisioned < request ≤ autoscaling max** → softer scale-up note
- **On-demand, request > table `OnDemandThroughput` max** → hard warn *(spec #4)*
- **On-demand, no table max, request > account quota** → hard warn *(spec #5)*
- **Effective rate too slow to move the table's data in the time remaining before the job timeout** → "will likely time out" warn *(spec #1)*

Reuses the existing application-autoscaling + `get_quota_value` plumbing. Warnings are observational only — the return value is unchanged. Uses `log.warning`.

## Spec #1 — the timeout/ETA warning, now against time *remaining* (review follow-up)

Check #1 is a **planning-time estimate**: "look at the table metadata, decide how long the rate will take, and if it exceeds the budget, warn." Every input already lives in `get_dynamodb_throughput_configs` — the effective rate (user-set or table-derived), `TableSizeBytes`/`ItemCount` from the `describe_table`, and `--XTimeout` — so it sits alongside checks #2–#5 in `table_info`.

**The fix in Jason's latest review:** the budget must be the time **remaining** before the timeout, not the raw timeout. Multi-phase verbs run sequentially — `delete` does a scan phase, then a write phase — and resolve the *later* phase's rate only after an earlier phase has already burned part of the timeout. Checking a delete's write phase against the full 60 min is wrong when the scan already consumed 45 of them; it has to be checked against the ~15 min left.

Implementation:

- A monotonic reference is captured at module import (which on a Glue worker is job startup — `root.py` imports the verb, which imports `table_info`). `_job_elapsed_minutes()` returns wall-clock elapsed since then, clamped non-negative.
- `get_dynamodb_throughput_configs` computes `remaining = timeout − elapsed` and passes that to `_warn_if_job_may_timeout`, whose message now names the **time remaining** rather than the raw timeout.
- Because this function is called **when each phase begins**, a late phase automatically sees a shrunken budget — no per-verb plumbing, and no cross-phase state. This deliberately does **not** predict what future phases will need (per the spec).
- **No new IAM**: elapsed comes from the local monotonic clock, not `glue:GetJobRun`, so the permission envelope is unchanged.

I confirmed no verb calls `get_dynamodb_throughput_configs` earlier than the phase that needs it (find's delete resolves the write rate *after* the scan `count()`; reads resolve at connector `load()` time), matching Jason's note that no verb calls it overly early.

`_warn_if_job_may_timeout` reuses the same unit formulas as the cost estimators (read = `ceil(size/8096)`; write = `item_count * ceil(avg_item_size/1024)`), divides by the effective rate, and warns if the estimate exceeds the remaining budget. Best-effort: missing/zero metadata or a non-numeric rate simply skips.

## Permissions envelope (review follow-up)

The autoscaling-aware checks read a provisioned table's autoscaling maximum, which the generated Glue role could not previously see. This PR expands the permission envelope, and does all three things that entails:

- **Bootstrap:** new `MinimalAutoScalingAccess` inline policy granting `application-autoscaling:DescribeScalableTargets` on `Resource: "*"` (the action has no resource-level scoping).
- **README:** documents the new permission in the custom-role list, including the degradation behavior.
- **Version bump** `1` → `2`: existing bootstraps pick up the new policy via the version-mismatch role refresh (#84/#233).

**Graceful degradation (Jason's option b):** if the role lacks the permission, the job does **not** error — it skips the autoscaling-aware capacity check and logs a `log.warning` that it's proceeding without visibility into the table's autoscaling metrics, naming the missing permission. No false "exceeds provisioned" is emitted. The permission stays genuinely optional; granting it just re-enables the check.

## Second call site found live — and fixed

A live e2e run surfaced a bug this PR now fixes. There are **two** places that read a provisioned table's autoscaling settings, and graceful degradation has to cover both:

1. `_effective_capacity_ceiling` — the capacity-warning path. Already caught the AccessDenied and degraded.
2. `get_and_print_dynamodb_table_info` — the "Auto Scaling Settings" **diagnostic print** that runs *earlier* (`load/__init__.py` calls it before the write). This `describe_scalable_targets` was **unguarded** (pre-existing, commit `5a933d1`), so a provisioned `load` with the permission denied crashed there at info-print time, **before any data moved**. The traceback pointed at `load/__init__.py:117` (the `except` re-raise) because `from None` masked the real origin — which made it look like a connector-write failure; it was not.

Fix: wrap the diagnostic describe loop in `try/except`. On denial it logs `"Could not read autoscaling settings … skipping this diagnostic. Grant application-autoscaling:DescribeScalableTargets …"` and proceeds. With both call sites guarded, a provisioned load whose role is denied the permission runs to **SUCCEEDED**.

## Tests

TDD — `tests/server/test_rate_capacity_warnings.py` (all five checks). Check #1 now has coverage for the remaining-budget rework: `_job_elapsed_minutes` (zero at start, grows with the clock, clamped non-negative), `_warn_if_job_may_timeout` racing the time *remaining* rather than the raw timeout (a rate that fits a full 60-min timeout still warns when only 10 min remain), and an `elapsed-shrinks-the-budget` wiring regression through `get_dynamodb_throughput_configs` (mimics the multi-phase delete: the write rate resolves after ~55 min elapsed, leaving ~5 min for an ~8-min job → warns; early in the job → quiet). Plus `test_table_info.py::test_autoscaling_describe_denied_does_not_crash_print` (the diagnostic-print guard) and bootstrap-policy assertions in `tests/client/test_bootstrap.py`. `table_info.py` is at 100% line+branch coverage. Full offline suite: **1421 passing**, line 94.6%, branch 90.6%. Badges updated.

### E2E (opt-in, real Glue — not in `make test`)

`make test-e2e-capacity-warnings` proves the behavior on **real Glue jobs** — full suite **6 passed** (5 whole-system + 1 security):

- `tests/e2e/whole_system/test_capacity_warnings.py` — the four capacity warnings surface against real tables of each billing topology (provisioned-exceeds / autoscaling-max / soft scale-up / on-demand-max), plus **check #1**: a slow `--XMaxWriteRate` into the persistent, already-large `write_table` makes the estimate predict a multi-hour run and warn, while only ~20 rows are actually written so the job SUCCEEDS in ~2 min. Loading (not reading) decouples the estimate — keyed off the target's existing `ItemCount` — from the real work (the tiny input CSV); a read can't decouple these, since throttling to trip the estimate also throttles the real scan. Guards against a false-green (asserts the target's real `ItemCount` forces the estimate past the timeout before trusting the pass).
- `tests/e2e/security/test_capacity_warning_missing_perm.py` — a provisioned load whose Glue role is **explicitly denied** the permission emits both degradation notes **and the job reaches SUCCEEDED**. `CommandResult.output` (stdout+stderr) was added because Glue LiveTail routes `log.warning` to stderr.

**Note on the remaining-budget rework:** this suite's check-#1 scenario is a single-phase `load`, so elapsed ≈ 0 and remaining ≈ the raw timeout — it proves the warning still surfaces live, and the message substring it asserts on is unchanged. The specific late-phase "budget shrank because a scan already ran" behavior is proven by the unit regression above; a bespoke live multi-phase delete proof would need a table large enough for the scan to burn real minutes, which the unit test covers deterministically. The live suite runs on the fork's `fork-ci` pipeline as a background sanity check.

`transient_table` was extended for PROVISIONED / autoscaling-target / on-demand `MaxWriteRequestUnits` shapes.

## Rebase note

Rebased onto current `main` — includes #234 (issue #182) and #236/#237 (connector read-rate resolution). #236/#237 touch `glue_connector.py`, not the `table_info` capacity path, so no logic overlap; clean rebase.
