### PR TITLE
[bulk_executor] fix(update): remove redundant TableName from scan_kwargs

### DIFF
--- a/tools/bulk_executor/server/src/python_modules/update/__init__.py
+++ b/tools/bulk_executor/server/src/python_modules/update/__init__.py
@@ -115,7 +115,6 @@ def _update_data(monitor_options, table_name, generate, segment, total_segments,
     skipped_count = 0
     failed_count = 0
     scan_kwargs = {
-        "TableName": table_name,
         "Segment": segment,
         "TotalSegments": total_segments
     }

--- a/tools/bulk_executor/tests/server/test_update.py
+++ b/tools/bulk_executor/tests/server/test_update.py
@@ -559,7 +559,7 @@ class TestUpdateDataPagination:
         updated_acc.add.assert_called_once_with(3)
 
     def test_scan_kwargs_include_segment_and_total(self, monkeypatch):
-        """Lines 117-121: scan_kwargs includes TableName, Segment, TotalSegments."""
+        """Lines 117-120: scan_kwargs includes Segment, TotalSegments (not TableName — the Table resource already knows its name)."""
         scan_kwargs_seen = []
         table = MagicMock()
 
@@ -576,7 +576,7 @@ class TestUpdateDataPagination:
             MagicMock(), MagicMock(), MagicMock(), MagicMock(), MagicMock()
         )
 
-        assert scan_kwargs_seen[0]['TableName'] == 'my-tbl'
+        assert 'TableName' not in scan_kwargs_seen[0]
         assert scan_kwargs_seen[0]['Segment'] == 7
         assert scan_kwargs_seen[0]['TotalSegments'] == 100
 


### PR DESCRIPTION
## What

Removes the redundant `TableName` key from `scan_kwargs` in the `update` verb.

The verb builds `table = dynamodb_resource.Table(table_name)` and calls `table.scan(**scan_kwargs)`. On a Table **resource**, the scan is already bound to that table, so passing `TableName` is redundant (and an unexpected key on the resource-level API). This drops it while keeping `Segment` / `TotalSegments` for the parallel scan.

## Testing

- `test_scan_kwargs_include_segment_and_total` updated to assert `TableName` is absent. Verified RED→GREEN: reintroducing the key fails the test.
- Full offline suite green (`make test`): 1358 passing.

## Notes

Clean re-submission of the fix originally in #188, minus the unrelated `_jsonify_message` regex tests that PR had bundled in. No overlap with any other open PR.
