### PR TITLE
Adding cross-region support for diff

### DIFF
--- a/tools/bulk_executor/README.md
+++ b/tools/bulk_executor/README.md
@@ -79,7 +79,10 @@ Here are some example use cases:
 
 
 # Compare two tables for differences (uses segmented scans internally)
+# You can specify a name or a full ARN. Using an ARN lets you drive work cross-region and cross-account!
+# If going cross-account, you need a resource-based policy on the table to allow access.
 ./bulk diff --table t --table2 t2
+./bulk diff --table arn:aws:dynamodb:us-east-1:123456789012:table/t --table2 arn:aws:dynamodb:us-west-2:987654321098:table/t2
 
 # The default diff format is "keys" to show primary keys having changes with +/-/* for adds/removes/changes
 # Specifying the format "full" outputs the total items with +/- for before/after

--- a/tools/bulk_executor/README.md
+++ b/tools/bulk_executor/README.md
@@ -470,10 +470,34 @@ If you ever want to stop execution early, you can hit Control-C. The interrupt w
 #### `diff`
 
 * Performs parallel scans to two tables to compare for differences.
-* Requires `table` and `table2` parameters.
+* Requires `table` and `table2` parameters. Parameters can be table names or table ARNs. Using ARNs allows cross-account / cross-region access.
 * Accepts an optional `format` which can be `compact` (prints primary keys of all changed items with `+`, `-`, `*` for adds, removes, changes) or `full` (prints the full values of all changed items with `+` and `-` for before and after). Default is `compact`.
 * Accepts an optional `sample-fraction` to indicate a fraction of the two tables to compare, between 0.0 and 1.0. Can help with sanity checking that runs faster and at lower cost.
 * Accepts an optional `s3` parameter to output the result to S3.
+
+If doing cross-account, you need a resource-based policy to enable access. The following example RBP allows access from two specific roles in the 123456789012 account. The `role/ClientSide` is whatever role you have for the command-line Python program (so the client-side can describe the table and estimate costs). The `role/AWSGlueServiceRoleBulkDynamoDB-DdbReadWrite-us-east-1` is whatever role you have attached to the Glue job (so the `diff` can be performed).
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "CrossAccountIdentityBasedPolicy",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": [
+          "arn:aws:iam::123456789012:role/ClientSide",
+          "arn:aws:iam::123456789012:role/AWSGlueServiceRoleBulkDynamoDB-DdbReadOnly-us-east-1"
+        ]
+      },
+      "Action": [
+          "dynamodb:DescribeTable",
+          "dynamodb:Scan"
+      ],
+      "Resource": "arn:aws:dynamodb:us-west-1:599882009758:table/table2"
+    }
+  ]
+}
+```
 
 #### `load`
 

--- a/tools/bulk_executor/server/src/python_modules/diff.py
+++ b/tools/bulk_executor/server/src/python_modules/diff.py
@@ -12,7 +12,10 @@ from python_modules.shared.errors import get_error_message
 from python_modules.shared.table_info import (
     get_and_print_dynamodb_table_info,
     get_and_print_table_scan_cost,
-    get_dynamodb_throughput_configs
+    get_dynamodb_throughput_configs,
+    _region_from_table_ref,
+    infer_region,
+    _default_region
 )
 
 from python_modules.shared.rate_limiter import (
@@ -155,13 +158,17 @@ def log_diff(symbol, stream, concise_format):
 
 
 def diff_segment(stream_a_name, stream_b_name, monitor_options_a, monitor_options_b, segment, total_segments, consistent_read, concise_format, job_id, use_s3, bucket, schema_broadcast, rate_limiter_shared_config):
+    table1_region = infer_region(stream_a_name)
+    table2_region = infer_region(stream_b_name)
     rate_limiter_worker_a = RateLimiterWorker(
         shared_config=rate_limiter_shared_config,
+        region_name=table1_region,
         **monitor_options_a
     )
 
     rate_limiter_worker_b = RateLimiterWorker(
         shared_config=rate_limiter_shared_config,
+        region_name=table2_region,
         **monitor_options_b
     )
 
@@ -289,7 +296,7 @@ def diff_segment(stream_a_name, stream_b_name, monitor_options_a, monitor_option
     return diff[0:PRINT_LIMIT]
 
 def print_dynamodb_table_info(table_name, fraction=1.0):
-    region_name = boto3.Session().region_name
+    region_name = _region_from_table_ref(table_name) or _default_region()
     table_info = get_and_print_dynamodb_table_info(table_name)
     return get_and_print_table_scan_cost(table_info, region_name, fraction=fraction)
 
@@ -323,8 +330,10 @@ def run(job, spark_context, glue_context, parsed_args):
     print(f"TOTAL DynamoDB cost for scanning both tables (approx): ${total_cost:,.2f}")
     print()
 
-    schema1 = boto3.client("dynamodb").describe_table(TableName=table1)['Table']['KeySchema']
-    schema2 = boto3.client("dynamodb").describe_table(TableName=table2)['Table']['KeySchema']
+    table1_region = infer_region(table1)
+    table2_region = infer_region(table2)
+    schema1 = boto3.client("dynamodb", region_name=table1_region).describe_table(TableName=table1)['Table']['KeySchema']
+    schema2 = boto3.client("dynamodb", region_name=table2_region).describe_table(TableName=table2)['Table']['KeySchema']
 
     def extract_keys(schema):
         pk = next(e['AttributeName'] for e in schema if e['KeyType'] == 'HASH')
@@ -350,7 +359,8 @@ def run(job, spark_context, glue_context, parsed_args):
         job_run_id=job_id
     )
 
-    rate_limiter_aggregator = RateLimiterAggregator(shared_config=rate_limiter_shared_config)
+    # uses S3 from bootstrapping process -> should use same default region
+    rate_limiter_aggregator = RateLimiterAggregator(shared_config=rate_limiter_shared_config, region_name=_default_region())
 
     monitor_options_1 = get_dynamodb_throughput_configs(parsed_args, table1, modes=("read"), format="monitor")
     monitor_options_2 = get_dynamodb_throughput_configs(parsed_args, table2, modes=("read"), format="monitor")

--- a/tools/bulk_executor/server/src/python_modules/shared/export/pipeline/__init__.py
+++ b/tools/bulk_executor/server/src/python_modules/shared/export/pipeline/__init__.py
@@ -3,7 +3,7 @@ import time
 from ...bulk_executor_error import BulkExecutorError
 from ...logger import log
 from ...errors import ListAccumulator
-from ...table_info import get_dynamodb_throughput_configs
+from ...table_info import get_dynamodb_throughput_configs, infer_region
 from ...rate_limiter import RateLimiterAggregator, RateLimiterSharedConfig
 
 from .validator import validate
@@ -103,11 +103,12 @@ def run_export_pipeline(spark_context, parsed_args, transform_package, post_vali
     table_name = parsed_args.get('table')
     s3_path = parsed_args.get('s3_path')
     transform_name = parsed_args.get('transform')
+    region_name = infer_region(table_name)
 
     bucket_name = parsed_args.get('s3-bucket-name')
     job_run_id = parsed_args.get("JOB_RUN_ID")
     rate_limiter_shared_config = RateLimiterSharedConfig(bucket=bucket_name, job_run_id=job_run_id)
-    rate_limiter_aggregator = RateLimiterAggregator(shared_config=rate_limiter_shared_config)
+    rate_limiter_aggregator = RateLimiterAggregator(shared_config=rate_limiter_shared_config, region_name=region_name)
 
     monitor_options = get_dynamodb_throughput_configs(parsed_args, table_name, modes=["write"], format="monitor")
     log.debug(f"monitor_options {monitor_options}")

--- a/tools/bulk_executor/server/src/python_modules/shared/export/writers/batch_writer.py
+++ b/tools/bulk_executor/server/src/python_modules/shared/export/writers/batch_writer.py
@@ -6,6 +6,7 @@ from botocore.config import Config
 from typing import Dict, Any, Iterator
 from .base_writer import DynamoDBWriter
 from ...rate_limiter import RateLimiterWorker
+from ...table_info import infer_region
 from ...logger import log
 from ...errors import get_error_code, get_error_message
 
@@ -29,6 +30,7 @@ class BatchWriter(DynamoDBWriter):
         """Write partition using batch_writer for high performance."""
         local_count = 0
         rate_limiter_worker = None
+        region_name = infer_region(table_name)
         
         if debug_accumulator: debug_accumulator.add(["Batch writer function started"])
         
@@ -38,6 +40,7 @@ class BatchWriter(DynamoDBWriter):
             if debug_accumulator: debug_accumulator.add(["Rate limiter worker started"])
             rate_limiter_worker = RateLimiterWorker(
                 shared_config=rate_limiter_shared_config,
+                region_name=region_name,
                 **monitor_options,
             )
             session = rate_limiter_worker.get_session()

--- a/tools/bulk_executor/server/src/python_modules/shared/rate_limiter/__init__.py
+++ b/tools/bulk_executor/server/src/python_modules/shared/rate_limiter/__init__.py
@@ -30,13 +30,14 @@ class RateLimiterAggregator:
 
     Args:
         shared_config (RateLimiterSharedConfig): The shared config between Aggregator and Worker.
+        region_name (str): Name of region in which session should be created.
         modes (none to many list of ("read", "write")): The expected execution modes of the DynamoDB actions requiring rate limiting.
     """
-    def __init__(self, shared_config):
+    def __init__(self, shared_config, region_name=None):
         log.debug(f"Initializing...Bucket:{shared_config.bucket}, Prefix:{shared_config.bucket}")
 
         self.rate_limiter_monitor_aggregator = DistributedDynamoDBMonitorAggregator(
-            session=Session(),
+            session=Session(region_name=region_name),
             bucket=shared_config.bucket,
             prefix=shared_config.prefix,
         )
@@ -55,10 +56,11 @@ class RateLimiterWorker:
 
     Args:
         shared_config (RateLimiterSharedConfig): The shared config between Aggregator and Worker.
+        region_name (str): Name of region in which session should be created.
         monitor_options: The expected monitor options (see @table_info#get_dynamodb_throughput_configs for more info)
     """
-    def __init__(self, shared_config, **monitor_options):
-        self.session = Session()
+    def __init__(self, shared_config, region_name=None, **monitor_options):
+        self.session = Session(region_name=region_name)
         log.info(f"Rate limiter, init, monitor_options {monitor_options}")
         self.rate_limiter_monitor_worker = DistributedDynamoDBMonitorWorker(
             session=self.session,

--- a/tools/bulk_executor/server/src/python_modules/shared/table_info.py
+++ b/tools/bulk_executor/server/src/python_modules/shared/table_info.py
@@ -205,6 +205,8 @@ def get_and_print_dynamodb_table_info(table_name, index_name=None, quiet=False):
     }
 
 def get_and_print_table_scan_cost(table_info, region_name=None, fraction=1.0, numberOfScans=1):
+    # For cross-region scenarios, callers must pass region_name explicitly.
+    # The fallback to _default_region() is correct for single-region verbs.
     region_name = (
         region_name
         or table_info.get("region_name")
@@ -268,6 +270,8 @@ def get_and_print_table_write_cost(table_info, item_count, size_bytes):
     return 0
 
 def get_and_print_table_copy_write_cost(source_info, target_info):
+    # For cross-region, target_info should include "region_name" so pricing
+    # uses the target region. Falls back to default region for single-region usage.
     region_name = (
         target_info.get("region_name") # it's the target we price writes in
         or _default_region()
@@ -454,3 +458,16 @@ def _region_from_table_ref(table_ref: str) -> str | None:
         return None
     return arn.get("region")
 
+def infer_region(table_ref: str) -> str:
+    """
+    Infers the most appropriate region to use for a table reference:
+    If an ARN is provided, that region is used. Without an ARN,
+    we look on the client or the environment for the region.
+    If nothing succeeds, this results in an exception.
+    :param table_ref: reference to table like ARN or its name
+    :return: region in which we assume table to be
+    """
+    region_name = _region_from_table_ref(table_ref) or _default_region()
+    if not region_name:
+        raise ValueError(f"Unable to determine region_name from {table_ref} or environment.")
+    return region_name

--- a/tools/bulk_executor/tests/server/test_diff.py
+++ b/tools/bulk_executor/tests/server/test_diff.py
@@ -1559,3 +1559,339 @@ class TestAttributeTypeCoverage:
         a = {'pk': {'S': 'k'}, 'attr': {'BOOL': True}}
         b = {'pk': {'S': 'k'}, 'attr': {'BOOL': False}}
         assert not diff_module.item_matches(a, b)
+
+
+# --- Cross-Region Support ---------------------------------------------------
+
+# Load the real table_info module so we can reference its functions without
+# duplicating their implementations. The conftest mocks the module as Mock(),
+# but we can load it from disk using importlib (same pattern as test_table_info.py).
+# We load it under 'python_modules.shared.table_info' so relative imports
+# (from .logger, from .pricing) resolve to the conftest-registered mocks.
+import importlib.util
+from pathlib import Path
+
+_TABLE_INFO_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "server/src/python_modules/shared/table_info.py"
+)
+
+# Temporarily pop the mock, load the real module, then restore the mock for
+# other tests that rely on it being a Mock.
+_prev_table_info = sys.modules.get('python_modules.shared.table_info')
+_ti_spec = importlib.util.spec_from_file_location(
+    "python_modules.shared.table_info", str(_TABLE_INFO_PATH)
+)
+_real_table_info = importlib.util.module_from_spec(_ti_spec)
+sys.modules['python_modules.shared.table_info'] = _real_table_info
+_ti_spec.loader.exec_module(_real_table_info)
+# Restore the previous mock entry so diff_module (already imported) isn't affected
+if _prev_table_info is not None:
+    sys.modules['python_modules.shared.table_info'] = _prev_table_info
+
+_real_region_from_table_ref = _real_table_info._region_from_table_ref
+
+
+def _make_infer_region(default_region='us-east-1'):
+    """Create an infer_region function with a configurable default region fallback.
+
+    The real infer_region calls _default_region() which needs boto3.Session().
+    For tests we provide the default region explicitly.
+    """
+    def infer_region(table_ref):
+        region = _real_region_from_table_ref(table_ref)
+        if region:
+            return region
+        return default_region
+    return infer_region
+
+
+@pytest.fixture
+def patch_region_funcs(monkeypatch):
+    """Fixture to replace the mocked region functions on diff_module with real ones."""
+    monkeypatch.setattr(diff_module, '_region_from_table_ref', _real_region_from_table_ref)
+    monkeypatch.setattr(diff_module, 'infer_region', _make_infer_region('us-east-1'))
+
+
+class TestCrossRegionDiff:
+    """Tests for cross-region table comparison support."""
+
+    @patch.object(diff_module, 'RateLimiterWorker')
+    @patch.object(diff_module, 'SegmentStream')
+    def test_diff_segment_passes_different_regions_to_workers(self, mock_stream_cls, mock_rl, monkeypatch):
+        """Two ARNs from different regions should create workers with different regions."""
+        monkeypatch.setattr(diff_module, 'infer_region', _make_infer_region())
+
+        mock_rl_instance = MagicMock()
+        mock_rl_instance.get_session.return_value = MagicMock()
+        mock_rl.return_value = mock_rl_instance
+
+        # Setup empty streams
+        stream = MagicMock()
+        stream.is_finished.return_value = True
+        stream.head.return_value = None
+        stream.has_sort_key = False
+        stream.pk = 'pk'
+        mock_stream_cls.return_value = stream
+
+        arn1 = 'arn:aws:dynamodb:us-east-1:123456789012:table/t1'
+        arn2 = 'arn:aws:dynamodb:eu-west-1:123456789012:table/t2'
+        schema_broadcast = MagicMock()
+        schema_broadcast.value = {
+            'table1': {'pk': 'pk', 'sk': None},
+            'table2': {'pk': 'pk', 'sk': None}
+        }
+
+        diff_module.diff_segment(
+            arn1, arn2, {}, {},
+            0, 1, False, True, 'job1', False, None,
+            schema_broadcast, MagicMock()
+        )
+
+        calls = mock_rl.call_args_list
+        assert calls[0].kwargs['region_name'] == 'us-east-1'
+        assert calls[1].kwargs['region_name'] == 'eu-west-1'
+
+    @patch.object(diff_module, 'RateLimiterWorker')
+    @patch.object(diff_module, 'SegmentStream')
+    def test_diff_segment_same_region_both_workers(self, mock_stream_cls, mock_rl, monkeypatch):
+        """Two plain table names should use the default region for both workers."""
+        monkeypatch.setattr(diff_module, 'infer_region', _make_infer_region('us-west-2'))
+
+        mock_rl_instance = MagicMock()
+        mock_rl_instance.get_session.return_value = MagicMock()
+        mock_rl.return_value = mock_rl_instance
+
+        stream = MagicMock()
+        stream.is_finished.return_value = True
+        stream.head.return_value = None
+        stream.has_sort_key = False
+        stream.pk = 'pk'
+        mock_stream_cls.return_value = stream
+
+        schema_broadcast = MagicMock()
+        schema_broadcast.value = {
+            'table1': {'pk': 'pk', 'sk': None},
+            'table2': {'pk': 'pk', 'sk': None}
+        }
+
+        diff_module.diff_segment(
+            'table1', 'table2', {}, {},
+            0, 1, False, True, 'job1', False, None,
+            schema_broadcast, MagicMock()
+        )
+
+        calls = mock_rl.call_args_list
+        assert calls[0].kwargs['region_name'] == 'us-west-2'
+        assert calls[1].kwargs['region_name'] == 'us-west-2'
+
+    @patch.object(diff_module, 'RateLimiterWorker')
+    @patch.object(diff_module, 'SegmentStream')
+    def test_diff_segment_mixed_arn_and_plain_name(self, mock_stream_cls, mock_rl, monkeypatch):
+        """One ARN and one plain table name -> different region sources."""
+        monkeypatch.setattr(diff_module, 'infer_region', _make_infer_region('us-east-1'))
+
+        mock_rl_instance = MagicMock()
+        mock_rl_instance.get_session.return_value = MagicMock()
+        mock_rl.return_value = mock_rl_instance
+
+        stream = MagicMock()
+        stream.is_finished.return_value = True
+        stream.head.return_value = None
+        stream.has_sort_key = False
+        stream.pk = 'pk'
+        mock_stream_cls.return_value = stream
+
+        schema_broadcast = MagicMock()
+        schema_broadcast.value = {
+            'table1': {'pk': 'pk', 'sk': None},
+            'table2': {'pk': 'pk', 'sk': None}
+        }
+
+        arn1 = 'arn:aws:dynamodb:ap-southeast-1:123456789012:table/t1'
+        diff_module.diff_segment(
+            arn1, 'plain-table', {}, {},
+            0, 1, False, True, 'job1', False, None,
+            schema_broadcast, MagicMock()
+        )
+
+        calls = mock_rl.call_args_list
+        assert calls[0].kwargs['region_name'] == 'ap-southeast-1'
+        assert calls[1].kwargs['region_name'] == 'us-east-1'
+
+    def test_print_dynamodb_table_info_uses_arn_region(self, monkeypatch):
+        """When given an ARN, print_dynamodb_table_info passes the ARN region to scan cost."""
+        monkeypatch.setattr(diff_module, '_region_from_table_ref', _real_region_from_table_ref)
+        monkeypatch.setattr(diff_module, '_default_region', lambda: 'us-east-1')
+
+        mock_table_info = MagicMock(return_value={'item_count': 100})
+        mock_scan_cost = MagicMock(return_value=1.0)
+        monkeypatch.setattr(diff_module, 'get_and_print_dynamodb_table_info', mock_table_info)
+        monkeypatch.setattr(diff_module, 'get_and_print_table_scan_cost', mock_scan_cost)
+
+        arn = 'arn:aws:dynamodb:ap-northeast-1:123456789012:table/my-table'
+        diff_module.print_dynamodb_table_info(arn)
+
+        mock_scan_cost.assert_called_once()
+        call_args = mock_scan_cost.call_args
+        # region_name is the second positional arg
+        assert call_args[0][1] == 'ap-northeast-1'
+
+    def test_print_dynamodb_table_info_plain_name_uses_default(self, monkeypatch):
+        """Plain table name should use the default region."""
+        monkeypatch.setattr(diff_module, '_region_from_table_ref', _real_region_from_table_ref)
+        monkeypatch.setattr(diff_module, '_default_region', lambda: 'eu-central-1')
+
+        mock_table_info = MagicMock(return_value={'item_count': 100})
+        mock_scan_cost = MagicMock(return_value=0.5)
+        monkeypatch.setattr(diff_module, 'get_and_print_dynamodb_table_info', mock_table_info)
+        monkeypatch.setattr(diff_module, 'get_and_print_table_scan_cost', mock_scan_cost)
+
+        diff_module.print_dynamodb_table_info('my-table')
+
+        call_args = mock_scan_cost.call_args
+        assert call_args[0][1] == 'eu-central-1'
+
+    def test_run_creates_clients_with_different_regions(self, monkeypatch, capsys):
+        """run() should create DynamoDB clients with correct regions for each table."""
+        monkeypatch.setattr(diff_module, 'infer_region', _make_infer_region())
+        monkeypatch.setattr(diff_module, 'print_dynamodb_table_info', MagicMock(return_value=0.10))
+
+        boto3_mock = MagicMock()
+        client_mock = MagicMock()
+        client_mock.describe_table.return_value = {
+            'Table': {'KeySchema': [{'AttributeName': 'pk', 'KeyType': 'HASH'}]}
+        }
+        boto3_mock.client.return_value = client_mock
+        monkeypatch.setattr(diff_module, 'boto3', boto3_mock)
+        monkeypatch.setattr(diff_module, 'RateLimiterSharedConfig', MagicMock())
+        monkeypatch.setattr(diff_module, 'RateLimiterAggregator', MagicMock())
+        monkeypatch.setattr(diff_module, 'get_dynamodb_throughput_configs', MagicMock(return_value={}))
+
+        spark_context = MagicMock()
+        rdd = MagicMock()
+        spark_context.parallelize.return_value = rdd
+        rdd.map.return_value.collect.return_value = [[]]
+
+        args = {
+            'splits': '2',
+            'sample_fraction': '1.0',
+            'table': 'arn:aws:dynamodb:us-east-1:111111111111:table/t1',
+            'table2': 'arn:aws:dynamodb:eu-west-1:222222222222:table/t2',
+            'format': 'keys',
+            's3': None,
+            'JOB_RUN_ID': 'job-1',
+            's3-bucket-name': 'bucket',
+        }
+
+        diff_module.run(MagicMock(), spark_context, MagicMock(), args)
+
+        # Verify boto3.client was called with correct regions
+        client_calls = boto3_mock.client.call_args_list
+        dynamodb_calls = [c for c in client_calls if c[0][0] == 'dynamodb']
+        regions = [c[1]['region_name'] for c in dynamodb_calls]
+        assert 'us-east-1' in regions
+        assert 'eu-west-1' in regions
+
+    def test_run_aggregator_receives_default_region(self, monkeypatch, capsys):
+        """The RateLimiterAggregator should be initialized with the default region (for S3 bootstrapping)."""
+        monkeypatch.setattr(diff_module, 'infer_region', _make_infer_region())
+        monkeypatch.setattr(diff_module, '_default_region', lambda: 'us-east-1')
+        monkeypatch.setattr(diff_module, 'print_dynamodb_table_info', MagicMock(return_value=0.10))
+
+        client_mock = MagicMock()
+        client_mock.describe_table.return_value = {
+            'Table': {'KeySchema': [{'AttributeName': 'pk', 'KeyType': 'HASH'}]}
+        }
+        monkeypatch.setattr(diff_module, 'boto3', MagicMock(
+            client=MagicMock(return_value=client_mock)
+        ))
+        monkeypatch.setattr(diff_module, 'RateLimiterSharedConfig', MagicMock())
+        agg_cls = MagicMock()
+        monkeypatch.setattr(diff_module, 'RateLimiterAggregator', agg_cls)
+        monkeypatch.setattr(diff_module, 'get_dynamodb_throughput_configs', MagicMock(return_value={}))
+
+        spark_context = MagicMock()
+        rdd = MagicMock()
+        spark_context.parallelize.return_value = rdd
+        rdd.map.return_value.collect.return_value = [[]]
+
+        args = {
+            'splits': '2',
+            'sample_fraction': '1.0',
+            'table': 'arn:aws:dynamodb:ap-south-1:111111111111:table/t1',
+            'table2': 'arn:aws:dynamodb:eu-west-1:222222222222:table/t2',
+            'format': 'keys',
+            's3': None,
+            'JOB_RUN_ID': 'job-1',
+            's3-bucket-name': 'bucket',
+        }
+
+        diff_module.run(MagicMock(), spark_context, MagicMock(), args)
+
+        agg_cls.assert_called_once()
+        call_kwargs = agg_cls.call_args.kwargs
+        assert call_kwargs['region_name'] == 'us-east-1'
+
+
+# --- RateLimiter Region Support ---------------------------------------------
+
+class TestRateLimiterRegionSupport:
+    """Tests that RateLimiterWorker and RateLimiterAggregator forward region_name to Session."""
+
+    @patch.object(diff_module, 'SegmentStream')
+    def test_worker_receives_region_name_kwarg(self, mock_stream_cls, monkeypatch):
+        """Verify RateLimiterWorker is called with region_name from infer_region."""
+        monkeypatch.setattr(diff_module, 'infer_region', _make_infer_region('us-east-1'))
+
+        stream = MagicMock()
+        stream.is_finished.return_value = True
+        stream.head.return_value = None
+        stream.has_sort_key = False
+        stream.pk = 'pk'
+        mock_stream_cls.return_value = stream
+
+        schema_broadcast = MagicMock()
+        schema_broadcast.value = {
+            'table1': {'pk': 'pk', 'sk': None},
+            'table2': {'pk': 'pk', 'sk': None}
+        }
+
+        with patch.object(diff_module, 'RateLimiterWorker') as mock_rl:
+            mock_rl_instance = MagicMock()
+            mock_rl_instance.get_session.return_value = MagicMock()
+            mock_rl.return_value = mock_rl_instance
+
+            arn = 'arn:aws:dynamodb:sa-east-1:123456789012:table/t1'
+            diff_module.diff_segment(
+                arn, 'plain-table', {}, {},
+                0, 1, False, True, 'job1', False, None,
+                schema_broadcast, MagicMock()
+            )
+
+            # First worker gets ARN region, second gets default
+            first_call = mock_rl.call_args_list[0]
+            second_call = mock_rl.call_args_list[1]
+            assert first_call.kwargs['region_name'] == 'sa-east-1'
+            assert second_call.kwargs['region_name'] == 'us-east-1'
+
+    @patch.object(diff_module, 'RateLimiterWorker')
+    @patch.object(diff_module, 'SegmentStream')
+    def test_worker_none_region_when_no_arn_no_default(self, mock_stream_cls, mock_rl):
+        """If infer_region raises ValueError, diff_segment should propagate it."""
+        mock_rl_instance = MagicMock()
+        mock_rl.return_value = mock_rl_instance
+
+        schema_broadcast = MagicMock()
+        schema_broadcast.value = {
+            'table1': {'pk': 'pk', 'sk': None},
+            'table2': {'pk': 'pk', 'sk': None}
+        }
+
+        with patch.object(diff_module, 'infer_region', side_effect=ValueError("Unable to determine region_name")):
+            with pytest.raises(ValueError, match="Unable to determine region_name"):
+                diff_module.diff_segment(
+                    'table1', 'table2', {}, {},
+                    0, 1, False, True, 'job1', False, None,
+                    schema_broadcast, MagicMock()
+                )

--- a/tools/bulk_executor/tests/server/test_table_info.py
+++ b/tools/bulk_executor/tests/server/test_table_info.py
@@ -1349,3 +1349,54 @@ class TestGetThroughputConfigsReadRateFalsyConnector:
         )
         assert 'dynamodb.throughput.read' not in opts
         assert opts['dynamodb.throughput.write'] == '100'
+
+
+# --- infer_region -----------------------------------------------------------
+
+
+class TestInferRegion:
+    """Tests for the infer_region helper that resolves a region from ARN or environment."""
+
+    def test_arn_returns_arn_region(self, boto3_mock):
+        arn = 'arn:aws:dynamodb:ap-southeast-1:123456789012:table/my-table'
+        assert table_info.infer_region(arn) == 'ap-southeast-1'
+
+    def test_different_regions_from_arns(self, boto3_mock):
+        arn1 = 'arn:aws:dynamodb:us-east-1:111111111111:table/t1'
+        arn2 = 'arn:aws:dynamodb:eu-west-1:222222222222:table/t2'
+        assert table_info.infer_region(arn1) == 'us-east-1'
+        assert table_info.infer_region(arn2) == 'eu-west-1'
+
+    def test_plain_name_returns_session_region(self, boto3_mock):
+        boto3_mock.Session.return_value.region_name = 'us-west-2'
+        assert table_info.infer_region('plain-table-name') == 'us-west-2'
+
+    def test_plain_name_falls_back_to_aws_region_env(self, boto3_mock, monkeypatch):
+        boto3_mock.Session.return_value.region_name = None
+        monkeypatch.setenv('AWS_REGION', 'eu-west-1')
+        assert table_info.infer_region('plain-name') == 'eu-west-1'
+
+    def test_plain_name_falls_back_to_aws_default_region_env(self, boto3_mock, monkeypatch):
+        boto3_mock.Session.return_value.region_name = None
+        monkeypatch.delenv('AWS_REGION', raising=False)
+        monkeypatch.setenv('AWS_DEFAULT_REGION', 'ap-northeast-1')
+        assert table_info.infer_region('plain-name') == 'ap-northeast-1'
+
+    def test_no_region_available_raises_value_error(self, boto3_mock, monkeypatch):
+        boto3_mock.Session.return_value.region_name = None
+        monkeypatch.delenv('AWS_REGION', raising=False)
+        monkeypatch.delenv('AWS_DEFAULT_REGION', raising=False)
+        with pytest.raises(ValueError, match="Unable to determine region_name"):
+            table_info.infer_region('plain-name')
+
+    def test_arn_region_takes_priority_over_session(self, boto3_mock):
+        """Even if the session has a different region, the ARN region should win."""
+        boto3_mock.Session.return_value.region_name = 'us-west-2'
+        arn = 'arn:aws:dynamodb:ap-south-1:123456789012:table/my-table'
+        assert table_info.infer_region(arn) == 'ap-south-1'
+
+    def test_non_dynamodb_arn_falls_back_to_default(self, boto3_mock):
+        """An ARN for a non-DynamoDB service shouldn't extract a region from it."""
+        boto3_mock.Session.return_value.region_name = 'us-east-1'
+        arn = 'arn:aws:s3:::my-bucket'
+        assert table_info.infer_region(arn) == 'us-east-1'


### PR DESCRIPTION
*Issue #, if available:* n.a.

*Description of changes:* The bulk operation `diff` could only run in a single region because boto3 never gets set up with a region and therefore always infers the region from the environment. Consequently, DDBs in a different region is not found. This PR adds support for tables in different regions for the `diff` operation. If a table is provided as an ARN, the region from the ARN is used. If a table is provided with just its name, the region is still inferred from the environment, making this change backwards compatible. The aggregator is always using the default region since it must run in the region that the tools were bootstrapped in.

*Testing:* Several new unit tests test the new functionality:
`TestCrossRegionDiff`: tests `diff_segment()` and `run()` cross-region behavior
- Two ARNs from different regions create `RateLimiterWorker` instances with the correct per-table region
- Two plain table names both use the default region
- One ARN + one plain name results in the ARN region and default region respectively
- `print_dynamodb_table_info extracts the region` from an ARN and passes it to scan cost calculation
- Plain table name falls back to the default region
- run() creates DynamoDB clients with the correct regions for each table ARN
- `RateLimiterAggregator` is initialized with table1's inferred region

`TestRateLimiterRegionSupport`: tests `RateLimiterWorker` region forwarding:
- `RateLimiterWorker` receives the correct `region_name` kwarg from `infer_region`
- If `infer_region` raises ValueError, `diff_segment` propagates it

`TestInferRegion`: tests `infer_region()` and `_region_from_table_ref()`:
- A DynamoDB ARN returns the region embedded in the ARN
-Various ARNs correctly extract different regions
- A plain table name returns the boto3 session's region
- Falls back to `AWS_REGION` env var when session has no region
- Falls back to `AWS_DEFAULT_REGION` env var
- Raises `ValueError` when no region can be determined
- ARN region wins over whatever the session reports
- A non-DynamoDB ARN (e.g. S3) falls back to the default region

Additionally, I executed the possible variants of cross-account diffs after bootstrapping the executing account (due to not having two identically schemed tables available in a single account, I omitted the case "no table has ARN". Table names and account IDs altered):

```bash
# both tables have ARN
./bulk bootstrap --XRole READ-ONLY # default region set to eu-west-1, account is first table account
./bulk diff --table arn:aws:dynamodb:eu-west-1:123456789012:table/t --table2 arn:aws:dynamodb:eu-south-2:987654321098:table/t2 --format full

# first table has ARN
./bulk bootstrap --XRole READ-ONLY # default region set to eu-south-2, account is second table account
./bulk diff --table arn:aws:dynamodb:eu-west-1:123456789012:table/t --table2 t2 --format full

# second table has ARN
./bulk bootstrap --XRole READ-ONLY # default region set to eu-west-1, account is first table account
./bulk diff --table t --table2 arn:aws:dynamodb:eu-south-2:987654321098:table/t2 --format full
```

All queries execute successfully. Console correctly indicates that the prices from `eu-west-1` and `eu-south-2` are being used.

Also ran tests using `make test`: 1375 passed, 49 skipped, 9 warnings

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
