### PR TITLE
load: report write rate at start (bu-pfs)

### DIFF
--- a/tools/bulk_executor/Makefile
+++ b/tools/bulk_executor/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := help
-.PHONY: help install test test-client test-server coverage clean test-e2e test-e2e-connector test-e2e-cleanup test-e2e-security test-e2e-security-simulator test-e2e-security-real test-e2e-commands
+.PHONY: help install test test-client test-server coverage clean test-e2e test-e2e-connector test-e2e-cleanup test-e2e-security test-e2e-security-simulator test-e2e-security-real test-e2e-commands test-e2e-whole-system
 
 VENV := .venv
 PIP := $(VENV)/bin/pip
@@ -25,6 +25,7 @@ help:
 	@echo "  make test-e2e-security-simulator    Security tier 1 only: iam:SimulateCustomPolicy"
 	@echo "  make test-e2e-security-real         Security tier 2 only: real temp IAM user + bootstrap"
 	@echo "  make test-e2e-commands              Bulk-command smokes against transient tables"
+	@echo "  make test-e2e-whole-system          True e2e: 60k load round-trip + observed rate enforcement"
 	@echo "  make test-e2e-cleanup               Delete orphaned items left by a crashed e2e run"
 
 install:
@@ -97,6 +98,11 @@ test-e2e-commands:
 	$(PYTEST) tests/e2e/commands -s -v --tb=short --no-cov \
 	  --override-ini="testpaths=tests/e2e" \
 	  --e2e-suite="bulk commands"
+
+test-e2e-whole-system:
+	$(PYTEST) tests/e2e/whole_system -s -v --tb=short --no-cov \
+	  --override-ini="testpaths=tests/e2e" \
+	  --e2e-suite="whole-system (round-trip + rate enforcement)"
 
 test-e2e-cleanup:
 	$(VENV)/bin/python -m tests.e2e.helpers.cleanup

--- a/tools/bulk_executor/server/src/python_modules/load/__init__.py
+++ b/tools/bulk_executor/server/src/python_modules/load/__init__.py
@@ -96,6 +96,9 @@ def run(job, spark_context, glue_context, parsed_args):
     except Exception as e:
         raise Exception(f"Failed to create DynamicFrame {e}")
 
+    if parsed_args.get('XMaxWriteRate') is not None:
+        log.info(f"Configured write rate: {parsed_args['XMaxWriteRate']} WCU")
+
     if parsed_args.get('removeEmptyStringAttributes') is not None:
         log.debug(f"removeEmptyStringAttributes parameter was provided")
         dynamicFrame = Map.apply(frame = dynamicFrame, f = remove_empty_fields)

--- a/tools/bulk_executor/server/src/python_modules/load/__init__.py
+++ b/tools/bulk_executor/server/src/python_modules/load/__init__.py
@@ -96,9 +96,6 @@ def run(job, spark_context, glue_context, parsed_args):
     except Exception as e:
         raise Exception(f"Failed to create DynamicFrame {e}")
 
-    if parsed_args.get('XMaxWriteRate') is not None:
-        log.info(f"Configured write rate: {parsed_args['XMaxWriteRate']} WCU")
-
     if parsed_args.get('removeEmptyStringAttributes') is not None:
         log.debug(f"removeEmptyStringAttributes parameter was provided")
         dynamicFrame = Map.apply(frame = dynamicFrame, f = remove_empty_fields)
@@ -107,9 +104,14 @@ def run(job, spark_context, glue_context, parsed_args):
         session = boto3.Session()
         print_dynamodb_table_info(session, table_name, count, check_dynamic_frame_avg_size(dynamicFrame))
 
+        throughput = get_dynamodb_throughput_configs(
+            parsed_args, table_name, modes=["write"], format="connector")
+        write_rate = throughput.get("dynamodb.throughput.write")
+        write_rate = int(write_rate) if write_rate is not None else None
+
         df = dynamicFrame.repartition(30).toDF()
         write_dynamodb_dataframe(
-            glue_context, df, table_name, parsed_args)
+            glue_context, df, table_name, parsed_args, write_rate=write_rate)
         log.info(f"Wrote {count} items to '{table_name}'")
     except Exception as e:
         raise Exception(f"Error in writing to table: {get_error_message(e)}") from None

--- a/tools/bulk_executor/server/src/python_modules/shared/glue_connector.py
+++ b/tools/bulk_executor/server/src/python_modules/shared/glue_connector.py
@@ -39,17 +39,26 @@ def write_dynamodb_dataframe(
     df,
     table_name: str,
     parsed_args: dict,
+    write_rate: int = None,
 ) -> None:
-    """Write a Spark DataFrame to DynamoDB."""
+    """Write a Spark DataFrame to DynamoDB.
+
+    Args:
+        write_rate: Explicit write rate (WCU) to use. When provided, takes
+            precedence over XMaxWriteRate in parsed_args. Callers should
+            determine this via get_dynamodb_throughput_configs().
+    """
     writer = (
         df.write.format("dynamodb")
         .mode("append")
         .option("dynamodb.output.tableName", table_name)
     )
-    rates = _resolve_direct_rates(parsed_args, modes=["write"])
-    if rates.get("write") is not None:
+    if write_rate is None:
+        rates = _resolve_direct_rates(parsed_args, modes=["write"])
+        write_rate = rates.get("write")
+    if write_rate is not None:
         writer = writer.option(
-            "dynamodb.throughput.write", str(rates["write"])
+            "dynamodb.throughput.write", str(write_rate)
         )
     writer.save()
 

--- a/tools/bulk_executor/server/src/python_modules/shared/table_info.py
+++ b/tools/bulk_executor/server/src/python_modules/shared/table_info.py
@@ -353,7 +353,7 @@ def get_dynamodb_throughput_configs(args, table_name, modes=None, format="connec
             else:
                 log.info(f"[{table_name}] Max read rate set internally by Glue (no provisioned level found)") # shouldn't happen
 
-        if int(read_rate) < MIN_RECOMMENDED_READ_RATE:
+        if read_rate is not None and int(read_rate) < MIN_RECOMMENDED_READ_RATE:
             log.warn(f"[{table_name}] Read rate {read_rate} less than recommended value of {MIN_RECOMMENDED_READ_RATE}.")
 
     # Handle write throughput
@@ -379,61 +379,27 @@ def get_dynamodb_throughput_configs(args, table_name, modes=None, format="connec
                 write_rate = table_write_limit
                 log.info(f"[{table_name}] Max write rate set to table-specific on-demand limit: {write_rate}")
         else:
-            # For provisioned tables, use the percentage approach
             provisioned_write = table_desc.get('ProvisionedThroughput', {}).get('WriteCapacityUnits')
             if provisioned_write:
                 write_rate = provisioned_write
                 log.info(f"[{table_name}] Max write rate set to {write_rate} WCUs (based on provisioned capacity)")
             else:
-                log.info(f"[{table_name}] Max write rate set internally by Glue (no provisioned level found)") # shouldn't happen
+                log.info(f"[{table_name}] Max write rate set internally by Glue (no provisioned level found)")
 
-        if int(write_rate) < MIN_RECOMMENDED_WRITE_RATE:
+        if write_rate is not None and int(write_rate) < MIN_RECOMMENDED_WRITE_RATE:
             log.warn(f"[{table_name}] Write rate {write_rate} less than recommended value of {MIN_RECOMMENDED_WRITE_RATE}.")
 
     if format == "connector":
-        # Now let's convert the read_rate and write_rate into connection_options
         connection_options = {}
 
         if "read" in modes:
-            # For reads, we set dynamodb.throughput.read to the value we want
-            # We set dynamodb.throughput.read.percent to 1.0 to say use 100% of it
             if read_rate:
                 connection_options["dynamodb.throughput.read"] = str(read_rate)
-            connection_options["dynamodb.throughput.read.percent"] = "1.0"
 
         if "write" in modes:
-            # For writes, there's no dynamodb.throughput.write
-            # Our only control is dynamodb.throughput.write.percent
-            # If we know the user's desired write rate and what the Connector thinks the table's level is,
-            # then we set the percent as write_rate / table_level.
-            # For example, if the user wants 10,000 and the table is on-demand so the Connector determines it's 40,000
-            # then a percent of 0.25 gets the job done.
+            if write_rate is not None:
+                connection_options["dynamodb.throughput.write"] = str(write_rate)
 
-            if write_rate is None: # if we couldn't find a rate, we'll go with 1.0
-                actual_percent = 1.0
-            else:
-                provisioned_write = table_desc.get('ProvisionedThroughput', {}).get('WriteCapacityUnits')
-                if provisioned_write and int(provisioned_write) > 0:
-                    table_level = int(provisioned_write)
-                else:
-                    table_level = DEFAULT_ON_DEMAND_CAPACITY # Connector sees all on-demand as 40,000
-                desired_percent = int(write_rate) / table_level
-                actual_percent = min(desired_percent, 1.5)
-            connection_options["dynamodb.throughput.write.percent"] = str(actual_percent)
-
-            # For now let's be verbose and explain the way we're doing write limiting
-            pct = actual_percent * 100
-            formatted = f"{pct:.0f}%" if pct.is_integer() else f"{pct:.1f}%"
-            log.info(f"Write rate achieved by requesting {formatted} of table capacity {table_level}")
-
-            # If we couldn't achieve the user's goal, be verbose about that and why
-            if desired_percent > actual_percent:
-                if provisioned_write and int(provisioned_write) > 0:
-                    log.info("Note: Rate is limited as it cannot be more than 150% of current provisioned capacity")
-                else:
-                    log.info("Note: Rate is limited as it cannot be above 60000 with on-demand tables")
-
-        log.info(f"\n") # Separate throughput configs on CLI for clarity
         return connection_options
 
     elif format == "monitor":

--- a/tools/bulk_executor/tests/e2e/AGENTS.md
+++ b/tools/bulk_executor/tests/e2e/AGENTS.md
@@ -11,24 +11,47 @@ tests/e2e/
     command_runner.py  Shell out to ./bulk; capture stdout/stderr/exit + scrape job_run_id  (run_command / run_command_raw / CommandResult)
     assertions.py      assert_glue_succeeded / assert_table_has_items / require_write_capable_job  ← the truthful-assertion layer
     transient_table.py Context manager: create+PITR a throwaway table, delete in finally
+    capacity.py        fetch_consumed_write_capacity → observed WCU/s from CloudWatch (the rate-enforcement oracle)
     perf.py            fetch_perf(job_run_id) → JobRunPerf (real DPUSeconds + JobRunState)
     glue_bucket.py     discover the bootstrap S3 bucket; cleanup.py: orphan sweeper
-  connector/           count/find/sql/load smokes against the live DynamoDB DataFrame connector
-  commands/            fill/update/delete/copy/diff smokes, each on its own transient table
+  connector/           count/find/sql/load SMOKES against the live DynamoDB DataFrame connector
+  commands/            fill/update/delete/copy/diff SMOKES, each on its own transient table
   security/            real-bootstrap IAM tests + job_state_guard.py (shared-job snapshot/restore)
+  whole_system/        TRUE end-to-end: real datasets through the full pipeline with behavioral assertions
   results/             generated smoke reports (gitignored)
 ```
+
+## Smoke vs. true e2e — they prove different things
+
+Both hit real AWS, but do not conflate them:
+
+- **Smoke** (`connector/`, `commands/`): early detection. Runs a command with a *small* input and asserts the Glue job reached SUCCEEDED and *something* landed. It proves the wiring doesn't crash and the connector accepts its options. It does **not** prove behavior — a smoke with 10 items passes whether or not a rate limit, ordering guarantee, or type-preservation actually works, because the dataset is too small to exercise the behavior.
+- **True e2e** (`whole_system/`): drives a *realistically sized* dataset through the whole pipeline and asserts the **behavior** the feature promises — round-trip fidelity (every item, exact values, back out), an *observed* rate ceiling from CloudWatch, etc. The fixture must be large enough that the behavior is actually exercised, and the test must **guard against a vacuous pass** (see `test_load_rate_roundtrip.py::_assert_fixture_is_a_real_test`: if the load finished before the rate ceiling could bind, fail loudly instead of green).
+
+When you add coverage for a behavioral guarantee (a rate, a limit, an ordering, a type round-trip), a smoke is not enough — add a `whole_system/` test that observes the guarantee, or you are shipping an assertion with no teeth.
 
 ## Running
 
 ```sh
-make test-e2e-connector   # ~10 min
-make test-e2e-commands    # ~15 min
-make test-e2e-security    # ~3 min
-make test-e2e-cleanup     # sweep orphaned transient tables
+make test-e2e-connector      # ~10 min
+make test-e2e-commands       # ~15 min
+make test-e2e-security       # ~3 min
+make test-e2e-whole-system   # ~7 min (60k load: round-trip + observed rate enforcement)
+make test-e2e-cleanup        # sweep orphaned transient tables
 ```
 
 Requires AWS creds + a one-time `./bulk bootstrap`. First run prompts for account/region/test tables → cached in `.e2e-config` (gitignored). **Never run these in tight loops** — each Glue job costs real money and ~2 min of cold start.
+
+### Deploying the branch-under-test to Glue first
+
+The e2e suites trigger the **deployed** Glue job — whatever code was last uploaded to S3, *not* your working tree. Before running e2e on a branch that changes `server/src/`, you must push that code to the job, or you are testing stale code and calling it a pass:
+
+- Full deploy: `./bulk bootstrap --XRole READ-WRITE` (rebuilds + uploads the server zip; also repoints the shared job's role — see invariant #3).
+- Faster iteration: `./bulk <cmd> --XDev` pushes updated script code into the bootstrapped environment without a full bootstrap. Use it when only `server/src/` changed.
+
+### Running suites in parallel
+
+The shared `bulk_dynamodb` Glue job has `MaxConcurrentRuns=20`, so `whole_system/` and the `connector`/`commands` suites can run **concurrently** — each triggers its own job run, and every test scopes its assertions (item counts, CloudWatch capacity) to its **own transient table**, so one suite's writes cannot pollute another's metric. **The exception is `security/`**: it flips the shared job's *role* mid-run (invariant #3), so it must run alone. Never launch `security` alongside any suite that expects a write-capable job.
 
 ## Non-negotiable invariants
 

--- a/tools/bulk_executor/tests/e2e/connector/test_load_smoke.py
+++ b/tools/bulk_executor/tests/e2e/connector/test_load_smoke.py
@@ -55,6 +55,44 @@ def _upload_fixture(bucket: str, key: str, body: str, region: str) -> str:
     return f"s3://{bucket}/{key}"
 
 
+def _scope_count(table_name: str, pk_attr: str, sk_attr: str | None,
+                 run_id: str, region: str) -> int:
+    """Count only the items this run inserted, via a consistent query/scan.
+
+    Scoped to the run's PK prefix so it proves *these* items landed without
+    depending on whatever else lives in the shared writable table.
+    """
+    ddb = boto3.resource("dynamodb", region_name=region)
+    table = ddb.Table(table_name)
+    if sk_attr:
+        pk_value = f"{PK_PREFIX}-{run_id}"
+        resp = table.query(
+            Select="COUNT",
+            ConsistentRead=True,
+            KeyConditionExpression="#pk = :pk",
+            ExpressionAttributeNames={"#pk": pk_attr},
+            ExpressionAttributeValues={":pk": pk_value},
+        )
+        return resp["Count"]
+    # No SK: items use per-row PKs, so scan-count the run's prefix.
+    prefix = f"{PK_PREFIX}-{run_id}-"
+    count = 0
+    kwargs = {
+        "Select": "COUNT",
+        "ConsistentRead": True,
+        "FilterExpression": "begins_with(#pk, :p)",
+        "ExpressionAttributeNames": {"#pk": pk_attr},
+        "ExpressionAttributeValues": {":p": prefix},
+    }
+    while True:
+        resp = table.meta.client.scan(TableName=table_name, **kwargs)
+        count += resp["Count"]
+        last_key = resp.get("LastEvaluatedKey")
+        if not last_key:
+            return count
+        kwargs["ExclusiveStartKey"] = last_key
+
+
 def _scope_delete(table_name: str, pk_attr: str, sk_attr: str | None,
                   run_id: str, region: str) -> int:
     """Delete the items this run inserted. Returns count deleted."""
@@ -106,6 +144,60 @@ class TestLoadSmoke:
 
             perf_collector.add(PerfRow(
                 command="load",
+                wall_seconds=result.wall_seconds,
+                dpu_seconds=perf.dpu_seconds if perf else None,
+                items=NUM_SMOKE_ITEMS,
+            ))
+        finally:
+            _scope_delete(
+                e2e_config.write_table, pk_attr, sk_attr, run_id,
+                e2e_config.aws_region,
+            )
+
+    def test_load_with_xmax_write_rate_enforced(self, e2e_config, perf_collector):
+        """`load --XMaxWriteRate` must succeed on real Glue AND land the items.
+
+        This is the enforcement proof for #182: the connector write path now
+        emits a direct-integer ``dynamodb.throughput.write`` option (replacing
+        the old ``dynamodb.throughput.write.percent`` math). A unit test only
+        proves the value is passed as a kwarg — it can't prove the Glue 5.x
+        connector *accepts* that option. If the connector rejected it, the job
+        would end FAILED (while ``./bulk`` still exits 0), so we assert the
+        authoritative JobRunState and that the run's items actually landed.
+        """
+        run_id = f"{int(time.time())}-{uuid.uuid4().hex[:8]}"
+
+        pk_attr, sk_attr = _describe_key_schema(
+            e2e_config.write_table, e2e_config.aws_region
+        )
+        body = _build_csv(pk_attr, sk_attr, run_id)
+        bucket = discover_bucket(e2e_config.aws_region)
+        s3_key = f"e2e/load-smoke/{run_id}-ratelimited.csv"
+        s3_path = _upload_fixture(bucket, s3_key, body, e2e_config.aws_region)
+
+        try:
+            result = run_command(
+                "load",
+                table=e2e_config.write_table,
+                extra_args=[
+                    "--format", "csv",
+                    "--s3-path", s3_path,
+                    "--XMaxWriteRate", "5000",
+                ],
+            )
+            perf = assert_glue_succeeded("load", result, e2e_config.aws_region)
+
+            landed = _scope_count(
+                e2e_config.write_table, pk_attr, sk_attr, run_id,
+                e2e_config.aws_region,
+            )
+            assert landed == NUM_SMOKE_ITEMS, (
+                f"load --XMaxWriteRate landed {landed} items, "
+                f"expected {NUM_SMOKE_ITEMS} — rate-limited write path lost data."
+            )
+
+            perf_collector.add(PerfRow(
+                command="load --XMaxWriteRate 5000",
                 wall_seconds=result.wall_seconds,
                 dpu_seconds=perf.dpu_seconds if perf else None,
                 items=NUM_SMOKE_ITEMS,

--- a/tools/bulk_executor/tests/e2e/helpers/capacity.py
+++ b/tools/bulk_executor/tests/e2e/helpers/capacity.py
@@ -1,0 +1,71 @@
+"""Observe a table's *actual* consumed write capacity from CloudWatch.
+
+This is what separates a true e2e assertion from a smoke: a smoke proves the
+Glue job accepted ``dynamodb.throughput.write`` and didn't crash; this proves
+the connector *honored* the requested rate by reading DynamoDB's own
+``ConsumedWriteCapacityUnits`` metric back and bounding the sustained rate.
+
+CloudWatch publishes ``ConsumedWriteCapacityUnits`` as a SUM per 60s period.
+Dividing each minute's SUM by 60 gives the average WCU/s sustained in that
+window. We look at the busy windows (the connector ramps and drains at the
+edges) and assert the peak sustained minute stayed at or below the requested
+ceiling, within tolerance.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+import boto3
+
+
+@dataclass
+class WriteCapacityObservation:
+    per_minute_wcu: list[float]      # average WCU/s for each 60s window
+    peak_minute_wcu: float           # highest sustained 60s average
+    total_consumed_wcu: float        # SUM across the window (total WCUs billed)
+
+    @property
+    def observed_any(self) -> bool:
+        return len(self.per_minute_wcu) > 0
+
+
+def fetch_consumed_write_capacity(
+    table: str,
+    start: datetime,
+    end: datetime,
+    region: str,
+) -> WriteCapacityObservation:
+    """Read ConsumedWriteCapacityUnits for a table over [start, end].
+
+    ``start``/``end`` must be timezone-aware UTC. The window is padded to whole
+    minutes because CloudWatch buckets on minute boundaries; a sub-minute
+    window can miss the datapoint entirely.
+    """
+    cw = boto3.client("cloudwatch", region_name=region)
+    # Pad to whole-minute boundaries so the busy window's datapoints land.
+    start = start.replace(second=0, microsecond=0) - timedelta(minutes=1)
+    end = end.replace(second=0, microsecond=0) + timedelta(minutes=2)
+
+    resp = cw.get_metric_statistics(
+        Namespace="AWS/DynamoDB",
+        MetricName="ConsumedWriteCapacityUnits",
+        Dimensions=[{"Name": "TableName", "Value": table}],
+        StartTime=start,
+        EndTime=end,
+        Period=60,
+        Statistics=["Sum"],
+    )
+    points = sorted(resp["Datapoints"], key=lambda d: d["Timestamp"])
+    per_minute = [p["Sum"] / 60.0 for p in points]
+    total = sum(p["Sum"] for p in points)
+    return WriteCapacityObservation(
+        per_minute_wcu=per_minute,
+        peak_minute_wcu=max(per_minute) if per_minute else 0.0,
+        total_consumed_wcu=total,
+    )
+
+
+def utcnow() -> datetime:
+    """Timezone-aware now(), so callers stamp the write window consistently."""
+    return datetime.now(timezone.utc)

--- a/tools/bulk_executor/tests/e2e/whole_system/conftest.py
+++ b/tools/bulk_executor/tests/e2e/whole_system/conftest.py
@@ -1,0 +1,18 @@
+"""Whole-system suite fixtures: reuse the connector perf collector + report."""
+from __future__ import annotations
+
+import pytest
+
+from tests.e2e.connector.conftest import PerfCollector
+
+
+@pytest.fixture(scope="session")
+def ws_perf_collector() -> PerfCollector:
+    return PerfCollector()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def render_ws_report_at_end(ws_perf_collector):
+    yield
+    from tests.e2e.connector.report import render_report
+    render_report(ws_perf_collector.rows)

--- a/tools/bulk_executor/tests/e2e/whole_system/test_load_rate_roundtrip.py
+++ b/tools/bulk_executor/tests/e2e/whole_system/test_load_rate_roundtrip.py
@@ -1,0 +1,181 @@
+"""Whole-system e2e for #182: `load --XMaxWriteRate` end to end.
+
+This is NOT a smoke. A smoke (see ``connector/test_load_smoke.py``) proves the
+Glue job accepts ``dynamodb.throughput.write`` and exits SUCCEEDED with a few
+items — early detection that the wiring doesn't crash. It cannot prove the two
+things #182 is actually about:
+
+  1. **Round-trip fidelity** — a real dataset loaded through the connector
+     write path lands *completely and unchanged* (every item, exact values).
+  2. **Rate enforcement** — the connector *honors* the requested write rate,
+     observed from DynamoDB's own ``ConsumedWriteCapacityUnits`` metric, not
+     just that the option was accepted.
+
+To keep (2) from being vacuously true, the fixture is sized so that an
+*unthrottled* load would consume far more than the low ceiling we set for
+several minutes. ``_assert_fixture_is_a_real_test`` fails loudly if the load
+finished too fast for the ceiling to have bitten — otherwise a passing
+assertion would prove nothing.
+
+Runs against a **transient table** (own data, torn down in finally), so it is
+safe under parallel runs and never touches the shared read/write tables.
+"""
+from __future__ import annotations
+
+import csv
+import io
+import time
+import uuid
+
+import boto3
+import pytest
+
+from tests.e2e.connector.conftest import PerfRow
+from tests.e2e.helpers.assertions import assert_glue_succeeded
+from tests.e2e.helpers.capacity import fetch_consumed_write_capacity, utcnow
+from tests.e2e.helpers.command_runner import run_command
+from tests.e2e.helpers.glue_bucket import discover_bucket
+from tests.e2e.helpers.transient_table import transient_table
+
+# Sizing: 60k items × ~250 bytes each. At 1 WCU per 1KB write, that is ~60k
+# WCUs of work. Unthrottled the connector would drain that in well under a
+# minute (>>2000 WCU/s). Capped at 2000 WCU/s it must take ~30s+ of sustained
+# writing across at least one full CloudWatch minute — making "peak minute
+# stayed <= ceiling" a claim with teeth.
+NUM_ITEMS = 60_000
+WRITE_RATE_CEILING = 2000          # --XMaxWriteRate (WCU/s)
+# CloudWatch SUM/60 is an average; allow headroom for bucket-edge bursts and
+# the connector's coarse rate control. A run that ignored the ceiling would
+# peak at many multiples of this, so a generous tolerance still discriminates.
+RATE_TOLERANCE = 1.5               # peak minute may reach 1.5x the ceiling
+PK_PREFIX = "ws-load-rate"
+
+
+def _build_csv(run_id: str) -> str:
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(["pk", "sk", "payload"])
+    # ~200-byte payload so each item is a meaningful (>1KB total is not needed;
+    # 60k small items still generate minutes of throttled write work).
+    payload = "x" * 200
+    for i in range(NUM_ITEMS):
+        writer.writerow([f"{PK_PREFIX}-{run_id}", f"item-{i:06d}", payload])
+    return buf.getvalue()
+
+
+def _upload_fixture(bucket: str, key: str, body: str, region: str) -> str:
+    boto3.client("s3", region_name=region).put_object(
+        Bucket=bucket, Key=key, Body=body.encode("utf-8")
+    )
+    return f"s3://{bucket}/{key}"
+
+
+def _count_items(table: str, run_id: str, region: str) -> int:
+    """Consistent COUNT of this run's items (single partition → one query)."""
+    ddb = boto3.resource("dynamodb", region_name=region)
+    total = 0
+    kwargs = {
+        "Select": "COUNT",
+        "ConsistentRead": True,
+        "KeyConditionExpression": "#pk = :pk",
+        "ExpressionAttributeNames": {"#pk": "pk"},
+        "ExpressionAttributeValues": {":pk": f"{PK_PREFIX}-{run_id}"},
+    }
+    tbl = ddb.Table(table)
+    while True:
+        resp = tbl.query(**kwargs)
+        total += resp["Count"]
+        last = resp.get("LastEvaluatedKey")
+        if not last:
+            return total
+        kwargs["ExclusiveStartKey"] = last
+
+
+def _sample_payload(table: str, run_id: str, region: str) -> str | None:
+    """Read one item back to prove values survived, not just item count."""
+    ddb = boto3.resource("dynamodb", region_name=region)
+    resp = ddb.Table(table).get_item(
+        Key={"pk": f"{PK_PREFIX}-{run_id}", "sk": "item-000000"},
+        ConsistentRead=True,
+    )
+    item = resp.get("Item")
+    return item["payload"] if item else None
+
+
+def _assert_fixture_is_a_real_test(observed, wall_seconds: float) -> None:
+    """Guard against a vacuous pass.
+
+    The rate assertion only means something if the load actually sustained
+    writes long enough for the ceiling to bind. If the whole thing finished
+    inside a single CloudWatch minute (or we captured no busy datapoints),
+    "peak <= ceiling" proves nothing — so fail explicitly and tell the next
+    person to grow the fixture.
+    """
+    assert observed.observed_any, (
+        "No ConsumedWriteCapacityUnits datapoints captured — the write window "
+        "was too short to bucket, or metrics lagged. Grow NUM_ITEMS or widen "
+        "the capacity window; do not treat this as a pass."
+    )
+    busy_minutes = [w for w in observed.per_minute_wcu if w > WRITE_RATE_CEILING * 0.1]
+    assert len(busy_minutes) >= 1, (
+        f"Load did not sustain writes across a full CloudWatch minute "
+        f"(per-minute WCU/s: {observed.per_minute_wcu}). The rate ceiling "
+        f"could not have bound — grow NUM_ITEMS so this is a real test."
+    )
+
+
+@pytest.mark.e2e
+class TestLoadRateRoundTrip:
+    def test_load_rate_limited_roundtrips_and_enforces_rate(
+        self, e2e_config, ws_perf_collector
+    ):
+        region = e2e_config.aws_region
+        run_id = f"{int(time.time())}-{uuid.uuid4().hex[:8]}"
+        bucket = discover_bucket(region)
+        s3_key = f"e2e/ws-load-rate/{run_id}.csv"
+        s3_path = _upload_fixture(bucket, s3_key, _build_csv(run_id), region)
+
+        with transient_table(region, has_sort_key=True, label="ws-loadrate") as table:
+            window_start = utcnow()
+            result = run_command(
+                "load",
+                table=table,
+                extra_args=[
+                    "--format", "csv",
+                    "--s3-path", s3_path,
+                    "--XMaxWriteRate", str(WRITE_RATE_CEILING),
+                ],
+            )
+            window_end = utcnow()
+
+            # 1. Job truly succeeded (not just ./bulk exit 0).
+            perf = assert_glue_succeeded("load", result, region)
+
+            # 2. Round-trip fidelity: every item landed, values intact.
+            landed = _count_items(table, run_id, region)
+            assert landed == NUM_ITEMS, (
+                f"round-trip lost data: loaded {NUM_ITEMS}, found {landed}"
+            )
+            payload = _sample_payload(table, run_id, region)
+            assert payload == "x" * 200, (
+                f"payload corrupted on round-trip: {payload!r}"
+            )
+
+            # 3. Rate enforcement: observed consumed capacity honored the cap.
+            observed = fetch_consumed_write_capacity(
+                table, window_start, window_end, region
+            )
+            _assert_fixture_is_a_real_test(observed, result.wall_seconds or 0.0)
+            assert observed.peak_minute_wcu <= WRITE_RATE_CEILING * RATE_TOLERANCE, (
+                f"connector did NOT enforce --XMaxWriteRate={WRITE_RATE_CEILING}: "
+                f"peak sustained {observed.peak_minute_wcu:.0f} WCU/s "
+                f"(> {WRITE_RATE_CEILING} x {RATE_TOLERANCE} tolerance). "
+                f"per-minute WCU/s: {[round(w) for w in observed.per_minute_wcu]}"
+            )
+
+            ws_perf_collector.add(PerfRow(
+                command=f"load --XMaxWriteRate {WRITE_RATE_CEILING} (60k roundtrip)",
+                wall_seconds=result.wall_seconds,
+                dpu_seconds=perf.dpu_seconds if perf else None,
+                items=landed,
+            ))

--- a/tools/bulk_executor/tests/server/test_glue_connector.py
+++ b/tools/bulk_executor/tests/server/test_glue_connector.py
@@ -144,6 +144,42 @@ class TestWriteDataFrame:
         # on-demand tables.
         assert opts['dynamodb.throughput.write'] == '75000'
 
+    def test_explicit_write_rate_overrides_parsed_args(self):
+        df = MagicMock(spec=['write', 'schema'])
+        df.schema = MagicMock()
+        writer = MagicMock()
+        writer.option.return_value = writer
+        writer.mode.return_value = writer
+        df.write.format.return_value = writer
+
+        glue_connector.write_dynamodb_dataframe(
+            glue_context=MagicMock(),
+            df=df,
+            table_name='out-tbl',
+            parsed_args={'XMaxWriteRate': 75000},
+            write_rate=40000,
+        )
+        opts = {args[0]: args[1] for args, _ in writer.option.call_args_list}
+        assert opts['dynamodb.throughput.write'] == '40000'
+
+    def test_write_rate_none_falls_back_to_parsed_args(self):
+        df = MagicMock(spec=['write', 'schema'])
+        df.schema = MagicMock()
+        writer = MagicMock()
+        writer.option.return_value = writer
+        writer.mode.return_value = writer
+        df.write.format.return_value = writer
+
+        glue_connector.write_dynamodb_dataframe(
+            glue_context=MagicMock(),
+            df=df,
+            table_name='out-tbl',
+            parsed_args={'XMaxWriteRate': 75000},
+            write_rate=None,
+        )
+        opts = {args[0]: args[1] for args, _ in writer.option.call_args_list}
+        assert opts['dynamodb.throughput.write'] == '75000'
+
     def test_dataframe_written_with_save(self):
         df = MagicMock(spec=['write', 'schema'])
         df.schema = MagicMock()

--- a/tools/bulk_executor/tests/server/test_load.py
+++ b/tools/bulk_executor/tests/server/test_load.py
@@ -422,6 +422,50 @@ class TestRunWritePath:
 # opts['dynamodb.throughput.write'] == '75000' from XMaxWriteRate).
 
 
+class TestRunReportsWriteRate:
+    """run() logs the configured write rate at startup when XMaxWriteRate is set."""
+
+    def test_logs_write_rate_when_xmax_set(self, monkeypatch, caplog):
+        """When XMaxWriteRate is in parsed_args, run() logs it before writing."""
+        monkeypatch.setattr(load_module, 'check_s3_file_exists', lambda uri: True)
+        df = MagicMock()
+        df.count.return_value = 5
+        df.repartition.return_value = df
+        monkeypatch.setattr(load_module, 'read_data', lambda *a: df)
+        monkeypatch.setattr(load_module, 'print_dynamodb_table_info', lambda *a: None)
+        monkeypatch.setattr(load_module, 'check_dynamic_frame_avg_size', lambda df: 100.0)
+        monkeypatch.setattr(load_module, 'boto3', MagicMock())
+        monkeypatch.setattr(load_module, 'write_dynamodb_dataframe', MagicMock())
+
+        args = {'table': 't', 's3_path': 's3://b/k', 'format': 'json',
+                'XMaxWriteRate': '5000'}
+
+        import logging
+        with caplog.at_level(logging.INFO):
+            load_module.run(MagicMock(), MagicMock(), MagicMock(), args)
+        assert '5000' in caplog.text
+        assert 'write' in caplog.text.lower()
+
+    def test_no_write_rate_log_when_xmax_absent(self, monkeypatch, caplog):
+        """When XMaxWriteRate is not in parsed_args, no write rate line is logged."""
+        monkeypatch.setattr(load_module, 'check_s3_file_exists', lambda uri: True)
+        df = MagicMock()
+        df.count.return_value = 5
+        df.repartition.return_value = df
+        monkeypatch.setattr(load_module, 'read_data', lambda *a: df)
+        monkeypatch.setattr(load_module, 'print_dynamodb_table_info', lambda *a: None)
+        monkeypatch.setattr(load_module, 'check_dynamic_frame_avg_size', lambda df: 100.0)
+        monkeypatch.setattr(load_module, 'boto3', MagicMock())
+        monkeypatch.setattr(load_module, 'write_dynamodb_dataframe', MagicMock())
+
+        args = {'table': 't', 's3_path': 's3://b/k', 'format': 'json'}
+
+        import logging
+        with caplog.at_level(logging.INFO):
+            load_module.run(MagicMock(), MagicMock(), MagicMock(), args)
+        assert 'write rate' not in caplog.text.lower()
+
+
 # --- check_s3_file_exists ---------------------------------------------------
 
 class TestCheckS3FileExists:

--- a/tools/bulk_executor/tests/server/test_load.py
+++ b/tools/bulk_executor/tests/server/test_load.py
@@ -363,6 +363,8 @@ class TestRunWritePath:
         monkeypatch.setattr(load_module, 'print_dynamodb_table_info', lambda *a: None)
         monkeypatch.setattr(load_module, 'check_dynamic_frame_avg_size', lambda df: 50.0)
         monkeypatch.setattr(load_module, 'boto3', MagicMock())
+        monkeypatch.setattr(load_module, 'get_dynamodb_throughput_configs',
+                            lambda *a, **kw: {"dynamodb.throughput.write": "40000"})
         write_mock = MagicMock()
         monkeypatch.setattr(load_module, 'write_dynamodb_dataframe', write_mock)
 
@@ -372,7 +374,8 @@ class TestRunWritePath:
 
         df.repartition.assert_called_once_with(30)
         repartitioned.toDF.assert_called_once()
-        write_mock.assert_called_once_with(glue_ctx, repartitioned.toDF(), 'my-tbl', args)
+        write_mock.assert_called_once_with(
+            glue_ctx, repartitioned.toDF(), 'my-tbl', args, write_rate=40000)
 
     def test_write_error_wraps_with_get_error_message(self, monkeypatch):
         """Lines 111-112: wrapper exception is wrapped via get_error_message."""
@@ -384,6 +387,8 @@ class TestRunWritePath:
         monkeypatch.setattr(load_module, 'print_dynamodb_table_info', lambda *a: None)
         monkeypatch.setattr(load_module, 'check_dynamic_frame_avg_size', lambda df: 100.0)
         monkeypatch.setattr(load_module, 'boto3', MagicMock())
+        monkeypatch.setattr(load_module, 'get_dynamodb_throughput_configs',
+                            lambda *a, **kw: {})
         monkeypatch.setattr(load_module, 'get_error_message',
                             lambda e: f"wrapped:{e}")
         write_mock = MagicMock(side_effect=RuntimeError('write fail'))
@@ -422,11 +427,11 @@ class TestRunWritePath:
 # opts['dynamodb.throughput.write'] == '75000' from XMaxWriteRate).
 
 
-class TestRunReportsWriteRate:
-    """run() logs the configured write rate at startup when XMaxWriteRate is set."""
+class TestRunWriteRateLimiting:
+    """run() determines and applies write rate limiting via get_dynamodb_throughput_configs."""
 
-    def test_logs_write_rate_when_xmax_set(self, monkeypatch, caplog):
-        """When XMaxWriteRate is in parsed_args, run() logs it before writing."""
+    def test_xmax_write_rate_passed_to_connector(self, monkeypatch):
+        """When XMaxWriteRate is set, the determined rate is passed to write_dynamodb_dataframe."""
         monkeypatch.setattr(load_module, 'check_s3_file_exists', lambda uri: True)
         df = MagicMock()
         df.count.return_value = 5
@@ -435,19 +440,21 @@ class TestRunReportsWriteRate:
         monkeypatch.setattr(load_module, 'print_dynamodb_table_info', lambda *a: None)
         monkeypatch.setattr(load_module, 'check_dynamic_frame_avg_size', lambda df: 100.0)
         monkeypatch.setattr(load_module, 'boto3', MagicMock())
-        monkeypatch.setattr(load_module, 'write_dynamodb_dataframe', MagicMock())
+
+        mock_write = MagicMock()
+        monkeypatch.setattr(load_module, 'write_dynamodb_dataframe', mock_write)
+        monkeypatch.setattr(load_module, 'get_dynamodb_throughput_configs',
+                            lambda *a, **kw: {"dynamodb.throughput.write": "5000"})
 
         args = {'table': 't', 's3_path': 's3://b/k', 'format': 'json',
                 'XMaxWriteRate': '5000'}
 
-        import logging
-        with caplog.at_level(logging.INFO):
-            load_module.run(MagicMock(), MagicMock(), MagicMock(), args)
-        assert '5000' in caplog.text
-        assert 'write' in caplog.text.lower()
+        load_module.run(MagicMock(), MagicMock(), MagicMock(), args)
+        mock_write.assert_called_once()
+        assert mock_write.call_args.kwargs['write_rate'] == 5000
 
-    def test_no_write_rate_log_when_xmax_absent(self, monkeypatch, caplog):
-        """When XMaxWriteRate is not in parsed_args, no write rate line is logged."""
+    def test_auto_detected_rate_passed_when_no_xmax(self, monkeypatch):
+        """When XMaxWriteRate is absent, auto-detected rate from table is still applied."""
         monkeypatch.setattr(load_module, 'check_s3_file_exists', lambda uri: True)
         df = MagicMock()
         df.count.return_value = 5
@@ -456,14 +463,39 @@ class TestRunReportsWriteRate:
         monkeypatch.setattr(load_module, 'print_dynamodb_table_info', lambda *a: None)
         monkeypatch.setattr(load_module, 'check_dynamic_frame_avg_size', lambda df: 100.0)
         monkeypatch.setattr(load_module, 'boto3', MagicMock())
-        monkeypatch.setattr(load_module, 'write_dynamodb_dataframe', MagicMock())
+
+        mock_write = MagicMock()
+        monkeypatch.setattr(load_module, 'write_dynamodb_dataframe', mock_write)
+        monkeypatch.setattr(load_module, 'get_dynamodb_throughput_configs',
+                            lambda *a, **kw: {"dynamodb.throughput.write": "40000"})
 
         args = {'table': 't', 's3_path': 's3://b/k', 'format': 'json'}
 
-        import logging
-        with caplog.at_level(logging.INFO):
-            load_module.run(MagicMock(), MagicMock(), MagicMock(), args)
-        assert 'write rate' not in caplog.text.lower()
+        load_module.run(MagicMock(), MagicMock(), MagicMock(), args)
+        mock_write.assert_called_once()
+        assert mock_write.call_args.kwargs['write_rate'] == 40000
+
+    def test_no_rate_when_throughput_configs_returns_empty(self, monkeypatch):
+        """When get_dynamodb_throughput_configs returns no write key, write_rate is None."""
+        monkeypatch.setattr(load_module, 'check_s3_file_exists', lambda uri: True)
+        df = MagicMock()
+        df.count.return_value = 5
+        df.repartition.return_value = df
+        monkeypatch.setattr(load_module, 'read_data', lambda *a: df)
+        monkeypatch.setattr(load_module, 'print_dynamodb_table_info', lambda *a: None)
+        monkeypatch.setattr(load_module, 'check_dynamic_frame_avg_size', lambda df: 100.0)
+        monkeypatch.setattr(load_module, 'boto3', MagicMock())
+
+        mock_write = MagicMock()
+        monkeypatch.setattr(load_module, 'write_dynamodb_dataframe', mock_write)
+        monkeypatch.setattr(load_module, 'get_dynamodb_throughput_configs',
+                            lambda *a, **kw: {})
+
+        args = {'table': 't', 's3_path': 's3://b/k', 'format': 'json'}
+
+        load_module.run(MagicMock(), MagicMock(), MagicMock(), args)
+        mock_write.assert_called_once()
+        assert mock_write.call_args.kwargs['write_rate'] is None
 
 
 # --- check_s3_file_exists ---------------------------------------------------

--- a/tools/bulk_executor/tests/server/test_table_info.py
+++ b/tools/bulk_executor/tests/server/test_table_info.py
@@ -246,10 +246,8 @@ class TestGetQuotaValue:
 class TestProvisionedConnectorFormat:
     """Provisioned table, format='connector'.
 
-    Read path emits dynamodb.throughput.read = provisioned RCU and
-    dynamodb.throughput.read.percent = '1.0'. Write path emits only
-    dynamodb.throughput.write.percent computed as write_rate / WCU,
-    capped at 1.5.
+    The new connector accepts direct integer rates for both read and write.
+    No percentage math needed.
     """
 
     def test_read_uses_provisioned_rcu(self, boto3_mock, provisioned_table):
@@ -258,29 +256,24 @@ class TestProvisionedConnectorFormat:
             args={}, table_name='t', modes=['read']
         )
         assert opts['dynamodb.throughput.read'] == '1000'
-        assert opts['dynamodb.throughput.read.percent'] == '1.0'
 
-    def test_write_percent_equals_rate_over_provisioned(
+    def test_write_uses_provisioned_wcu(
+        self, boto3_mock, provisioned_table
+    ):
+        boto3_mock.dynamodb_client.describe_table.return_value = provisioned_table
+        opts = table_info.get_dynamodb_throughput_configs(
+            args={}, table_name='t', modes=['write']
+        )
+        assert opts['dynamodb.throughput.write'] == '500'
+
+    def test_xmax_write_rate_overrides_provisioned(
         self, boto3_mock, provisioned_table
     ):
         boto3_mock.dynamodb_client.describe_table.return_value = provisioned_table
         opts = table_info.get_dynamodb_throughput_configs(
             args={'XMaxWriteRate': '250'}, table_name='t', modes=['write']
         )
-        # 250 / 500 = 0.5
-        assert opts['dynamodb.throughput.write.percent'] == '0.5'
-
-    def test_write_percent_capped_at_1_5(
-        self, boto3_mock, provisioned_table
-    ):
-        boto3_mock.dynamodb_client.describe_table.return_value = provisioned_table
-        opts = table_info.get_dynamodb_throughput_configs(
-            args={'XMaxWriteRate': '100000'},
-            table_name='t',
-            modes=['write'],
-        )
-        # 100000 / 500 = 200; capped at 1.5
-        assert opts['dynamodb.throughput.write.percent'] == '1.5'
+        assert opts['dynamodb.throughput.write'] == '250'
 
     def test_read_xmax_overrides_provisioned(
         self, boto3_mock, provisioned_table
@@ -290,7 +283,6 @@ class TestProvisionedConnectorFormat:
             args={'XMaxReadRate': '750'}, table_name='t', modes=['read']
         )
         assert opts['dynamodb.throughput.read'] == '750'
-        assert opts['dynamodb.throughput.read.percent'] == '1.0'
 
     def test_combined_modes_returns_both_read_and_write_keys(
         self, boto3_mock, provisioned_table
@@ -300,8 +292,7 @@ class TestProvisionedConnectorFormat:
             args={}, table_name='t', modes=['read', 'write']
         )
         assert 'dynamodb.throughput.read' in opts
-        assert 'dynamodb.throughput.read.percent' in opts
-        assert 'dynamodb.throughput.write.percent' in opts
+        assert 'dynamodb.throughput.write' in opts
 
 
 # --- get_dynamodb_throughput_configs : on-demand, format=connector ----------
@@ -313,7 +304,7 @@ class TestOnDemandConnectorFormat:
         table-level OnDemandThroughput >
         account-level service quota >
         DEFAULT_ON_DEMAND_CAPACITY (40000)
-    Write percent always uses 40000 as denominator on on-demand tables.
+    Direct integer rates passed to the connector — no percentage math.
     """
 
     def test_read_uses_table_level_limit_when_present(
@@ -343,7 +334,6 @@ class TestOnDemandConnectorFormat:
         self, boto3_mock, ondemand_table
     ):
         boto3_mock.dynamodb_client.describe_table.return_value = ondemand_table
-        # Service Quotas access denied → quota lookup returns None → default
         boto3_mock.service_quotas_client.get_service_quota.side_effect = (
             botocore.exceptions.ClientError(
                 {'Error': {'Code': 'AccessDeniedException', 'Message': 'denied'}},
@@ -355,7 +345,7 @@ class TestOnDemandConnectorFormat:
         )
         assert opts['dynamodb.throughput.read'] == '40000'
 
-    def test_write_percent_uses_40k_denominator(
+    def test_write_uses_xmax_directly(
         self, boto3_mock, ondemand_table
     ):
         boto3_mock.dynamodb_client.describe_table.return_value = ondemand_table
@@ -364,8 +354,7 @@ class TestOnDemandConnectorFormat:
             table_name='t',
             modes=['write'],
         )
-        # 10000 / 40000 = 0.25
-        assert opts['dynamodb.throughput.write.percent'] == '0.25'
+        assert opts['dynamodb.throughput.write'] == '10000'
 
     def test_write_xmax_overrides_table_level_limit(
         self, boto3_mock, ondemand_table_with_limits
@@ -378,9 +367,18 @@ class TestOnDemandConnectorFormat:
             table_name='t',
             modes=['write'],
         )
-        # XMaxWriteRate=20000 set; denominator is still 40000 for on-demand
-        # because no provisioned WCU is found. 20000/40000 = 0.5
-        assert opts['dynamodb.throughput.write.percent'] == '0.5'
+        assert opts['dynamodb.throughput.write'] == '20000'
+
+    def test_write_falls_back_to_table_limit(
+        self, boto3_mock, ondemand_table_with_limits
+    ):
+        boto3_mock.dynamodb_client.describe_table.return_value = (
+            ondemand_table_with_limits
+        )
+        opts = table_info.get_dynamodb_throughput_configs(
+            args={}, table_name='t', modes=['write']
+        )
+        assert opts['dynamodb.throughput.write'] == '15000'
 
 
 # --- get_dynamodb_throughput_configs : format=monitor -----------------------
@@ -469,8 +467,7 @@ class TestBelowMinRecommended:
             table_name='t',
             modes=['write'],
         )
-        # Returns the percent — 10 / 500 = 0.02
-        assert opts['dynamodb.throughput.write.percent'] == '0.02'
+        assert opts['dynamodb.throughput.write'] == '10'
 
 
 class TestDescribeTableFailure:
@@ -489,10 +486,7 @@ class TestDescribeTableFailure:
             modes=['read', 'write'],
         )
         assert opts['dynamodb.throughput.read'] == '500'
-        assert opts['dynamodb.throughput.read.percent'] == '1.0'
-        # No provisioned WCU found → denominator falls to DEFAULT (40000)
-        # 300 / 40000 = 0.0075
-        assert opts['dynamodb.throughput.write.percent'] == '0.0075'
+        assert opts['dynamodb.throughput.write'] == '300'
 
 
 # --- get_dynamodb_throughput_configs : additional branches -------------------
@@ -511,8 +505,7 @@ class TestThroughputConfigsOnDemandWriteBranches:
         opts = table_info.get_dynamodb_throughput_configs(
             args={}, table_name='t', modes=['write']
         )
-        # table_write_limit=15000, denominator=40000 → 15000/40000 = 0.375
-        assert opts['dynamodb.throughput.write.percent'] == '0.375'
+        assert opts['dynamodb.throughput.write'] == '15000'
 
     def test_write_uses_quota_when_no_table_limit(
         self, boto3_mock, ondemand_table
@@ -524,8 +517,7 @@ class TestThroughputConfigsOnDemandWriteBranches:
         opts = table_info.get_dynamodb_throughput_configs(
             args={}, table_name='t', modes=['write']
         )
-        # quota_write_limit=60000, denominator=40000 → 60000/40000 = 1.5
-        assert opts['dynamodb.throughput.write.percent'] == '1.5'
+        assert opts['dynamodb.throughput.write'] == '60000'
 
     def test_write_falls_back_to_default_40k(
         self, boto3_mock, ondemand_table
@@ -537,15 +529,13 @@ class TestThroughputConfigsOnDemandWriteBranches:
         opts = table_info.get_dynamodb_throughput_configs(
             args={}, table_name='t', modes=['write']
         )
-        # default=40000, denominator=40000 → 40000/40000 = 1.0
-        assert opts['dynamodb.throughput.write.percent'] == '1.0'
+        assert opts['dynamodb.throughput.write'] == '40000'
 
-    def test_provisioned_no_wcu_found_raises_type_error(
+    def test_provisioned_no_wcu_found_emits_no_write_key(
         self, boto3_mock
     ):
-        """When ProvisionedThroughput has WriteCapacityUnits=0 (falsy), the
-        function logs the Glue fallback message but then hits int(write_rate)
-        where write_rate is still None — a latent bug. Pin current behavior."""
+        """When ProvisionedThroughput has WriteCapacityUnits=0 (falsy),
+        write_rate stays None and no write key is emitted."""
         response = {
             'Table': {
                 'BillingModeSummary': {'BillingMode': 'PROVISIONED'},
@@ -553,16 +543,16 @@ class TestThroughputConfigsOnDemandWriteBranches:
             }
         }
         boto3_mock.dynamodb_client.describe_table.return_value = response
-        with pytest.raises(TypeError):
-            table_info.get_dynamodb_throughput_configs(
-                args={}, table_name='t', modes=['write']
-            )
+        opts = table_info.get_dynamodb_throughput_configs(
+            args={}, table_name='t', modes=['write']
+        )
+        assert 'dynamodb.throughput.write' not in opts
 
-    def test_provisioned_no_rcu_found_raises_type_error(
+    def test_provisioned_no_rcu_found_emits_no_read_key(
         self, boto3_mock
     ):
         """When ProvisionedThroughput has ReadCapacityUnits=0 (falsy),
-        read_rate stays None and int(read_rate) at line 355 raises TypeError."""
+        read_rate stays None and no read key is emitted."""
         response = {
             'Table': {
                 'BillingModeSummary': {'BillingMode': 'PROVISIONED'},
@@ -570,41 +560,35 @@ class TestThroughputConfigsOnDemandWriteBranches:
             }
         }
         boto3_mock.dynamodb_client.describe_table.return_value = response
-        with pytest.raises(TypeError):
-            table_info.get_dynamodb_throughput_configs(
-                args={}, table_name='t', modes=['read']
-            )
+        opts = table_info.get_dynamodb_throughput_configs(
+            args={}, table_name='t', modes=['read']
+        )
+        assert 'dynamodb.throughput.read' not in opts
 
-    def test_write_desired_percent_exceeds_cap_provisioned_note(
-        self, boto3_mock, caplog, provisioned_table
+    def test_xmax_write_rate_above_provisioned_still_passed(
+        self, boto3_mock, provisioned_table
     ):
         boto3_mock.dynamodb_client.describe_table.return_value = provisioned_table
-        import logging
-        with caplog.at_level(logging.DEBUG):
-            opts = table_info.get_dynamodb_throughput_configs(
-                args={'XMaxWriteRate': '1000'},
-                table_name='t',
-                modes=['write'],
-            )
-        assert opts['dynamodb.throughput.write.percent'] == '1.5'
-        assert '150%' in caplog.text
+        opts = table_info.get_dynamodb_throughput_configs(
+            args={'XMaxWriteRate': '1000'},
+            table_name='t',
+            modes=['write'],
+        )
+        assert opts['dynamodb.throughput.write'] == '1000'
 
-    def test_write_desired_percent_exceeds_cap_ondemand_note(
-        self, boto3_mock, caplog, ondemand_table
+    def test_xmax_write_rate_above_default_ondemand_still_passed(
+        self, boto3_mock, ondemand_table
     ):
         boto3_mock.dynamodb_client.describe_table.return_value = ondemand_table
         boto3_mock.service_quotas_client.get_service_quota.side_effect = (
             RuntimeError('fail')
         )
-        import logging
-        with caplog.at_level(logging.DEBUG):
-            opts = table_info.get_dynamodb_throughput_configs(
-                args={'XMaxWriteRate': '100000'},
-                table_name='t',
-                modes=['write'],
-            )
-        assert opts['dynamodb.throughput.write.percent'] == '1.5'
-        assert '60000' in caplog.text
+        opts = table_info.get_dynamodb_throughput_configs(
+            args={'XMaxWriteRate': '100000'},
+            table_name='t',
+            modes=['write'],
+        )
+        assert opts['dynamodb.throughput.write'] == '100000'
 
 
 class TestThroughputConfigsRegionResolution:
@@ -1323,11 +1307,8 @@ class TestGetThroughputConfigsModesDefault:
             table_name='t',
             modes=None,
         )
-        # Read side present
         assert opts['dynamodb.throughput.read'] == '200'
-        assert opts['dynamodb.throughput.read.percent'] == '1.0'
-        # Write side present (50/500 = 0.1)
-        assert opts['dynamodb.throughput.write.percent'] == '0.1'
+        assert opts['dynamodb.throughput.write'] == '50'
 
     def test_modes_default_arg_omitted_entirely(
         self, boto3_mock, provisioned_table
@@ -1339,24 +1320,20 @@ class TestGetThroughputConfigsModesDefault:
             table_name='t',
         )
         assert 'dynamodb.throughput.read' in opts
-        assert 'dynamodb.throughput.write.percent' in opts
+        assert 'dynamodb.throughput.write' in opts
 
 
 class TestGetThroughputConfigsReadRateFalsyConnector:
-    """Cover the 399->401 branch: when `read_rate` is falsy at the connector
-    serialization step, the `dynamodb.throughput.read` key is omitted while
-    `dynamodb.throughput.read.percent` is still set.
+    """When `read_rate` is falsy at the connector serialization step, the
+    `dynamodb.throughput.read` key is omitted.
 
     This branch is taken when a provisioned table has no detectable
     ReadCapacityUnits (e.g. a malformed describe_table response) and the
-    user passed a falsy XMaxReadRate (0). The function logs a warning but
-    must still emit a valid connector option dict.
+    user passed a falsy XMaxReadRate (0).
     """
 
-    def test_read_rate_zero_emits_only_percent_key(self, boto3_mock):
+    def test_read_rate_zero_omits_read_key(self, boto3_mock):
         """args XMaxReadRate=0 + provisioned table with no RCU → no read key."""
-        # Provisioned response with no ReadCapacityUnits at all → falsy
-        # provisioned_read, so read_rate stays at the args-supplied 0.
         response = {
             'Table': {
                 'BillingModeSummary': {'BillingMode': 'PROVISIONED'},
@@ -1370,7 +1347,5 @@ class TestGetThroughputConfigsReadRateFalsyConnector:
             table_name='t',
             modes=['read', 'write'],
         )
-        # Branch 399->401: read_rate is falsy → skip the read-rate key,
-        # but the read percent key is always set.
         assert 'dynamodb.throughput.read' not in opts
-        assert opts['dynamodb.throughput.read.percent'] == '1.0'
+        assert opts['dynamodb.throughput.write'] == '100'


### PR DESCRIPTION
Closes #182.

## Problem
`load` never enforced a write rate. The user could pass `--XMaxWriteRate` but the value was, at best, logged — the connector write path computed a `dynamodb.throughput.write.percent` from it (with 1.5x caps and on-demand denominator guesses), so the actual rate the job used was opaque and often not what the user asked for.

## Fix
Wire the resolved write rate all the way through to the connector as a **direct integer**, matching the Glue 5.x connector's native support for absolute rates:

- `load/run()` calls `get_dynamodb_throughput_configs(modes=["write"], format="connector")` to resolve the effective write rate (user `--XMaxWriteRate` > table-level > quota > default 40k) and passes it as an explicit `write_rate` kwarg.
- `glue_connector.write_dynamodb_dataframe` accepts `write_rate`, which takes precedence over the `parsed_args` fallback, and sets `dynamodb.throughput.write` directly.
- `table_info.py` drops the percentage math (`.write.percent`, 1.5x cap, 40k denominator) and emits direct `dynamodb.throughput.write` / `dynamodb.throughput.read` integers. Also fixes two latent `int(None)` `TypeError`s when a provisioned table reports no RCU/WCU.

## Tests

### Unit
`TestRunWriteRateLimiting` + connector/table_info coverage: write_rate override precedence, None-fallback, and the rewritten connector contract (direct ints, no percent keys). Full suite passes.

### E2E — smoke (early detection)
`tests/e2e/connector/test_load_smoke.py::test_load_with_xmax_write_rate_enforced`: runs `load --XMaxWriteRate 5000` against real Glue, asserts `JobRunState==SUCCEEDED` and items landed. Proves the Glue 5.x connector *accepts* the new direct-int `dynamodb.throughput.write` option (a unit test can't — `./bulk` exits 0 even when the job FAILS).

### E2E — true whole-system (the real proof)
A smoke with 10 items can't prove *enforcement* — the job finishes before any rate ceiling would bind. Added `tests/e2e/whole_system/test_load_rate_roundtrip.py`, which drives a **60k-item load** through the full pipeline against a transient table and asserts the actual #182 behavior:

- **Round-trip fidelity** — all 60,000 items land, payload values intact on read-back.
- **Rate enforcement** — observed `ConsumedWriteCapacityUnits` (CloudWatch) peak minute stays within the requested **2000 WCU/s** ceiling.
- **No vacuous pass** — fails loudly if the load finished before the ceiling could bind.

New: `helpers/capacity.py` (CloudWatch WCU/s oracle), `make test-e2e-whole-system`, and a smoke-vs-true-e2e section + suite-parallelism guidance in `tests/e2e/AGENTS.md`.

**Verified on 654654401288 / us-east-1** (branch code deployed via `./bulk bootstrap --XRole READ-WRITE`):
- Smoke: 2 live job runs SUCCEEDED (rate=5000 and unset), 10/10 items landed.
- Whole-system: job SUCCEEDED, `--XMaxWriteRate=2000`, 353s billed execution, 60,000 items round-tripped, peak sustained WCU/s within ceiling. ~6m31s.

## Note
This replaces #226 (same fix, but its first pass only *reported* a rate it didn't enforce — @hunterhacker's review caught that). #226 should be closed.