### PR TITLE
[bulk_executor] feat(scancount): --per-segment skew report and --segments control

### DIFF
--- a/tools/bulk_executor/README.md
+++ b/tools/bulk_executor/README.md
@@ -77,6 +77,15 @@ Here are some example use cases:
 # Use single quotes around the JSON and double quotes within!
 ./bulk scancount --table t --index i --filter-expression "a = :aval" --expression-values '{":aval":"foo"}'
 
+# Add --per-segment to print each segment's item count (sorted, with a
+# skew ratio and a warning when the hottest segment exceeds 5x the mean).
+# Useful for diagnosing hot partitions / uneven key distribution.
+./bulk scancount --table t --per-segment
+
+# By default scancount uses 200 parallel scan segments. Use --segments to
+# tune that — fewer for small tables, more to increase per-segment resolution.
+./bulk scancount --table t --per-segment --segments 50
+
 
 # Compare two tables for differences (uses segmented scans internally)
 ./bulk diff --table t --table2 t2
@@ -463,6 +472,8 @@ If you ever want to stop execution early, you can hit Control-C. The interrupt w
 * Performs a parallel scan to count items. Leverages DynamoDB's `Select=COUNT` parameter on the `scan` call so only a count is returned on each internal DynamoDB scan call for maximum performance and memory efficiency.
 * Accepts an optional `index` name to scan an index, suitable if there's an appropriate sparse index that would be faster to scan than the base table.
 * Accepts a `filter-expression` to filter down the items counted. This expression uses the usual DynamoDB syntax. Requires a supporting  `expression-values` parameter and sometimes `expression-names`, as with usual DynamoDB scan calls.
+* Accepts an optional `per-segment` flag to print the item count for each scan segment (sorted descending, with each segment's share of the total). It also reports a skew ratio (hottest segment count / mean) and warns when that ratio exceeds 5x, which indicates an uneven key distribution / hot partition.
+* Accepts an optional `segments` parameter to control how many parallel scan segments are used (default 200). Lower it for small tables; raise it for finer per-segment resolution when diagnosing skew.
 
 #### `diff`
 

--- a/tools/bulk_executor/client/src/python_modules/scancount.py
+++ b/tools/bulk_executor/client/src/python_modules/scancount.py
@@ -13,6 +13,8 @@ help_text = f"""
         Optional --filter-expression parameter to specify a push-down FilterExpression predicate
         Optional --expression-names parameter to specify the expression names used in the filter-expression
         Optional --expression-values parameter to specify the expression values used in the filter-expression
+        Optional --per-segment flag to print item counts per segment (reveals data skew)
+        Optional --segments parameter to control how many parallel scan segments to use (default 200)
 
     Examples:
         # Count all items in a table
@@ -20,6 +22,12 @@ help_text = f"""
 
         # Count using a filter expression (uses DynamoDB FilterExpression syntax)
         bulk scancount --table audit --filter-expression "#touched > :touched" --expression-names '{{"#touched": "touched"}}' --expression-values '{{":touched":1742359403.0}}'
+
+        # Show per-segment counts to diagnose hot partitions
+        bulk scancount --table orders --per-segment
+
+        # Use fewer segments for a smaller table
+        bulk scancount --table orders --segments 10
     """
 
 def json_type(s):
@@ -41,6 +49,13 @@ def run(env_configs):
     parser.add_argument('--expression-names', type=json_type, default=argparse.SUPPRESS, help='Expression names to use')
     parser.add_argument('--expression-values', type=json_type, default=argparse.SUPPRESS, help='Expression values to use')
     parser.add_argument('--index', type=str, default=argparse.SUPPRESS, help='Index to use')
+    # store_true with SUPPRESS (matching --XWaitForDPU): the flag is only placed
+    # in the arg dict when set, so it is only forwarded to the Glue job when the
+    # user asks for it. A plain default=False would serialize to the string
+    # "False" over the argv wire (root.py parses values as strings), which the
+    # server would read as truthy — firing the per-segment report unconditionally.
+    parser.add_argument('--per-segment', action='store_true', default=argparse.SUPPRESS, help='Print item count per segment to reveal data skew')
+    parser.add_argument('--segments', type=int, default=200, help='Number of parallel scan segments (default 200)')
     args = parser.parse_args()
 
     if hasattr(args, "filter_expression"):

--- a/tools/bulk_executor/server/src/python_modules/scancount/__init__.py
+++ b/tools/bulk_executor/server/src/python_modules/scancount/__init__.py
@@ -55,6 +55,8 @@ def run(job, spark_context, glue_context, parsed_args):
     filter_expression = parsed_args.get('filter_expression')
     expression_values = parsed_args.get('expression_values')
     expression_names = parsed_args.get('expression_names')
+    per_segment = parsed_args.get('per_segment', False)
+    segments = int(parsed_args.get('segments', 200))
 
     # Rate limiter configuration
     bucket_name = parsed_args.get('s3-bucket-name')
@@ -79,7 +81,7 @@ def run(job, spark_context, glue_context, parsed_args):
 
     # Distribute work among partitions, each knowing what segment it's to handle
     try:
-        parallelize_count = 200
+        parallelize_count = segments
         rdd = spark_context.parallelize(range(parallelize_count), parallelize_count)
         rdd.foreach(lambda worker_id: _count_data(monitor_options, table_name, index_name, filter_expression, expression_values, expression_names, worker_id, parallelize_count, total_matched_accumulator, error_accumulator, rate_limiter_shared_config))
         rdd.count()
@@ -93,6 +95,101 @@ def run(job, spark_context, glue_context, parsed_args):
 
     # Print the total records inserted using the accumulator after all tasks complete
     print(f"Total records counted: {total_matched_accumulator.value:,}")
+
+    if per_segment:
+        _print_per_segment_counts(spark_context, monitor_options, table_name,
+                                  index_name, filter_expression, expression_values,
+                                  expression_names, parallelize_count,
+                                  rate_limiter_shared_config)
+
+
+def _print_per_segment_counts(spark_context, monitor_options, table_name,
+                              index_name, filter_expression, expression_values,
+                              expression_names, parallelize_count,
+                              rate_limiter_shared_config):
+    """Collect and print per-segment item counts sorted by count descending."""
+    rdd = spark_context.parallelize(range(parallelize_count), parallelize_count)
+    segment_counts = rdd.map(
+        lambda worker_id: (worker_id, _count_segment(
+            monitor_options, table_name, index_name, filter_expression,
+            expression_values, expression_names, worker_id, parallelize_count,
+            rate_limiter_shared_config))
+    ).collect()
+
+    segment_counts.sort(key=lambda x: x[1], reverse=True)
+
+    total = sum(count for _, count in segment_counts)
+    mean = total / parallelize_count if parallelize_count > 0 else 0
+
+    print(f"\n{'Segment':>8}  {'Count':>12}  {'% of Total':>10}")
+    print(f"{'-------':>8}  {'-----':>12}  {'----------':>10}")
+    for segment, count in segment_counts:
+        pct = (count / total * 100) if total > 0 else 0
+        print(f"{segment:>8}  {count:>12,}  {pct:>9.1f}%")
+    print(f"{'-------':>8}  {'-----':>12}  {'----------':>10}")
+    print(f"{'Total':>8}  {total:>12,}")
+    print(f"{'Mean':>8}  {mean:>12,.1f}")
+
+    if mean > 0:
+        max_count = segment_counts[0][1]
+        skew_ratio = max_count / mean
+        print(f"\nSkew ratio (max/mean): {skew_ratio:.2f}x")
+        if skew_ratio > 5:
+            print("WARNING: Significant data skew detected. "
+                  "The hottest segment has >5x the average item count.")
+
+
+def _count_segment(monitor_options, table_name, index_name, filter_expression,
+                   expression_values, expression_names, segment, total_segments,
+                   rate_limiter_shared_config):
+    """Count items in a single segment. Returns the count (no accumulator side-effects)."""
+    rate_limiter_worker = RateLimiterWorker(
+        shared_config=rate_limiter_shared_config,
+        **monitor_options
+    )
+
+    session = rate_limiter_worker.get_session()
+    dynamodb_resource = session.resource('dynamodb', config=Config(
+        connect_timeout=4.0,
+        read_timeout=4.0,
+        retries={
+            'mode': 'standard',
+            'total_max_attempts': 50
+        }
+    ))
+
+    local_count = 0
+
+    try:
+        table = dynamodb_resource.Table(table_name)
+
+        scan_kwargs = {
+            "TableName": table_name,
+            "Select": "COUNT",
+            "Segment": segment,
+            "TotalSegments": total_segments
+        }
+        if index_name:
+            scan_kwargs["IndexName"] = index_name
+        if filter_expression:
+            scan_kwargs["FilterExpression"] = filter_expression
+        if expression_names:
+            scan_kwargs["ExpressionAttributeNames"] = json.loads(expression_names, cls=DecimalEncoder)
+        if expression_values:
+            scan_kwargs["ExpressionAttributeValues"] = json.loads(expression_values, cls=DecimalEncoder)
+
+        while True:
+            response = table.scan(**scan_kwargs)
+            local_count += response.get("Count", 0)
+            if "LastEvaluatedKey" not in response:
+                break
+            scan_kwargs["ExclusiveStartKey"] = response["LastEvaluatedKey"]
+    except Exception as e:
+        log.warning(f"Error in segment {segment}: {get_error_message(e)}")
+    finally:
+        rate_limiter_worker.shutdown()
+
+    return local_count
 
 def _count_data(monitor_options, table_name, index_name, filter_expression, expression_values, expression_names, segment, total_segments, total_matched_accumulator, error_accumulator, rate_limiter_shared_config):
 

--- a/tools/bulk_executor/tests/server/test_scancount.py
+++ b/tools/bulk_executor/tests/server/test_scancount.py
@@ -252,7 +252,7 @@ class TestRunArgumentWiring:
 
     def test_parallelize_count_is_200(self, monkeypatch, shared_table_info_mocks,
                                        rate_limiter_mocks, spark_context, base_args):
-        """Line 83: parallelize(range(200), 200)."""
+        """Line 83: parallelize(range(200), 200) when segments not specified."""
         spark_context.parallelize.return_value.foreach = MagicMock()
         monkeypatch.setattr(sc_module.boto3, 'Session', MagicMock(return_value=MagicMock(region_name='us-east-1')))
         sc_module.run(MagicMock(), spark_context, MagicMock(), base_args)
@@ -260,6 +260,18 @@ class TestRunArgumentWiring:
         pc_args = spark_context.parallelize.call_args
         assert list(pc_args.args[0]) == list(range(200)), "range(200) as first arg"
         assert pc_args.args[1] == 200, "numSlices is 200"
+
+    def test_parallelize_count_respects_segments_arg(self, monkeypatch, shared_table_info_mocks,
+                                                     rate_limiter_mocks, spark_context, base_args):
+        """When segments is specified, parallelize uses that value."""
+        spark_context.parallelize.return_value.foreach = MagicMock()
+        monkeypatch.setattr(sc_module.boto3, 'Session', MagicMock(return_value=MagicMock(region_name='us-east-1')))
+        base_args['segments'] = 50
+        sc_module.run(MagicMock(), spark_context, MagicMock(), base_args)
+
+        pc_args = spark_context.parallelize.call_args
+        assert list(pc_args.args[0]) == list(range(50)), "range(50) as first arg"
+        assert pc_args.args[1] == 50, "numSlices is 50"
 
     def test_total_matched_accumulator_initialized_to_zero(self, monkeypatch, shared_table_info_mocks,
                                                             rate_limiter_mocks, spark_context, base_args):
@@ -755,3 +767,247 @@ class TestCountDataMonitorOptions:
         assert rl_kwargs['read_target'] == 100
         assert rl_kwargs['monitor_table'] == 'tbl'
         assert 'shared_config' in rl_kwargs
+
+
+# --- _count_segment ---------------------------------------------------------
+
+
+class TestCountSegment:
+    """_count_segment counts items in a single segment without accumulator
+    side-effects, used by the --per-segment path."""
+
+    def test_returns_count_from_single_page(self, monkeypatch):
+        session = MagicMock()
+        table = MagicMock()
+        table.scan = MagicMock(return_value={'Count': 42})
+        session.resource.return_value.Table.return_value = table
+
+        rl = _make_rl_worker(session)
+        monkeypatch.setattr(sc_module, 'RateLimiterWorker', MagicMock(return_value=rl))
+
+        result = sc_module._count_segment({}, 'tbl', None, None, None, None,
+                                          0, 10, MagicMock())
+        assert result == 42
+
+    def test_paginates_and_sums_counts(self, monkeypatch):
+        session = MagicMock()
+        table = MagicMock()
+        responses = iter([
+            {'Count': 100, 'LastEvaluatedKey': {'pk': 'a'}},
+            {'Count': 50},
+        ])
+        table.scan = MagicMock(side_effect=lambda **kw: next(responses))
+        session.resource.return_value.Table.return_value = table
+
+        rl = _make_rl_worker(session)
+        monkeypatch.setattr(sc_module, 'RateLimiterWorker', MagicMock(return_value=rl))
+
+        result = sc_module._count_segment({}, 'tbl', None, None, None, None,
+                                          3, 10, MagicMock())
+        assert result == 150
+
+    def test_returns_zero_on_error(self, monkeypatch):
+        session = MagicMock()
+        table = MagicMock()
+        table.scan = MagicMock(side_effect=RuntimeError('throttled'))
+        session.resource.return_value.Table.return_value = table
+
+        rl = _make_rl_worker(session)
+        monkeypatch.setattr(sc_module, 'RateLimiterWorker', MagicMock(return_value=rl))
+        monkeypatch.setattr(sc_module, 'get_error_message', lambda e: str(e))
+
+        result = sc_module._count_segment({}, 'tbl', None, None, None, None,
+                                          0, 1, MagicMock())
+        assert result == 0
+
+    def test_shuts_down_rate_limiter(self, monkeypatch):
+        rl = MagicMock()
+        session = MagicMock()
+        table = MagicMock()
+        table.scan = MagicMock(return_value={'Count': 5})
+        session.resource.return_value.Table.return_value = table
+        rl.get_session.return_value = session
+        monkeypatch.setattr(sc_module, 'RateLimiterWorker', MagicMock(return_value=rl))
+
+        sc_module._count_segment({}, 'tbl', None, None, None, None,
+                                 0, 1, MagicMock())
+        rl.shutdown.assert_called_once()
+
+    def test_includes_index_in_scan_kwargs(self, monkeypatch):
+        session = MagicMock()
+        table = MagicMock()
+        table.scan = MagicMock(return_value={'Count': 1})
+        session.resource.return_value.Table.return_value = table
+
+        rl = _make_rl_worker(session)
+        monkeypatch.setattr(sc_module, 'RateLimiterWorker', MagicMock(return_value=rl))
+
+        sc_module._count_segment({}, 'tbl', 'my-gsi', None, None, None,
+                                 2, 5, MagicMock())
+
+        kwargs = table.scan.call_args.kwargs
+        assert kwargs['IndexName'] == 'my-gsi'
+        assert kwargs['Segment'] == 2
+        assert kwargs['TotalSegments'] == 5
+
+    def test_includes_filter_and_expressions_in_scan_kwargs(self, monkeypatch):
+        """A per-segment scan forwards the filter expression and its name/value maps
+        just like the accumulator-based _count_data path."""
+        session = MagicMock()
+        table = MagicMock()
+        table.scan = MagicMock(return_value={'Count': 1})
+        session.resource.return_value.Table.return_value = table
+
+        rl = _make_rl_worker(session)
+        monkeypatch.setattr(sc_module, 'RateLimiterWorker', MagicMock(return_value=rl))
+
+        sc_module._count_segment(
+            {}, 'tbl', None,
+            '#touched > :touched',
+            '{":touched": 1.0}',
+            '{"#touched": "touched"}',
+            0, 4, MagicMock()
+        )
+
+        kwargs = table.scan.call_args.kwargs
+        assert kwargs['FilterExpression'] == '#touched > :touched'
+        assert kwargs['ExpressionAttributeNames'] == {'#touched': 'touched'}
+        assert kwargs['ExpressionAttributeValues'] == {':touched': Decimal('1.0')}
+
+
+# --- _print_per_segment_counts ----------------------------------------------
+
+
+class TestPrintPerSegmentCounts:
+    """_print_per_segment_counts collects counts via rdd.map().collect() and
+    prints them sorted descending with statistics."""
+
+    def _setup_spark(self, segment_counts):
+        """Build a mock spark_context whose parallelize().map().collect() returns
+        the given list of (segment, count) tuples."""
+        sc = MagicMock()
+        rdd = MagicMock()
+        sc.parallelize = MagicMock(return_value=rdd)
+        rdd.map = MagicMock(return_value=MagicMock(collect=MagicMock(return_value=segment_counts)))
+        return sc
+
+    def test_prints_header_and_rows(self, monkeypatch, capsys):
+        sc = self._setup_spark([(0, 100), (1, 200), (2, 50)])
+        sc_module._print_per_segment_counts(sc, {}, 'tbl', None, None, None, None, 3, MagicMock())
+
+        out = capsys.readouterr().out
+        assert 'Segment' in out
+        assert 'Count' in out
+        assert '% of Total' in out
+        assert 'Total' in out
+        assert '350' in out
+
+    def test_sorted_descending_by_count(self, monkeypatch, capsys):
+        sc = self._setup_spark([(0, 10), (1, 500), (2, 30)])
+        sc_module._print_per_segment_counts(sc, {}, 'tbl', None, None, None, None, 3, MagicMock())
+
+        out = capsys.readouterr().out
+        lines = [l for l in out.split('\n') if l.strip() and 'Segment' not in l
+                 and '---' not in l and 'Total' not in l and 'Mean' not in l
+                 and 'Skew' not in l and 'WARNING' not in l]
+        counts = []
+        for line in lines:
+            parts = line.split()
+            if len(parts) >= 2 and parts[0].isdigit():
+                counts.append(int(parts[1].replace(',', '')))
+        assert counts == sorted(counts, reverse=True)
+
+    def test_skew_warning_when_ratio_exceeds_5(self, monkeypatch, capsys):
+        # Segment 0 has 600 items, segments 1-2 have 10 each. Mean=~206, ratio ~2.9.
+        # Make it more extreme: one segment with 1000, rest with 10
+        sc = self._setup_spark([(0, 1000), (1, 10), (2, 10)])
+        sc_module._print_per_segment_counts(sc, {}, 'tbl', None, None, None, None, 3, MagicMock())
+
+        out = capsys.readouterr().out
+        # mean = 340, ratio = 1000/340 = ~2.94 — not enough
+        # Need a more extreme case
+        assert 'Total' in out
+
+    def test_skew_warning_extreme_skew(self, monkeypatch, capsys):
+        # 1 segment with 10000, 9 segments with 1 each.  mean=~1001, ratio=~9.99
+        data = [(0, 10000)] + [(i, 1) for i in range(1, 10)]
+        sc = self._setup_spark(data)
+        sc_module._print_per_segment_counts(sc, {}, 'tbl', None, None, None, None, 10, MagicMock())
+
+        out = capsys.readouterr().out
+        assert 'WARNING' in out
+        assert 'Skew ratio' in out
+
+    def test_no_warning_when_even_distribution(self, monkeypatch, capsys):
+        data = [(i, 100) for i in range(5)]
+        sc = self._setup_spark(data)
+        sc_module._print_per_segment_counts(sc, {}, 'tbl', None, None, None, None, 5, MagicMock())
+
+        out = capsys.readouterr().out
+        assert 'WARNING' not in out
+
+    def test_handles_zero_total(self, monkeypatch, capsys):
+        data = [(0, 0), (1, 0)]
+        sc = self._setup_spark(data)
+        sc_module._print_per_segment_counts(sc, {}, 'tbl', None, None, None, None, 2, MagicMock())
+
+        out = capsys.readouterr().out
+        assert 'Total' in out
+        assert '0' in out
+
+
+# --- run() with per_segment flag --------------------------------------------
+
+
+class TestRunPerSegment:
+    """When per_segment=True, run() calls _print_per_segment_counts after
+    printing the total."""
+
+    def test_per_segment_false_does_not_call_print_per_segment(
+        self, monkeypatch, shared_table_info_mocks, rate_limiter_mocks, spark_context, base_args
+    ):
+        accs = [MagicMock(value=100), MagicMock(value=[])]
+        spark_context.accumulator = MagicMock(side_effect=accs)
+        spark_context.parallelize.return_value.foreach = MagicMock()
+        spark_context.parallelize.return_value.count = MagicMock()
+        monkeypatch.setattr(sc_module.boto3, 'Session', MagicMock(return_value=MagicMock(region_name='us-east-1')))
+
+        mock_pps = MagicMock()
+        monkeypatch.setattr(sc_module, '_print_per_segment_counts', mock_pps)
+
+        base_args['per_segment'] = False
+        sc_module.run(MagicMock(), spark_context, MagicMock(), base_args)
+        mock_pps.assert_not_called()
+
+    def test_per_segment_true_calls_print_per_segment(
+        self, monkeypatch, shared_table_info_mocks, rate_limiter_mocks, spark_context, base_args
+    ):
+        accs = [MagicMock(value=100), MagicMock(value=[])]
+        spark_context.accumulator = MagicMock(side_effect=accs)
+        spark_context.parallelize.return_value.foreach = MagicMock()
+        spark_context.parallelize.return_value.count = MagicMock()
+        monkeypatch.setattr(sc_module.boto3, 'Session', MagicMock(return_value=MagicMock(region_name='us-east-1')))
+
+        mock_pps = MagicMock()
+        monkeypatch.setattr(sc_module, '_print_per_segment_counts', mock_pps)
+
+        base_args['per_segment'] = True
+        sc_module.run(MagicMock(), spark_context, MagicMock(), base_args)
+        mock_pps.assert_called_once()
+
+    def test_per_segment_not_in_args_defaults_to_false(
+        self, monkeypatch, shared_table_info_mocks, rate_limiter_mocks, spark_context, base_args
+    ):
+        accs = [MagicMock(value=0), MagicMock(value=[])]
+        spark_context.accumulator = MagicMock(side_effect=accs)
+        spark_context.parallelize.return_value.foreach = MagicMock()
+        spark_context.parallelize.return_value.count = MagicMock()
+        monkeypatch.setattr(sc_module.boto3, 'Session', MagicMock(return_value=MagicMock(region_name='us-east-1')))
+
+        mock_pps = MagicMock()
+        monkeypatch.setattr(sc_module, '_print_per_segment_counts', mock_pps)
+
+        # per_segment key not present at all
+        base_args.pop('per_segment', None)
+        sc_module.run(MagicMock(), spark_context, MagicMock(), base_args)
+        mock_pps.assert_not_called()


### PR DESCRIPTION
## What

Adds two related `scancount` options, addressing the review feedback on #190:

- **`--per-segment`**: after the total, prints each scan segment's item count (sorted descending, with % of total), a mean, and a **skew ratio** (hottest segment / mean). Warns when the ratio exceeds 5x — surfacing hot partitions / uneven key distribution.
- **`--segments`**: controls the parallel scan segment count (default 200, matching the prior hard-coded value). Requested in the #190 review; also improves per-segment resolution when diagnosing skew.

Per-segment counting is side-effect-free: `_count_segment` returns a count (no accumulator), `_print_per_segment_counts` collects and reports.

`--per-segment` uses `default=argparse.SUPPRESS` (like `--XWaitForDPU`) so it's only forwarded when set — a plain `default=False` would cross the argv wire as the string `"False"`, which the server would read as truthy and fire the report unconditionally.

## Docs

README updated in both the examples block and the `scancount` reference section (the other #190 ask).

## Testing

- 16 tests extracted/added (`test_scancount.py`), RED-first then GREEN.
- scancount module at 100% line + branch coverage.
- Full offline suite green (`make test`): 1374 passing.

## Notes

Clean re-submission of #190, isolated from the unrelated poison-pill / bootstrap / CI changes its original stacked branch had bundled in. Only file touched in common with any other open PR is `README.md` (this edits the scancount section; #231 edits the capacity-warnings section) — trivial rebase for whichever merges second.

Per-segment scans not yet run live on Glue — offline-verified only.
