### PR TITLE
ci(bulk_executor): bump checkout@v5 and setup-python@v6 for Node 24

### DIFF
--- a/.github/workflows/bulk-executor-unit-tests.yml
+++ b/.github/workflows/bulk-executor-unit-tests.yml
@@ -24,10 +24,10 @@ jobs:
         working-directory: tools/bulk_executor
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 


### PR DESCRIPTION
## What

Bumps two GitHub Actions in `.github/workflows/bulk-executor-unit-tests.yml`:

- `actions/checkout@v4` → `@v5`
- `actions/setup-python@v5` → `@v6`

One-line-each change, no workflow logic or behavior change.

## Why

`checkout@v4` and `setup-python@v5` declare the **Node 20** runtime. GitHub is [deprecating Node 20 on Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) and currently auto-forces these actions onto Node 24, emitting a deprecation annotation on **every** run of this workflow:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, actions/setup-python@v5.

The `@v5`/`@v6` majors are the Node-24-native releases. Bumping clears the annotation before GitHub hard-removes Node 20 (at which point the pinned versions would fail rather than warn).

## Scope

Standalone CI hygiene — unrelated to any in-flight `bulk_executor` feature/test work. Touches only the unit-tests workflow file; no source, tests, or docs.

## Verification

Ran the updated workflow on a fork before opening this PR:

- Job `unit-tests` → **success** (full offline suite, ~1m)
- Post-steps confirm the new pins (`Post Run actions/checkout@v5`)
- **Annotations: 0** — the Node 20 deprecation warning no longer appears