### PR TITLE
fix(load): remove stray per-arg printing

### DIFF
--- a/tools/bulk_executor/client/src/python_modules/load.py
+++ b/tools/bulk_executor/client/src/python_modules/load.py
@@ -82,8 +82,6 @@ def run(env_configs):
 
     if format_type == "csv":
         for arg in vars(args):
-            log.info(f"arg: {arg} with value {getattr(args, arg)}")
-
             if arg not in ALLOWED_ARGUMENTS_CSV_LOAD and not arg.startswith("X"):
                 parser.error(f'argument [{arg}] is not allowed for load commands using CSV format')
             elif arg == "withHeader":


### PR DESCRIPTION
Removes an unconditional log.info() that dumps every parsed CLI argument (including values) on every CSV load. Only fires on the csv format path, isn't gated by verbosity, and duplicates the consolidated 'Running action ... with arguments' log a few lines later. No behavior change.