### PR TITLE
fix(bulk_executor): restore read-rate resolution + logging in connector

### DIFF
--- a/tools/bulk_executor/server/src/python_modules/shared/glue_connector.py
+++ b/tools/bulk_executor/server/src/python_modules/shared/glue_connector.py
@@ -9,6 +9,8 @@ attached to the job. Bootstrap handles both requirements; verbs go through
 this module without caring about the underlying Spark API.
 """
 
+from python_modules.shared.table_info import get_dynamodb_throughput_configs
+
 
 def read_dynamodb_dataframe(
     glue_context,
@@ -16,7 +18,14 @@ def read_dynamodb_dataframe(
     parsed_args: dict,
     splits: int = 200,
 ):
-    """Read a DynamoDB table into a Spark DataFrame."""
+    """Read a DynamoDB table into a Spark DataFrame.
+
+    The read rate is resolved through get_dynamodb_throughput_configs, which
+    picks the effective rate from the user's --XMaxReadRate or, failing that,
+    the table's quota/provisioned/on-demand capacity — and logs which it chose.
+    Without this, an unspecified rate would silently fall to the connector's
+    0.5-ratio default with nothing logged (issue #236).
+    """
     spark = glue_context.spark_session
     reader = (
         spark.read.format("dynamodb")
@@ -25,11 +34,11 @@ def read_dynamodb_dataframe(
         .option("dynamodb.consistentRead", "false")
     )
 
-    rates = _resolve_direct_rates(parsed_args, modes=["read"])
-    if rates.get("read") is not None:
-        reader = reader.option(
-            "dynamodb.throughput.read", str(rates["read"])
-        )
+    connection_options = get_dynamodb_throughput_configs(
+        parsed_args, table_name, modes=["read"], format="connector"
+    )
+    for key, value in connection_options.items():
+        reader = reader.option(key, value)
 
     return reader.load()
 

--- a/tools/bulk_executor/tests/server/test_glue_connector.py
+++ b/tools/bulk_executor/tests/server/test_glue_connector.py
@@ -13,18 +13,33 @@ from unittest.mock import MagicMock
 import pytest
 
 
-# Real modules; conftest mocks shared, so substitute the real ones.
-sys.modules.pop('python_modules.shared.glue_connector', None)
-sys.modules.pop('shared.glue_connector', None)
-
 _REPO_ROOT = Path(__file__).resolve().parents[2] / "server/src"
 
 
 def _load_real(module_path: str, file_path: Path):
+    """Load the real module for this test file only.
+
+    conftest installs a Mock at ``python_modules.shared.glue_connector`` so
+    verb-side tests can import the wrapper as a black box. We need the real
+    implementation here, but must NOT leave it in sys.modules — doing so
+    swaps the real (describe_table-calling) get_dynamodb_throughput_configs
+    into every downstream test that imports a verb (test_sql, test_load, ...).
+    So we set it only for the duration of exec_module, then restore whatever
+    conftest had there.
+    """
+    saved = {name: sys.modules.get(name)
+             for name in (module_path, 'shared.glue_connector')}
     spec = importlib.util.spec_from_file_location(module_path, str(file_path))
     mod = importlib.util.module_from_spec(spec)
     sys.modules[module_path] = mod
-    spec.loader.exec_module(mod)
+    try:
+        spec.loader.exec_module(mod)
+    finally:
+        for name, original in saved.items():
+            if original is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
     return mod
 
 
@@ -32,6 +47,22 @@ glue_connector = _load_real(
     "python_modules.shared.glue_connector",
     _REPO_ROOT / "python_modules/shared/glue_connector.py",
 )
+
+
+@pytest.fixture(autouse=True)
+def throughput_configs(monkeypatch):
+    """Replace get_dynamodb_throughput_configs with a controllable MagicMock.
+
+    Rate resolution + logging is the responsibility of
+    get_dynamodb_throughput_configs (covered by test_table_info.py); the
+    wrapper's only job is to apply whatever connector options it returns.
+    Tests set `.return_value` to the connector-format dict they want applied.
+    Defaults to {} (no throughput override). Autouse so no test hits the real
+    describe_table.
+    """
+    mock = MagicMock(return_value={})
+    monkeypatch.setattr(glue_connector, 'get_dynamodb_throughput_configs', mock)
+    return mock
 
 
 # --- Fixtures ---------------------------------------------------------------
@@ -70,17 +101,34 @@ class TestReadDataFrame:
         assert opts['dynamodb.input.tableName'] == 'my-table'
         assert opts['dynamodb.splits'] == '300'
         assert opts['dynamodb.consistentRead'] == 'false'
-        # Without XMaxReadRate, no direct throughput option should be set --
-        # let the connector use its 0.5 ratio default.
-        assert 'dynamodb.throughput.read' not in opts
 
-    def test_xmax_read_rate_passes_through_as_direct_int(self, glue_context):
+    def test_read_rate_resolved_via_throughput_configs(self, glue_context, throughput_configs):
+        # Issue #236: even without --XMaxReadRate, the wrapper delegates to
+        # get_dynamodb_throughput_configs, which resolves the rate from the
+        # table (quota/provisioned/on-demand) AND logs it. Whatever connector
+        # options it returns must be applied to the reader.
+        throughput_configs.return_value = {'dynamodb.throughput.read': '120000'}
         glue_connector.read_dynamodb_dataframe(
-            glue_context, 't', {'XMaxReadRate': 12345}, splits=200
+            glue_context, 't', {}, splits=200
+        )
+        throughput_configs.assert_called_once_with(
+            {}, 't', modes=['read'], format='connector'
         )
         reader = glue_context.spark_session.read.format.return_value
         opts = {args[0]: args[1] for args, _ in reader.option.call_args_list}
-        assert opts['dynamodb.throughput.read'] == '12345'
+        assert opts['dynamodb.throughput.read'] == '120000'
+
+    def test_no_throughput_option_when_configs_empty(self, glue_context, throughput_configs):
+        # When the resolver returns nothing (e.g. describe/quota lookups all
+        # failed), the wrapper sets no throughput option and lets the connector
+        # fall back to its own 0.5 ratio default.
+        throughput_configs.return_value = {}
+        glue_connector.read_dynamodb_dataframe(
+            glue_context, 't', {}, splits=200
+        )
+        reader = glue_context.spark_session.read.format.return_value
+        opts = {args[0]: args[1] for args, _ in reader.option.call_args_list}
+        assert 'dynamodb.throughput.read' not in opts
 
     def test_load_is_called_and_dataframe_returned(self, glue_context):
         result = glue_connector.read_dynamodb_dataframe(


### PR DESCRIPTION
Fixes #236.

## The bug

`read_dynamodb_dataframe` only set `dynamodb.throughput.read` when the user passed `--XMaxReadRate`. Without the flag, it fell through to the Glue DynamoDB connector's own `dynamodb.throughput.read.ratio=0.5` default — reading at **50% of the table's capacity, with nothing logged** about the effective rate. This is why a `find` on an on-demand table with a 240k account quota was silently reading at ~120k with no "Max read rate set to..." line.

## Root cause

A regression from `ac43a2c` (connector centralization). `find`/`sql` used to call `get_dynamodb_throughput_configs(parsed_args, table, modes=["read"])` inline — the function that both **resolves** the rate (from `--XMaxReadRate`, else quota/provisioned/on-demand) and **logs** which it chose. Centralization replaced that with a flag-only `_resolve_direct_rates` helper, dropping both the resolution and the log line.

## The fix

- **Read path only:** `read_dynamodb_dataframe` again delegates to `get_dynamodb_throughput_configs(modes=["read"])`, restoring pre-centralization behavior.
- **Write path unchanged:** its sole caller (`load`) already pre-resolves the rate and passes it explicitly (PR #234), so it's left byte-identical to `main`.

## Tests

- Rewrote `TestReadDataFrame` to assert the wrapper delegates to the resolver and applies whatever connector options it returns (the `--XMaxReadRate` passthrough remains covered at its proper layer in `test_table_info.py`).
- Fixed `test_glue_connector` leaking the real module into `sys.modules`, which had been swapping the real `describe_table`-calling resolver into downstream verb tests.

Full offline suite: 1358 passed. (README badges to be refreshed separately.)