### PR TITLE
[bulk_executor] feat: add --XMaxEstimatedCostAllowed cost gate

### DIFF
--- a/tools/bulk_executor/bulk
+++ b/tools/bulk_executor/bulk
@@ -93,6 +93,9 @@ if(is_client_and_server_action): # Only run the server if the client script DNE 
     args = utils.get_args_from_processed_args(processed_args)
     script_args = utils.convert_client_dict_to_script_args(processed_args)
 
+    # Cost gate - check estimated cost before launching Glue
+    utils.check_cost_gate(env_configs, processed_args)
+
     # Dev Mode - Push new code to S3 without a full bootstrap
     if(args.get('XDev')):
         BootstrapInfrastructure(env_configs).update_python_modules_in_s3()

--- a/tools/bulk_executor/client/src/utils/__init__.py
+++ b/tools/bulk_executor/client/src/utils/__init__.py
@@ -107,6 +107,9 @@ def glue_job_arguments():
     parser.add_argument("--XMaxWriteRate", type=int, default=argparse.SUPPRESS, help="Maximum amount of write units to consume per second.")
     parser.add_argument("--XMaxReadRate", type=int, default=argparse.SUPPRESS, help="Maximum amount of read units to consume per second.")
 
+    # Cost guard
+    parser.add_argument("--XMaxEstimatedCostAllowed", type=float, default=argparse.SUPPRESS, help="Maximum allowed estimated DynamoDB cost (in dollars). If the estimated cost exceeds this value, the job will not be launched.")
+
     return parser
 
 def environment_arguments():
@@ -246,6 +249,132 @@ def validate_tables(env_configs, parser, *tables, index=None, pitr_enabled=False
                 for name in shared:
                     if lsi_a[name] != lsi_b[name]:
                         warn(f"LSI '{name}' differs between '{reference_table}' and '{table_name}'")
+
+
+def estimate_cost(env_configs, processed_args):
+    """
+    Estimate the DynamoDB cost of a job based on table size and operation type.
+    Returns the estimated cost in dollars.
+    """
+    import math
+
+    region = env_configs.aws_region
+    clients = Clients(region)
+    dynamodb_client = clients.dynamodb_client
+
+    tables = []
+    if 'table' in processed_args:
+        tables.append(('read', processed_args['table']))
+    if 'source' in processed_args:
+        tables.append(('read', processed_args['source']))
+    if 'target' in processed_args:
+        tables.append(('write', processed_args['target']))
+
+    if not tables:
+        return 0.0
+
+    total_cost = 0.0
+    pricing_client = boto3.client('pricing', region_name='us-east-1')
+
+    for operation, table_name in tables:
+        try:
+            table_ref_region = _region_from_table_ref(table_name) or region
+            regional_client = Clients(table_ref_region).dynamodb_client
+            response = regional_client.describe_table(TableName=table_name)
+            table_desc = response['Table']
+        except ClientError:
+            continue
+
+        item_count = table_desc.get('ItemCount', 0)
+        size_bytes = table_desc.get('TableSizeBytes', 0)
+        billing_mode = table_desc.get('BillingModeSummary', {}).get('BillingMode', 'PROVISIONED')
+
+        table_class = table_desc.get('TableClassSummary', {}).get('TableClass', 'STANDARD')
+        if table_class == 'STANDARD_INFREQUENT_ACCESS':
+            write_pricing_category = 'ia_wcu_pricing'
+            read_pricing_category = 'ia_rcu_pricing'
+        else:
+            write_pricing_category = 'std_wcu_pricing'
+            read_pricing_category = 'std_rcu_pricing'
+
+        try:
+            pricing_response = pricing_client.get_products(
+                ServiceCode='AmazonDynamoDB',
+                Filters=[
+                    {'Type': 'TERM_MATCH', 'Field': 'productFamily', 'Value': 'Amazon DynamoDB PayPerRequest Throughput'},
+                    {'Type': 'TERM_MATCH', 'Field': 'regionCode', 'Value': table_ref_region}
+                ],
+                FormatVersion='aws_v1',
+                MaxResults=100
+            )
+            ondemand_pricing = {}
+            for entry in pricing_response['PriceList']:
+                product = json.loads(entry)
+                product_group = product['product']['attributes']['group']
+                offer = product['terms']['OnDemand'].popitem()
+                price_dimensions = offer[1]['priceDimensions']
+                for dim_code in price_dimensions:
+                    price = float(price_dimensions[dim_code]['pricePerUnit']['USD'])
+                    if price != 0:
+                        if product_group == 'DDB-ReadUnits':
+                            ondemand_pricing['std_rcu_pricing'] = price
+                        elif product_group == 'DDB-WriteUnits':
+                            ondemand_pricing['std_wcu_pricing'] = price
+                        elif product_group == 'DDB-ReadUnitsIA':
+                            ondemand_pricing['ia_rcu_pricing'] = price
+                        elif product_group == 'DDB-WriteUnitsIA':
+                            ondemand_pricing['ia_wcu_pricing'] = price
+        except Exception:
+            ondemand_pricing = {
+                'std_rcu_pricing': 0.00000025,
+                'std_wcu_pricing': 0.00000125,
+                'ia_rcu_pricing': 0.00000025,
+                'ia_wcu_pricing': 0.00000125,
+            }
+
+        if operation == 'read':
+            read_units = math.ceil(size_bytes / 8096)
+            unit_cost = float(ondemand_pricing.get(read_pricing_category, 0.00000025))
+            cost = read_units * unit_cost
+            if billing_mode == 'PROVISIONED':
+                cost = cost / 1.5
+            total_cost += cost
+        elif operation == 'write':
+            if item_count == 0:
+                continue
+            avg_size = size_bytes / item_count
+            avg_write_units_per_item = math.ceil(avg_size / 1024)
+            write_units = item_count * avg_write_units_per_item
+            unit_cost = float(ondemand_pricing.get(write_pricing_category, 0.00000125))
+            cost = write_units * unit_cost
+            if billing_mode == 'PROVISIONED':
+                cost = cost / 1.5
+            total_cost += cost
+
+    return total_cost
+
+
+def check_cost_gate(env_configs, processed_args):
+    """
+    Check if estimated cost exceeds the --XMaxEstimatedCostAllowed threshold.
+    Returns True if the job should proceed, exits with error if cost is too high.
+    """
+    max_cost = processed_args.get('XMaxEstimatedCostAllowed')
+    if max_cost is None:
+        return True
+
+    estimated_cost = estimate_cost(env_configs, processed_args)
+    log.info(f"Estimated DynamoDB cost: ${estimated_cost:,.2f}")
+    log.info(f"Maximum allowed cost: ${max_cost:,.2f}")
+
+    if estimated_cost > max_cost:
+        sys.exit(
+            f"Estimated cost ${estimated_cost:,.2f} exceeds the maximum allowed cost of "
+            f"${max_cost:,.2f}. Job will not be launched. "
+            f"Increase --XMaxEstimatedCostAllowed or reduce the scope of the operation."
+        )
+
+    return True
 
 
 def sanitize_arg(value, pattern, replacement=''):

--- a/tools/bulk_executor/tests/client/utils/test_cost_gate.py
+++ b/tools/bulk_executor/tests/client/utils/test_cost_gate.py
@@ -1,0 +1,353 @@
+"""Unit tests for the cost gate feature (--XMaxEstimatedCostAllowed).
+
+Covers `client/src/utils/__init__.py`:
+- estimate_cost(): read-only table cost estimation, write cost estimation,
+  copy (source+target) combined cost, missing table graceful skip, pricing
+  API fallback to hardcoded defaults
+- check_cost_gate(): param not set → pass-through, cost under threshold →
+  proceed, cost over threshold → sys.exit with message
+"""
+
+import json
+import math
+from unittest.mock import MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError
+
+import utils as utils_module
+from utils import check_cost_gate, estimate_cost
+
+
+# --- Fixtures ---------------------------------------------------------------
+
+@pytest.fixture
+def mock_env_configs():
+    env = MagicMock()
+    env.aws_region = "us-east-1"
+    return env
+
+
+@pytest.fixture
+def mock_table_response():
+    return {
+        'Table': {
+            'ItemCount': 1000,
+            'TableSizeBytes': 1_000_000,
+            'BillingModeSummary': {'BillingMode': 'PAY_PER_REQUEST'},
+            'TableClassSummary': {'TableClass': 'STANDARD'},
+        }
+    }
+
+
+@pytest.fixture
+def mock_pricing_response():
+    """Pricing API response with standard on-demand prices."""
+    def make_entry(group, price):
+        return json.dumps({
+            'product': {'attributes': {'group': group}},
+            'terms': {'OnDemand': {
+                'offer1': {
+                    'priceDimensions': {
+                        'dim1': {'pricePerUnit': {'USD': str(price)}}
+                    }
+                }
+            }}
+        })
+
+    return {
+        'PriceList': [
+            make_entry('DDB-ReadUnits', 0.00000025),
+            make_entry('DDB-WriteUnits', 0.00000125),
+        ]
+    }
+
+
+# --- estimate_cost ----------------------------------------------------------
+
+class TestEstimateCost:
+    """Tests for estimate_cost function."""
+
+    def test_returns_zero_when_no_tables(self, mock_env_configs):
+        """No table/source/target in args → zero cost."""
+        result = estimate_cost(mock_env_configs, {'verb': 'bootstrap'})
+        assert result == 0.0
+
+    @patch('utils.Clients')
+    @patch('utils.boto3.client')
+    def test_read_cost_on_demand_table(
+        self, mock_boto3_client, mock_clients_cls,
+        mock_env_configs, mock_table_response, mock_pricing_response
+    ):
+        """Estimates read cost for a single --table arg (on-demand billing)."""
+        mock_ddb = MagicMock()
+        mock_ddb.describe_table.return_value = mock_table_response
+        mock_clients_cls.return_value.dynamodb_client = mock_ddb
+
+        mock_pricing = MagicMock()
+        mock_pricing.get_products.return_value = mock_pricing_response
+        mock_boto3_client.return_value = mock_pricing
+
+        result = estimate_cost(mock_env_configs, {'table': 'my-table'})
+
+        size_bytes = 1_000_000
+        read_units = math.ceil(size_bytes / 8096)
+        expected = read_units * 0.00000025
+        assert result == pytest.approx(expected)
+
+    @patch('utils.Clients')
+    @patch('utils.boto3.client')
+    def test_read_cost_provisioned_table(
+        self, mock_boto3_client, mock_clients_cls,
+        mock_env_configs, mock_pricing_response
+    ):
+        """Provisioned tables get 1.5x discount on cost."""
+        table_response = {
+            'Table': {
+                'ItemCount': 500,
+                'TableSizeBytes': 500_000,
+                'BillingModeSummary': {'BillingMode': 'PROVISIONED'},
+                'TableClassSummary': {'TableClass': 'STANDARD'},
+            }
+        }
+        mock_ddb = MagicMock()
+        mock_ddb.describe_table.return_value = table_response
+        mock_clients_cls.return_value.dynamodb_client = mock_ddb
+
+        mock_pricing = MagicMock()
+        mock_pricing.get_products.return_value = mock_pricing_response
+        mock_boto3_client.return_value = mock_pricing
+
+        result = estimate_cost(mock_env_configs, {'table': 'my-table'})
+
+        read_units = math.ceil(500_000 / 8096)
+        expected = (read_units * 0.00000025) / 1.5
+        assert result == pytest.approx(expected)
+
+    @patch('utils.Clients')
+    @patch('utils.boto3.client')
+    def test_write_cost_for_copy_target(
+        self, mock_boto3_client, mock_clients_cls,
+        mock_env_configs, mock_pricing_response
+    ):
+        """Copy target estimates write cost based on item count and size."""
+        source_response = {
+            'Table': {
+                'ItemCount': 10000,
+                'TableSizeBytes': 10_000_000,
+                'BillingModeSummary': {'BillingMode': 'PAY_PER_REQUEST'},
+                'TableClassSummary': {'TableClass': 'STANDARD'},
+            }
+        }
+        target_response = {
+            'Table': {
+                'ItemCount': 10000,
+                'TableSizeBytes': 10_000_000,
+                'BillingModeSummary': {'BillingMode': 'PAY_PER_REQUEST'},
+                'TableClassSummary': {'TableClass': 'STANDARD'},
+            }
+        }
+        mock_ddb = MagicMock()
+        mock_ddb.describe_table.side_effect = [source_response, target_response]
+        mock_clients_cls.return_value.dynamodb_client = mock_ddb
+
+        mock_pricing = MagicMock()
+        mock_pricing.get_products.return_value = mock_pricing_response
+        mock_boto3_client.return_value = mock_pricing
+
+        result = estimate_cost(mock_env_configs, {'source': 'src-table', 'target': 'tgt-table'})
+
+        # Read cost for source
+        read_units = math.ceil(10_000_000 / 8096)
+        read_cost = read_units * 0.00000025
+
+        # Write cost for target
+        avg_size = 10_000_000 / 10000
+        avg_write_units = math.ceil(avg_size / 1024)
+        write_units = 10000 * avg_write_units
+        write_cost = write_units * 0.00000125
+
+        expected = read_cost + write_cost
+        assert result == pytest.approx(expected)
+
+    @patch('utils.Clients')
+    @patch('utils.boto3.client')
+    def test_skips_missing_table(
+        self, mock_boto3_client, mock_clients_cls, mock_env_configs
+    ):
+        """If describe_table raises ClientError, skip that table."""
+        mock_ddb = MagicMock()
+        mock_ddb.describe_table.side_effect = ClientError(
+            {'Error': {'Code': 'ResourceNotFoundException', 'Message': 'not found'}},
+            'DescribeTable'
+        )
+        mock_clients_cls.return_value.dynamodb_client = mock_ddb
+
+        result = estimate_cost(mock_env_configs, {'table': 'missing-table'})
+        assert result == 0.0
+
+    @patch('utils.Clients')
+    @patch('utils.boto3.client')
+    def test_uses_fallback_pricing_on_api_error(
+        self, mock_boto3_client, mock_clients_cls,
+        mock_env_configs, mock_table_response
+    ):
+        """Falls back to hardcoded pricing when pricing API fails."""
+        mock_ddb = MagicMock()
+        mock_ddb.describe_table.return_value = mock_table_response
+        mock_clients_cls.return_value.dynamodb_client = mock_ddb
+
+        mock_pricing = MagicMock()
+        mock_pricing.get_products.side_effect = Exception("pricing unavailable")
+        mock_boto3_client.return_value = mock_pricing
+
+        result = estimate_cost(mock_env_configs, {'table': 'my-table'})
+
+        # Should still produce a cost using fallback pricing
+        read_units = math.ceil(1_000_000 / 8096)
+        expected = read_units * 0.00000025
+        assert result == pytest.approx(expected)
+
+    @patch('utils.Clients')
+    @patch('utils.boto3.client')
+    def test_read_cost_infrequent_access_uses_ia_pricing(
+        self, mock_boto3_client, mock_clients_cls, mock_env_configs
+    ):
+        """STANDARD_INFREQUENT_ACCESS table reads use the IA read-unit price."""
+        table_response = {
+            'Table': {
+                'ItemCount': 1000,
+                'TableSizeBytes': 1_000_000,
+                'BillingModeSummary': {'BillingMode': 'PAY_PER_REQUEST'},
+                'TableClassSummary': {'TableClass': 'STANDARD_INFREQUENT_ACCESS'},
+            }
+        }
+        mock_ddb = MagicMock()
+        mock_ddb.describe_table.return_value = table_response
+        mock_clients_cls.return_value.dynamodb_client = mock_ddb
+
+        def make_entry(group, price):
+            return json.dumps({
+                'product': {'attributes': {'group': group}},
+                'terms': {'OnDemand': {'offer1': {'priceDimensions': {
+                    'dim1': {'pricePerUnit': {'USD': str(price)}}
+                }}}}
+            })
+
+        # Include every pricing group so the DDB-*IA branches are exercised.
+        mock_pricing = MagicMock()
+        mock_pricing.get_products.return_value = {'PriceList': [
+            make_entry('DDB-ReadUnits', 0.00000025),
+            make_entry('DDB-WriteUnits', 0.00000125),
+            make_entry('DDB-ReadUnitsIA', 0.00000031),
+            make_entry('DDB-WriteUnitsIA', 0.00000156),
+        ]}
+        mock_boto3_client.return_value = mock_pricing
+
+        result = estimate_cost(mock_env_configs, {'table': 'my-table'})
+
+        read_units = math.ceil(1_000_000 / 8096)
+        expected = read_units * 0.00000031  # IA read price, not STANDARD
+        assert result == pytest.approx(expected)
+
+    @patch('utils.Clients')
+    @patch('utils.boto3.client')
+    def test_write_cost_skips_target_with_zero_items(
+        self, mock_boto3_client, mock_clients_cls,
+        mock_env_configs, mock_pricing_response
+    ):
+        """A write target with zero items contributes no write cost (avoids div-by-zero)."""
+        target_response = {
+            'Table': {
+                'ItemCount': 0,
+                'TableSizeBytes': 0,
+                'BillingModeSummary': {'BillingMode': 'PAY_PER_REQUEST'},
+                'TableClassSummary': {'TableClass': 'STANDARD'},
+            }
+        }
+        mock_ddb = MagicMock()
+        mock_ddb.describe_table.return_value = target_response
+        mock_clients_cls.return_value.dynamodb_client = mock_ddb
+
+        mock_pricing = MagicMock()
+        mock_pricing.get_products.return_value = mock_pricing_response
+        mock_boto3_client.return_value = mock_pricing
+
+        result = estimate_cost(mock_env_configs, {'target': 'empty-table'})
+        assert result == 0.0
+
+    @patch('utils.Clients')
+    @patch('utils.boto3.client')
+    def test_write_cost_provisioned_target_gets_discount(
+        self, mock_boto3_client, mock_clients_cls,
+        mock_env_configs, mock_pricing_response
+    ):
+        """Provisioned write targets get the same 1.5x discount as reads."""
+        target_response = {
+            'Table': {
+                'ItemCount': 10000,
+                'TableSizeBytes': 10_000_000,
+                'BillingModeSummary': {'BillingMode': 'PROVISIONED'},
+                'TableClassSummary': {'TableClass': 'STANDARD'},
+            }
+        }
+        mock_ddb = MagicMock()
+        mock_ddb.describe_table.return_value = target_response
+        mock_clients_cls.return_value.dynamodb_client = mock_ddb
+
+        mock_pricing = MagicMock()
+        mock_pricing.get_products.return_value = mock_pricing_response
+        mock_boto3_client.return_value = mock_pricing
+
+        result = estimate_cost(mock_env_configs, {'target': 'tgt-table'})
+
+        avg_size = 10_000_000 / 10000
+        avg_write_units = math.ceil(avg_size / 1024)
+        write_units = 10000 * avg_write_units
+        expected = (write_units * 0.00000125) / 1.5
+        assert result == pytest.approx(expected)
+
+
+# --- check_cost_gate --------------------------------------------------------
+
+class TestCheckCostGate:
+    """Tests for check_cost_gate function."""
+
+    def test_passes_when_param_not_set(self, mock_env_configs):
+        """No --XMaxEstimatedCostAllowed → always proceed."""
+        result = check_cost_gate(mock_env_configs, {'table': 'my-table'})
+        assert result is True
+
+    @patch('utils.estimate_cost')
+    def test_passes_when_cost_under_threshold(self, mock_estimate, mock_env_configs):
+        """Cost below threshold → proceed normally."""
+        mock_estimate.return_value = 5.00
+        result = check_cost_gate(
+            mock_env_configs,
+            {'table': 'my-table', 'XMaxEstimatedCostAllowed': 10.00}
+        )
+        assert result is True
+
+    @patch('utils.estimate_cost')
+    def test_exits_when_cost_exceeds_threshold(self, mock_estimate, mock_env_configs):
+        """Cost above threshold → sys.exit with message."""
+        mock_estimate.return_value = 15.50
+        with pytest.raises(SystemExit) as exc_info:
+            check_cost_gate(
+                mock_env_configs,
+                {'table': 'my-table', 'XMaxEstimatedCostAllowed': 10.00}
+            )
+        exit_message = str(exc_info.value)
+        assert "$15.50" in exit_message
+        assert "$10.00" in exit_message
+        assert "exceeds" in exit_message
+
+    @patch('utils.estimate_cost')
+    def test_passes_when_cost_equals_threshold(self, mock_estimate, mock_env_configs):
+        """Cost exactly equal to threshold → proceed (not strictly greater)."""
+        mock_estimate.return_value = 10.00
+        result = check_cost_gate(
+            mock_env_configs,
+            {'table': 'my-table', 'XMaxEstimatedCostAllowed': 10.00}
+        )
+        assert result is True


### PR DESCRIPTION
## What

Adds an optional client-side **cost gate**: `--XMaxEstimatedCostAllowed`.

When set, the CLI estimates the DynamoDB cost of the operation before launching Glue (read cost for `--table`/`--source`, write cost for `--target`) using the Pricing API — with a hardcoded fallback if that call fails — and aborts with an actionable message if the estimate exceeds the threshold. Absent the flag, behavior is unchanged.

- `estimate_cost()`: per-table read/write cost; on-demand vs provisioned (1.5x discount); STANDARD vs Infrequent-Access table class; missing-table skip; pricing-API fallback.
- `check_cost_gate()`: no flag → pass-through; cost ≤ threshold → proceed; cost > threshold → `sys.exit` with guidance to raise the limit or reduce scope.
- Wired into `bulk` just before the Glue launch.

## Testing

- 14 unit tests (`test_cost_gate.py`), written RED-first (ImportError, functions absent) then GREEN. Covers IA pricing, zero-item-write skip, provisioned write discount, fallback pricing, and all three gate outcomes.
- New cost-gate code at 100% line coverage.
- Full offline suite green (`make test`): 1371 passing.

## Notes

Clean re-submission of #219, isolated from the unrelated `--XIdleTimeout` and error-handling changes its original stacked branch had bundled in. No file overlap with other open PRs.

Not yet exercised against the live Pricing API end-to-end — offline-verified only.
