### PR TITLE
Region-correct metrics storage: Parquet lake + compaction

### DIFF
--- a/tools/dynamodb-optima/src/dynamodb_optima/analysis/capacity_mode.py
+++ b/tools/dynamodb-optima/src/dynamodb_optima/analysis/capacity_mode.py
@@ -268,15 +268,20 @@ class CapacityModeAnalyzer:
             (df["metric_name"] == "ConsumedWriteCapacityUnits") & (df["statistic"] == "Sum")
         ]
 
+        # Sum -> per-second rate: divide by the row's ACTUAL period_seconds, not a
+        # hardcoded 60. The lake stores mixed 60s (1-min) and 300s (5-min) rows;
+        # assuming 60 makes 5-min data read 5x too high.
         read_metrics = [
             MetricDataPoint(
                 metric_name="ConsumedReadCapacityUnits",
                 timestamp=ts,
                 table_name=table_name,
                 consumed_units=float(value),
-                units_per_second=float(value) / 60.0
+                units_per_second=float(value) / float(period) if period else float(value)
             )
-            for ts, value in zip(read_df["timestamp"], read_df["value"])
+            for ts, value, period in zip(
+                read_df["timestamp"], read_df["value"], read_df["period_seconds"]
+            )
         ]
 
         write_metrics = [
@@ -285,9 +290,11 @@ class CapacityModeAnalyzer:
                 timestamp=ts,
                 table_name=table_name,
                 consumed_units=float(value),
-                units_per_second=float(value) / 60.0
+                units_per_second=float(value) / float(period) if period else float(value)
             )
-            for ts, value in zip(write_df["timestamp"], write_df["value"])
+            for ts, value, period in zip(
+                write_df["timestamp"], write_df["value"], write_df["period_seconds"]
+            )
         ]
 
         return read_metrics, write_metrics

--- a/tools/dynamodb-optima/src/dynamodb_optima/analysis/capacity_mode.py
+++ b/tools/dynamodb-optima/src/dynamodb_optima/analysis/capacity_mode.py
@@ -6,7 +6,7 @@ with autoscaling simulation for accurate cost projections.
 """
 
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Optional, Tuple
 from decimal import Decimal
 from functools import lru_cache
@@ -14,6 +14,7 @@ from functools import lru_cache
 from ..config import get_settings
 from ..logging import get_logger
 from ..aws.pricing_collector import PricingCollector
+from ..database import lake
 from .autoscaling_sim import AutoscalingSimulator, MetricDataPoint
 
 logger = get_logger(__name__)
@@ -245,59 +246,50 @@ class CapacityModeAnalyzer:
         table_name: str,
         days: int
     ) -> Tuple[List[MetricDataPoint], List[MetricDataPoint]]:
-        """Get CloudWatch metrics from database."""
-        cutoff_date = datetime.now() - timedelta(days=days)
-        
-        # Get read metrics from metrics table (resource_name for both tables and GSIs)
-        read_results = self.connection.execute(
-            """
-            SELECT timestamp, value
-            FROM metrics
-            WHERE account_id = ? AND region = ? AND resource_name = ?
-                AND metric_name = 'ConsumedReadCapacityUnits'
-                AND statistic = 'Sum'
-                AND timestamp >= ?
-            ORDER BY timestamp ASC
-            """,
-            (account_id, region, table_name, cutoff_date)
-        ).fetchall()
-        
-        # Get write metrics
-        write_results = self.connection.execute(
-            """
-            SELECT timestamp, value
-            FROM metrics
-            WHERE account_id = ? AND region = ? AND resource_name = ?
-                AND metric_name = 'ConsumedWriteCapacityUnits'
-                AND statistic = 'Sum'
-                AND timestamp >= ?
-            ORDER BY timestamp ASC
-            """,
-            (account_id, region, table_name, cutoff_date)
-        ).fetchall()
-        
+        """Get CloudWatch metrics from the Parquet lake (table resource, not GSIs)."""
+        cutoff_date = datetime.now(timezone.utc) - timedelta(days=days)
+        end_date = datetime.now(timezone.utc)
+
+        df = lake.read_metrics(account_id, region, table_name, cutoff_date, end_date)
+
+        if df.empty:
+            return [], []
+
+        df = df.sort_values("timestamp")
+
+        # resource_name for the table itself equals table_name (GSIs use table_name#gsi_name
+        # and are not read here, matching the old query's implicit scope via resource_name = table_name).
+        df = df[df["resource_name"] == table_name]
+
+        read_df = df[
+            (df["metric_name"] == "ConsumedReadCapacityUnits") & (df["statistic"] == "Sum")
+        ]
+        write_df = df[
+            (df["metric_name"] == "ConsumedWriteCapacityUnits") & (df["statistic"] == "Sum")
+        ]
+
         read_metrics = [
             MetricDataPoint(
                 metric_name="ConsumedReadCapacityUnits",
-                timestamp=row[0],
+                timestamp=ts,
                 table_name=table_name,
-                consumed_units=float(row[1]),
-                units_per_second=float(row[1]) / 60.0
+                consumed_units=float(value),
+                units_per_second=float(value) / 60.0
             )
-            for row in read_results
+            for ts, value in zip(read_df["timestamp"], read_df["value"])
         ]
-        
+
         write_metrics = [
             MetricDataPoint(
                 metric_name="ConsumedWriteCapacityUnits",
-                timestamp=row[0],
+                timestamp=ts,
                 table_name=table_name,
-                consumed_units=float(row[1]),
-                units_per_second=float(row[1]) / 60.0
+                consumed_units=float(value),
+                units_per_second=float(value) / 60.0
             )
-            for row in write_results
+            for ts, value in zip(write_df["timestamp"], write_df["value"])
         ]
-        
+
         return read_metrics, write_metrics
     
     def _calculate_costs(

--- a/tools/dynamodb-optima/src/dynamodb_optima/analysis/utilization.py
+++ b/tools/dynamodb-optima/src/dynamodb_optima/analysis/utilization.py
@@ -495,9 +495,17 @@ class UtilizationAnalyzer:
             (df["metric_name"] == "ConsumedWriteCapacityUnits") & (df["statistic"] == "Sum")
         ]
 
-        # Convert Sum to per-second by dividing by 60 (1-minute period)
-        read_consumed = [v / 60.0 for v in read_df["value"].tolist()]
-        write_consumed = [v / 60.0 for v in write_df["value"].tolist()]
+        # Sum -> per-second rate: divide by each row's ACTUAL period_seconds, not a
+        # hardcoded 60. The lake stores mixed 60s and 300s rows; assuming 60 makes
+        # 5-min data read 5x too high.
+        read_consumed = [
+            v / float(p) if p else v
+            for v, p in zip(read_df["value"].tolist(), read_df["period_seconds"].tolist())
+        ]
+        write_consumed = [
+            v / float(p) if p else v
+            for v, p in zip(write_df["value"].tolist(), write_df["period_seconds"].tolist())
+        ]
 
         return read_consumed, write_consumed
     

--- a/tools/dynamodb-optima/src/dynamodb_optima/analysis/utilization.py
+++ b/tools/dynamodb-optima/src/dynamodb_optima/analysis/utilization.py
@@ -6,12 +6,13 @@ to reduce costs by adjusting capacity or switching to On-Demand mode.
 """
 
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Optional, Tuple
 from functools import lru_cache
 
 from ..logging import get_logger
 from ..aws.pricing_collector import PricingCollector
+from ..database import lake
 
 logger = get_logger(__name__)
 
@@ -377,6 +378,7 @@ class UtilizationAnalyzer:
         read_consumed, write_consumed = self._get_consumed_metrics(
             resource['account_id'],
             resource['region'],
+            resource['table_name'],
             resource['resource_name'],
             resource['resource_type'],
             days
@@ -464,49 +466,39 @@ class UtilizationAnalyzer:
         self,
         account_id: str,
         region: str,
+        table_name: str,
         resource_name: str,
         resource_type: str,
         days: int
     ) -> Tuple[List[float], List[float]]:
-        """Get consumed capacity metrics from database."""
-        cutoff = datetime.now() - timedelta(days=days)
-        
-        # Get read consumed capacity (per second, converted from Sum/period)
-        read_results = self.connection.execute(
-            """
-            SELECT value
-            FROM metrics
-            WHERE account_id = ?
-                AND region = ?
-                AND resource_name = ?
-                AND metric_name = 'ConsumedReadCapacityUnits'
-                AND statistic = 'Sum'
-                AND timestamp >= ?
-            ORDER BY timestamp
-            """,
-            (account_id, region, resource_name, cutoff)
-        ).fetchall()
-        
-        # Get write consumed capacity
-        write_results = self.connection.execute(
-            """
-            SELECT value
-            FROM metrics
-            WHERE account_id = ?
-                AND region = ?
-                AND resource_name = ?
-                AND metric_name = 'ConsumedWriteCapacityUnits'
-                AND statistic = 'Sum'
-                AND timestamp >= ?
-            ORDER BY timestamp
-            """,
-            (account_id, region, resource_name, cutoff)
-        ).fetchall()
-        
+        """Get consumed capacity metrics from the Parquet lake.
+
+        The lake is partitioned by (account_id, region, table_name); resource_name
+        (table_name or table_name#gsi_name) is filtered from the returned rows, same
+        scoping the old `metrics` table query did via the resource_name column.
+        """
+        cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+        end = datetime.now(timezone.utc)
+
+        df = lake.read_metrics(account_id, region, table_name, cutoff, end)
+
+        if df.empty:
+            return [], []
+
+        df = df.sort_values("timestamp")
+        df = df[df["resource_name"] == resource_name]
+
+        read_df = df[
+            (df["metric_name"] == "ConsumedReadCapacityUnits") & (df["statistic"] == "Sum")
+        ]
+        write_df = df[
+            (df["metric_name"] == "ConsumedWriteCapacityUnits") & (df["statistic"] == "Sum")
+        ]
+
         # Convert Sum to per-second by dividing by 60 (1-minute period)
-        read_consumed = [row[0] / 60.0 for row in read_results]
-        write_consumed = [row[0] / 60.0 for row in write_results]
-        
+        read_consumed = [v / 60.0 for v in read_df["value"].tolist()]
+        write_consumed = [v / 60.0 for v in write_df["value"].tolist()]
+
         return read_consumed, write_consumed
     
     def _generate_recommendation(

--- a/tools/dynamodb-optima/src/dynamodb_optima/aws/collector.py
+++ b/tools/dynamodb-optima/src/dynamodb_optima/aws/collector.py
@@ -461,9 +461,25 @@ class CloudWatchCollector(StateManagerMixin):
             region_resources = []
 
             for table_name in table_names:
+                # account_id is required downstream (lake partition path + gap detection).
+                # Resolve it from discovered metadata. A table not present in metadata
+                # was never discovered, so skip it with a warning rather than fail the run.
+                acct_rows = self.db_manager.execute_query(
+                    "SELECT account_id FROM table_metadata WHERE table_name = ? AND region = ?",
+                    [table_name, region],
+                )
+                if not acct_rows:
+                    logger.warning(
+                        f"Table '{table_name}' not found in {region} metadata "
+                        "(run discover first); skipping."
+                    )
+                    continue
+                account_id = acct_rows[0]["account_id"]
+
                 # Add table resource
                 region_resources.append(
                     {
+                        "account_id": account_id,
                         "resource_name": table_name,
                         "resource_type": "TABLE",
                         "table_name": table_name,
@@ -483,6 +499,7 @@ class CloudWatchCollector(StateManagerMixin):
                 for gsi in gsis:
                     region_resources.append(
                         {
+                            "account_id": account_id,
                             "resource_name": gsi["resource_name"],
                             "resource_type": "GSI",
                             "table_name": table_name,

--- a/tools/dynamodb-optima/src/dynamodb_optima/aws/collector.py
+++ b/tools/dynamodb-optima/src/dynamodb_optima/aws/collector.py
@@ -120,6 +120,7 @@ class CloudWatchCollector(StateManagerMixin):
         # Batch storage for metrics
         self._metric_batch: List[MetricDataPoint] = []
         self._batch_lock = asyncio.Lock()
+        self._current_run_id = "adhoc"
 
     def get_metric_configurations(
         self, service: str = "dynamodb", comprehensive: bool = False
@@ -177,6 +178,8 @@ class CloudWatchCollector(StateManagerMixin):
                 state = self._create_operation("COLLECTION", operation_id=operation_id)
         else:
             state = self._create_operation("COLLECTION", operation_id=operation_id)
+
+        self._current_run_id = state.operation_id
 
         # Initialize collection state if needed
         if not state.collection_state:
@@ -997,12 +1000,14 @@ class CloudWatchCollector(StateManagerMixin):
 
     def _direct_batch_insert(self, batch_data: List[Dict[str, Any]]) -> None:
         """Direct batch insert with performance timing."""
+        from ..database import lake
+
         insert_start = time.time()
         try:
-            self.db_manager.execute_batch_upsert_metrics(batch_data)
+            lake.write_metrics(batch_data, run_id=self._current_run_id)
             insert_duration_ms = (time.time() - insert_start) * 1000
             logger.debug(
-                f"DuckDB insert: {len(batch_data):,} metrics in {insert_duration_ms:.1f}ms "
+                f"Lake insert: {len(batch_data):,} metrics in {insert_duration_ms:.1f}ms "
                 f"({len(batch_data)/(insert_duration_ms/1000):.0f} records/sec)"
             )
         except Exception as e:
@@ -1071,64 +1076,24 @@ class CloudWatchCollector(StateManagerMixin):
         )
 
     def list_collected_metrics_summary(self) -> Dict[str, Any]:
-        """Get summary of collected metrics from database."""
-        try:
-            # Get metric counts by resource type
-            resource_query = """
-                SELECT resource_type, COUNT(*) as metric_count,
-                       COUNT(DISTINCT resource_name) as resource_count,
-                       COUNT(DISTINCT region) as region_count,
-                       MIN(timestamp) as earliest_metric,
-                       MAX(timestamp) as latest_metric
-                FROM metrics
-                GROUP BY resource_type
-            """
-            resource_stats = self.db_manager.execute_query(resource_query)
+        """Summarize collected metrics from the Parquet lake."""
+        import glob as _glob_mod
+        from ..paths import get_lake_dir
 
-            # Get metric counts by metric name
-            metric_query = """
-                SELECT metric_name, COUNT(*) as count,
-                       COUNT(DISTINCT resource_name) as resource_count
-                FROM metrics
-                GROUP BY metric_name
-                ORDER BY count DESC
-                LIMIT 10
-            """
-            metric_stats = self.db_manager.execute_query(metric_query)
+        pattern = str(get_lake_dir() / "**" / "*.parquet")
+        if not _glob_mod.glob(pattern, recursive=True):
+            return {"total_metrics": 0, "total_resources": 0, "total_regions": 0}
 
-            # Get recent collection activity
-            recent_query = """
-                SELECT DATE_TRUNC('day', timestamp) as date,
-                       COUNT(*) as metrics_collected
-                FROM metrics
-                WHERE timestamp >= CURRENT_DATE - INTERVAL '7 days'
-                GROUP BY DATE_TRUNC('day', timestamp)
-                ORDER BY date DESC
-            """
-            recent_stats = self.db_manager.execute_query(recent_query)
-
-            # Get total counts
-            total_query = """
-                SELECT COUNT(*) as total_metrics,
-                       COUNT(DISTINCT resource_name) as total_resources,
-                       COUNT(DISTINCT region) as total_regions
-                FROM metrics
-            """
-            totals = self.db_manager.execute_query(total_query)[0]
-
-            return {
-                "total_metrics": totals["total_metrics"],
-                "total_resources": totals["total_resources"],
-                "total_regions": totals["total_regions"],
-                "by_resource_type": resource_stats,
-                "top_metrics": metric_stats,
-                "recent_activity": recent_stats,
-                "last_updated": datetime.now(),
-            }
-
-        except Exception as e:
-            logger.error(f"Failed to get metrics summary: {e}")
-            return {"error": str(e)}
+        with self.db_manager.get_connection_context() as conn:
+            row = conn.execute(
+                f"""
+                SELECT COUNT(*) AS total_metrics,
+                       COUNT(DISTINCT resource_name) AS total_resources,
+                       COUNT(DISTINCT region) AS total_regions
+                FROM read_parquet('{pattern}', union_by_name=true)
+                """
+            ).fetchone()
+        return {"total_metrics": row[0], "total_resources": row[1], "total_regions": row[2]}
 
     # ========================================================================
     # OPTIMIZED CLOUDWATCH API BATCHING METHODS (Task 5.1)
@@ -1298,45 +1263,11 @@ class CloudWatchCollector(StateManagerMixin):
         Returns:
             Dict mapping metric key to latest timestamp, or empty dict if no data
         """
-        from datetime import timezone
-        
-        query = """
-            SELECT 
-                metric_name,
-                statistic,
-                period_seconds,
-                MAX(timestamp) as latest_timestamp
-            FROM metrics
-            WHERE account_id = ?
-              AND resource_name = ?
-              AND region = ?
-            GROUP BY metric_name, statistic, period_seconds
-        """
-        
-        try:
-            results = self.db_manager.execute_query(
-                query, [account_id, resource_name, region]
-            )
-            
-            coverage = {}
-            for row in results:
-                key = f"{row['metric_name']}:{row['statistic']}:{row['period_seconds']}"
-                timestamp = row['latest_timestamp']
-                
-                # Ensure timestamp is timezone-aware (UTC) for comparisons
-                if isinstance(timestamp, datetime) and timestamp.tzinfo is None:
-                    timestamp = timestamp.replace(tzinfo=timezone.utc)
-                
-                coverage[key] = timestamp
-            
-            return coverage
-            
-        except Exception as e:
-            logger.warning(
-                f"Failed to get latest timestamps for {resource_name}: {e}, "
-                "will collect full window"
-            )
-            return {}  # Empty dict means collect full window
+        from ..database import lake
+
+        # arg reorder: callsite gives (account_id, resource_name, region);
+        # lake.latest_timestamps wants (account_id, region, table_name).
+        return lake.latest_timestamps(account_id, region, resource_name)
 
     async def _collect_metrics_batch_optimized(
         self,

--- a/tools/dynamodb-optima/src/dynamodb_optima/aws/discovery.py
+++ b/tools/dynamodb-optima/src/dynamodb_optima/aws/discovery.py
@@ -89,6 +89,7 @@ class DiscoveryManager(StateManagerMixin):
         regions: List[str],
         operation_id: Optional[str] = None,
         resume_from_checkpoint: bool = False,
+        table_names: Optional[List[str]] = None,
     ) -> OperationState:
         """
         Discover all DynamoDB tables and GSIs across specified regions.
@@ -263,7 +264,9 @@ class DiscoveryManager(StateManagerMixin):
                 )
 
                 # Discover tables in this region (use ProgressTracker)
-                tables = await self._discover_tables_in_region(region, state)
+                tables = await self._discover_tables_in_region(
+                    region, state, table_names=table_names
+                )
                 collection_state.tables_discovered[region] = tables
 
                 # Discover GSIs for all tables in this region with progress tracking
@@ -378,44 +381,59 @@ class DiscoveryManager(StateManagerMixin):
         self.state_manager.save_checkpoint(state)
 
     async def _discover_tables_in_region(
-        self, region: str, state: OperationState
+        self, region: str, state: OperationState,
+        table_names: Optional[List[str]] = None,
     ) -> List[TableMetadata]:
-        """Discover all DynamoDB tables in a specific region."""
+        """Discover DynamoDB tables in a specific region.
+
+        If ``table_names`` is provided, skip the account-wide ``list_tables`` scan
+        and DescribeTable only those names (scoped discovery). Tables that do not
+        exist in this region are skipped with a warning via the per-table loop's
+        existing error handling. If ``table_names`` is None, discover ALL tables.
+        """
         tables = []
 
         try:
             async with await self.aws_client_manager.get_async_client(
                 "dynamodb", region
             ) as dynamodb:
-                # First, get all table names (scanning phase)
-                activity = ActivityIndicator(f"🔍 Scanning tables in {region}")
-                table_names_list = []
-                paginator_params = {"Limit": 100}  # Process in batches
-
-                while True:
-                    response = await dynamodb.list_tables(**paginator_params)
-                    table_names = response.get("TableNames", [])
-
-                    if not table_names:
-                        break
-
-                    table_names_list.extend(table_names)
-                    activity.update(
-                        f"Found {len(table_names_list)} table names in {region}..."
+                if table_names:
+                    # Scoped discovery: describe only the requested names, no enumeration.
+                    table_names_list = list(table_names)
+                    logger.info(
+                        f"Scoped discovery in {region}: describing "
+                        f"{len(table_names_list)} requested table(s), skipping list_tables"
                     )
+                else:
+                    # Full discovery: enumerate all table names (scanning phase).
+                    activity = ActivityIndicator(f"🔍 Scanning tables in {region}")
+                    table_names_list = []
+                    paginator_params = {"Limit": 100}  # Process in batches
 
-                    # Handle pagination
-                    last_evaluated_table_name = response.get("LastEvaluatedTableName")
-                    if last_evaluated_table_name:
-                        paginator_params["ExclusiveStartTableName"] = (
-                            last_evaluated_table_name
+                    while True:
+                        response = await dynamodb.list_tables(**paginator_params)
+                        table_names = response.get("TableNames", [])
+
+                        if not table_names:
+                            break
+
+                        table_names_list.extend(table_names)
+                        activity.update(
+                            f"Found {len(table_names_list)} table names in {region}..."
                         )
-                    else:
-                        break
 
-                activity.finish(
-                    f"Found {len(table_names_list)} tables to process in {region}"
-                )
+                        # Handle pagination
+                        last_evaluated_table_name = response.get("LastEvaluatedTableName")
+                        if last_evaluated_table_name:
+                            paginator_params["ExclusiveStartTableName"] = (
+                                last_evaluated_table_name
+                            )
+                        else:
+                            break
+
+                    activity.finish(
+                        f"Found {len(table_names_list)} tables to process in {region}"
+                    )
 
                 # Now process each table with progress bar (known total)
                 if table_names_list:

--- a/tools/dynamodb-optima/src/dynamodb_optima/aws/discovery.py
+++ b/tools/dynamodb-optima/src/dynamodb_optima/aws/discovery.py
@@ -174,7 +174,7 @@ class DiscoveryManager(StateManagerMixin):
                 state.collection_state.regions_to_discover = valid_regions
 
             # Perform discovery (state remains RUNNING)
-            await self._discover_regions(state)
+            await self._discover_regions(state, table_names=table_names)
 
             # Store discovered metadata in database (transaction commit happens here)
             await self._store_discovered_metadata(state)
@@ -209,8 +209,14 @@ class DiscoveryManager(StateManagerMixin):
             self.state_manager.save_checkpoint(state)
             raise
 
-    async def _discover_regions(self, state: OperationState) -> None:
-        """Discover tables and GSIs across all regions with progress tracking."""
+    async def _discover_regions(
+        self, state: OperationState, table_names: Optional[List[str]] = None
+    ) -> None:
+        """Discover tables and GSIs across all regions with progress tracking.
+
+        ``table_names`` (optional) scopes discovery to specific tables (passed through
+        to _discover_tables_in_region); None discovers all tables.
+        """
         collection_state = state.collection_state
 
         # Calculate remaining regions

--- a/tools/dynamodb-optima/src/dynamodb_optima/cli.py
+++ b/tools/dynamodb-optima/src/dynamodb_optima/cli.py
@@ -20,6 +20,7 @@ from .commands.core.health import health
 from .commands.core.status import status
 from .commands.core.version import version
 from .commands.discover import discover as discover_cmd
+from .commands.maintain import maintain as maintain_cmd
 from .config import get_settings
 from .logging import configure_logging, get_logger
 
@@ -76,6 +77,9 @@ main.add_command(collect_cur_cmd, name="collect-cur")
 main.add_command(analyze_capacity_cmd, name="analyze-capacity")
 main.add_command(analyze_table_class_cmd, name="analyze-table-class")
 main.add_command(analyze_utilization_cmd, name="analyze-utilization")
+
+# Add lake maintenance command
+main.add_command(maintain_cmd)
 
 
 # TODO: Implement list-recommendations command https://github.com/awslabs/amazon-dynamodb-tools/issues/120

--- a/tools/dynamodb-optima/src/dynamodb_optima/commands/collect.py
+++ b/tools/dynamodb-optima/src/dynamodb_optima/commands/collect.py
@@ -162,21 +162,20 @@ def collect(
         # Handle truncate flag
         metrics_before = 0
         if truncate:
-            click.echo("⚠️  Truncating metrics table...")
-            from ..database.connection import get_database_manager
-            db_manager = get_database_manager()
-            with db_manager.get_connection_context() as conn:
-                conn.execute("DELETE FROM metrics")
-            click.echo("✅ Metrics table truncated")
+            click.echo("⚠️  Truncating metrics lake...")
+            import shutil
+
+            from ..paths import get_lake_dir
+            lake_dir = get_lake_dir()
+            if lake_dir.exists():
+                shutil.rmtree(lake_dir)
+            click.echo("✅ Metrics lake truncated")
             click.echo()
         else:
-            # Get metrics count before collection
-            from ..database.connection import get_database_manager
-            db_manager = get_database_manager()
+            # Get metrics count before collection (metrics live in the Parquet lake now)
             try:
-                result_before = db_manager.execute_query("SELECT COUNT(*) as count FROM metrics")
-                metrics_before = result_before[0]['count'] if result_before else 0
-            except:
+                metrics_before = collector.list_collected_metrics_summary()["total_metrics"]
+            except Exception:
                 metrics_before = 0
         
         # Get unique accounts from table_metadata (per user's suggestion)
@@ -240,13 +239,10 @@ def collect(
         # Capture the actual operation_id from the result
         actual_operation_id = result.operation_id
         
-        # Get metrics count after collection
-        from ..database.connection import get_database_manager
-        db_manager = get_database_manager()
+        # Get metrics count after collection (metrics live in the Parquet lake now)
         try:
-            result_after = db_manager.execute_query("SELECT COUNT(*) as count FROM metrics")
-            metrics_after = result_after[0]['count'] if result_after else 0
-        except:
+            metrics_after = collector.list_collected_metrics_summary()["total_metrics"]
+        except Exception:
             metrics_after = 0
         
         new_metrics = metrics_after - metrics_before

--- a/tools/dynamodb-optima/src/dynamodb_optima/commands/collect.py
+++ b/tools/dynamodb-optima/src/dynamodb_optima/commands/collect.py
@@ -246,7 +246,16 @@ def collect(
             metrics_after = 0
         
         new_metrics = metrics_after - metrics_before
-        
+
+        # Compact landing -> served so files don't accumulate (end-of-write-run).
+        try:
+            from ..database import lake
+            lake.compact_pending()
+            click.echo("  Compacted metrics lake (landing -> served)")
+        except Exception as e:
+            # Non-fatal: reads never depend on compaction; log and move on.
+            click.echo(f"  Note: compaction skipped ({e})")
+
         # Display results
         click.echo()
         click.echo("✅ Collection completed successfully!")

--- a/tools/dynamodb-optima/src/dynamodb_optima/commands/discover.py
+++ b/tools/dynamodb-optima/src/dynamodb_optima/commands/discover.py
@@ -27,6 +27,11 @@ logger = get_logger(__name__)
 )
 @click.option("--profile", help="AWS profile name to use")
 @click.option(
+    "--tables",
+    help="Comma-separated table names to discover directly (DescribeTable per name, "
+    "skips the account-wide scan). Omit to discover ALL tables.",
+)
+@click.option(
     "--use-org",
     is_flag=True,
     help="Use AWS Organizations to discover accounts across entire organization",
@@ -57,6 +62,7 @@ def discover(
     ctx: click.Context,
     regions: Optional[str],
     profile: Optional[str],
+    tables: Optional[str],
     use_org: bool,
     org_role: Optional[str],
     skip_accounts: Optional[str],
@@ -227,12 +233,23 @@ def discover(
             click.echo(f"🔍 Starting discovery across {len(region_list)} regions...")
             click.echo()
             
+            # Parse optional scoped-discovery table list
+            table_list = (
+                [t.strip() for t in tables.split(",") if t.strip()] if tables else None
+            )
+            if table_list:
+                click.echo(
+                    f"🎯 Scoped discovery: {len(table_list)} specified table(s) "
+                    "(DescribeTable per name, skipping account scan)"
+                )
+
             # Run async discovery
             state = asyncio.run(
                 discovery_manager.discover_all_resources(
                     regions=region_list,
                     operation_id=operation_id,
                     resume_from_checkpoint=resume,
+                    table_names=table_list,
                 )
             )
             

--- a/tools/dynamodb-optima/src/dynamodb_optima/commands/maintain.py
+++ b/tools/dynamodb-optima/src/dynamodb_optima/commands/maintain.py
@@ -1,0 +1,18 @@
+"""Manual lake maintenance: compact landing -> served across the whole lake."""
+
+import click
+
+from ..database import lake
+
+
+@click.command(name="maintain")
+@click.pass_context
+def maintain(ctx: click.Context) -> None:
+    """Compact the metrics lake (merge landing files into served month shards)."""
+    click.echo("🧹 Compacting metrics lake (landing -> served)...")
+    lake.compact_pending()
+    click.echo("✅ Lake maintenance complete.")
+
+
+def get_maintain_command():
+    return maintain

--- a/tools/dynamodb-optima/src/dynamodb_optima/database/connection.py
+++ b/tools/dynamodb-optima/src/dynamodb_optima/database/connection.py
@@ -1160,23 +1160,38 @@ class DatabaseManager:
 
 # Global database manager instance
 _db_manager: Optional[DatabaseManager] = None
+# Guards singleton construction + one-time schema validation so concurrent callers
+# (e.g. parallel collection workers) don't each build a manager and race on schema
+# init (DuckDB "Catalog write-write conflict on create").
+_db_manager_lock = threading.Lock()
 
 
 def get_database_manager() -> DatabaseManager:
-    """Get database manager instance with lazy initialization."""
+    """Get database manager instance with lazy, thread-safe initialization.
+
+    Double-checked locking: the fast path (already-initialized) takes no lock; the
+    first-time construction + schema validation is serialized so concurrent callers
+    (parallel collection workers) don't each build a manager and race on schema init.
+    """
     global _db_manager
 
-    if _db_manager is None:
-        settings = get_settings()
-        _db_manager = DatabaseManager(
-            database_url=settings.database_url,
-            max_connections=settings.database_pool_size,
-        )
+    if _db_manager is not None:
+        return _db_manager
 
-        # Validate schema at startup
-        if not _db_manager.validate_schema_at_startup():
-            logger.error("Database schema validation failed at startup")
-            raise SchemaError("Database schema validation failed")
+    with _db_manager_lock:
+        # Re-check inside the lock: another thread may have initialized while we waited.
+        if _db_manager is None:
+            settings = get_settings()
+            manager = DatabaseManager(
+                database_url=settings.database_url,
+                max_connections=settings.database_pool_size,
+            )
+            # Validate schema at startup (once, under the lock).
+            if not manager.validate_schema_at_startup():
+                logger.error("Database schema validation failed at startup")
+                raise SchemaError("Database schema validation failed")
+            # Publish only after fully initialized so no thread sees a half-built manager.
+            _db_manager = manager
 
     return _db_manager
 

--- a/tools/dynamodb-optima/src/dynamodb_optima/database/connection.py
+++ b/tools/dynamodb-optima/src/dynamodb_optima/database/connection.py
@@ -23,7 +23,7 @@ from ..logging import get_logger
 logger = get_logger("dynamodb_optima.database")
 
 # Database schema version for migrations
-SCHEMA_VERSION = "1.0.0"
+SCHEMA_VERSION = "1.1.0"
 
 
 @dataclass
@@ -601,9 +601,6 @@ class DatabaseManager:
                 schema_version=SCHEMA_VERSION,
             )
 
-            # Create analysis views for dashboards
-            self._create_analysis_views(connection)
-
         except Exception as e:
             logger.error(f"Failed to initialize schema: {e}")
             raise SchemaError(f"Schema initialization failed: {e}")
@@ -612,12 +609,13 @@ class DatabaseManager:
         """Validate database schema integrity."""
         try:
             # Check required tables exist (comprehensive schema from schema.py)
+            # Note: `metrics` is no longer a DuckDB table — metrics live in the Parquet
+            # lake now (see database/lake.py).
             required_tables = [
                 "table_metadata",
                 "gsi_metadata",
                 "aws_accounts",
                 "pricing_data",
-                "metrics",
                 "capacity_mode_recommendations",
                 "table_class_recommendations",
                 "utilization_recommendations",
@@ -634,23 +632,6 @@ class DatabaseManager:
                 except Exception as e:
                     raise SchemaError(
                         f"Required table '{table}' not found or invalid: {e}"
-                    )
-
-            # Check required views exist
-            required_views = [
-                "normalized_metrics",
-                "metric_identifiers",
-                "daily_utilization",
-            ]
-
-            for view in required_views:
-                try:
-                    connection.execute(
-                        f"SELECT COUNT(*) FROM {view} LIMIT 1"
-                    ).fetchone()
-                except Exception as e:
-                    raise SchemaError(
-                        f"Required view '{view}' not found or invalid: {e}"
                     )
 
             # Validate schema version
@@ -670,22 +651,6 @@ class DatabaseManager:
 
             # Test basic operations on key tables
             try:
-                # Test metrics table structure
-                connection.execute(
-                    """
-                    SELECT table_name, resource_name, metric_name, timestamp, value
-                    FROM metrics LIMIT 1
-                """
-                ).fetchone()
-
-                # Test normalized_metrics view
-                connection.execute(
-                    """
-                    SELECT normalized_value, normalized_unit
-                    FROM normalized_metrics LIMIT 1
-                """
-                ).fetchone()
-                
                 # Test pricing_data table structure (use 'region_code' which is the PRIMARY column)
                 connection.execute(
                     """
@@ -727,96 +692,11 @@ class DatabaseManager:
         from .schema import initialize_database
         initialize_database(connection)
 
-        # Create normalized metrics view for utilization calculations
-        normalized_metrics_view_sql = """
-        CREATE OR REPLACE VIEW normalized_metrics AS
-        SELECT
-            *,
-            CASE
-                WHEN metric_name IN (
-                    'ConsumedReadCapacityUnits',
-                    'ConsumedWriteCapacityUnits'
-                ) AND statistic = 'Sum'
-                THEN value / period_seconds
-                ELSE value
-            END as normalized_value,
-
-            CASE
-                WHEN metric_name IN (
-                    'ConsumedReadCapacityUnits',
-                    'ConsumedWriteCapacityUnits'
-                ) AND statistic = 'Sum'
-                THEN 'Count/Second'
-                ELSE unit
-            END as normalized_unit
-        FROM metrics
-        """
-        connection.execute(normalized_metrics_view_sql)
-
-        # Create metric identifiers view for easy querying
-        metric_identifiers_view_sql = """
-        CREATE OR REPLACE VIEW metric_identifiers AS
-        SELECT
-            *,
-            CASE
-                WHEN operation IS NULL THEN
-                    CONCAT(metric_name, ':', statistic, ':', period_seconds)
-                WHEN operation_type IS NULL THEN
-                    CONCAT(metric_name, ':', statistic, ':', period_seconds,
-                           ':', operation)
-                ELSE
-                    CONCAT(metric_name, ':', statistic, ':', period_seconds,
-                           ':', operation, ':', operation_type)
-            END as metric_id
-        FROM metrics
-        """
-        connection.execute(metric_identifiers_view_sql)
-
-        # Create daily utilization materialized view for performance
-        daily_utilization_view_sql = """
-        CREATE OR REPLACE VIEW daily_utilization AS
-        SELECT
-            resource_name,
-            resource_type,
-            DATE(timestamp) as date,
-
-            -- Use normalized values for consumed capacity (converted to units/second)
-            AVG(CASE WHEN metric_name = 'ConsumedReadCapacityUnits'
-                     AND statistic = 'Sum' AND period_seconds = 300
-                     THEN value / period_seconds END) as avg_consumed_read_rate,
-            AVG(CASE WHEN metric_name = 'ProvisionedReadCapacityUnits'
-                     AND statistic = 'Average' AND period_seconds = 3600
-                     THEN value END) as avg_provisioned_read_rate,
-            AVG(CASE WHEN metric_name = 'ConsumedWriteCapacityUnits'
-                     AND statistic = 'Sum' AND period_seconds = 300
-                     THEN value / period_seconds END) as avg_consumed_write_rate,
-            AVG(CASE WHEN metric_name = 'ProvisionedWriteCapacityUnits'
-                     AND statistic = 'Average' AND period_seconds = 3600
-                     THEN value END) as avg_provisioned_write_rate,
-
-            -- Calculate utilization percentages
-            CASE WHEN AVG(CASE WHEN metric_name = 'ProvisionedReadCapacityUnits'
-                               AND statistic = 'Average' THEN value END) > 0
-                 THEN (AVG(CASE WHEN metric_name = 'ConsumedReadCapacityUnits'
-                                AND statistic = 'Sum' AND period_seconds = 300
-                                THEN value / period_seconds END) /
-                       AVG(CASE WHEN metric_name = 'ProvisionedReadCapacityUnits'
-                                AND statistic = 'Average' THEN value END)) * 100
-                 ELSE NULL END as read_utilization_percent,
-
-            CASE WHEN AVG(CASE WHEN metric_name = 'ProvisionedWriteCapacityUnits'
-                               AND statistic = 'Average' THEN value END) > 0
-                 THEN (AVG(CASE WHEN metric_name = 'ConsumedWriteCapacityUnits'
-                                AND statistic = 'Sum' AND period_seconds = 300
-                                THEN value / period_seconds END) /
-                       AVG(CASE WHEN metric_name = 'ProvisionedWriteCapacityUnits'
-                                AND statistic = 'Average' THEN value END)) * 100
-                 ELSE NULL END as write_utilization_percent
-        FROM metrics
-        WHERE timestamp >= CURRENT_DATE - INTERVAL '90 days'
-        GROUP BY resource_name, resource_type, DATE(timestamp)
-        """
-        connection.execute(daily_utilization_view_sql)
+        # NOTE: normalized_metrics / metric_identifiers / daily_utilization views used to be
+        # created here, all selecting FROM the DuckDB `metrics` table. That table has been
+        # removed (metrics now live in the Parquet lake, see database/lake.py), and DuckDB
+        # validates view definitions eagerly, so creating them would fail immediately with
+        # "Table with name metrics does not exist". Removed along with the table.
 
         # Create schema version table and insert current version
         schema_version_sql = """
@@ -836,36 +716,6 @@ class DatabaseManager:
         )
 
         logger.info(f"Database schema created successfully (version {SCHEMA_VERSION})")
-
-    def _create_analysis_views(self, connection: duckdb.DuckDBPyConnection) -> None:
-        """Create analysis views for dashboards and reporting."""
-        try:
-            from .view_manager import ViewManager
-
-            # Create view manager with existing connection
-            view_manager = ViewManager(self)
-
-            # Create capacity views (essential for cost optimization)
-            results = view_manager.create_all_views(categories=["capacity"])
-
-            successful_views = [name for name, success in results.items() if success]
-            failed_views = [name for name, success in results.items() if not success]
-
-            if successful_views:
-                logger.info(
-                    f"Created {len(successful_views)} analysis views",
-                    successful_views=successful_views,
-                )
-
-            if failed_views:
-                logger.warning(
-                    f"Failed to create {len(failed_views)} views",
-                    failed_views=failed_views,
-                )
-
-        except Exception as e:
-            logger.warning(f"Failed to create analysis views: {e}")
-            # Don't fail database initialization if views fail
 
     def get_schema_version(self) -> Optional[str]:
         """Get current schema version."""
@@ -1098,132 +948,6 @@ class DatabaseManager:
                 column_casts.append(col)
         return column_casts
 
-    def execute_batch_upsert_metrics(self, data: List[Dict[str, Any]]) -> None:
-        """Execute optimized bulk upsert for metrics using DuckDB's staging table approach."""
-        if not data:
-            return
-
-        # Lazy import - only needed conditionally
-        import json
-
-        # Lazy import - only needed conditionally
-        import os
-
-        # Lazy import - only needed conditionally
-        import tempfile
-
-        start_time = time.time()
-        record_count = len(data)
-
-        with self.get_connection_context() as conn:
-            try:
-                # Update batch metrics
-                with self._lock:
-                    self._performance_metrics.batch_operations += 1
-                    self._performance_metrics.batch_records_processed += record_count
-
-                # Create temporary JSON file for bulk loading
-                with tempfile.NamedTemporaryFile(
-                    mode="w", suffix=".json", delete=False
-                ) as temp_file:
-                    # Write data as NDJSON (newline-delimited JSON) for DuckDB
-                    for row in data:
-                        # Convert datetime to string for JSON serialization
-                        json_row = {}
-                        for key, value in row.items():
-                            if hasattr(value, "isoformat"):  # datetime object
-                                json_row[key] = value.isoformat()
-                            elif isinstance(value, dict):  # dimensions
-                                json_row[key] = json.dumps(value)
-                            else:
-                                json_row[key] = value
-                        temp_file.write(json.dumps(json_row) + "\n")
-
-                    temp_file_path = temp_file.name
-
-                try:
-                    # Create staging table and load data from JSON file - DuckDB's optimal approach
-                    staging_table_name = f"staging_metrics_{int(time.time() * 1000000)}"  # Use microseconds for uniqueness
-
-                    conn.execute(
-                        f"""
-                        CREATE TEMPORARY TABLE {staging_table_name} AS
-                        SELECT
-                            account_id,
-                            table_name,
-                            resource_name,
-                            resource_type,
-                            metric_name,
-                            operation,
-                            operation_type,
-                            statistic,
-                            period_seconds,
-                            CAST(timestamp AS TIMESTAMP) as timestamp,
-                            CAST(value AS DOUBLE) as value,
-                            unit,
-                            region,
-                            dimensions,
-                            CURRENT_TIMESTAMP as created_at
-                        FROM read_ndjson_auto(?)
-                    """,
-                        [temp_file_path],
-                    )
-
-                    # Perform bulk merge operation using DuckDB's efficient staging approach
-                    conn.execute(
-                        f"""
-                        INSERT INTO metrics
-                        SELECT * FROM {staging_table_name}
-                        ON CONFLICT (account_id, resource_name, metric_name, timestamp, statistic, period_seconds)
-                        DO UPDATE SET
-                            value = EXCLUDED.value,
-                            unit = EXCLUDED.unit,
-                            dimensions = EXCLUDED.dimensions,
-                            operation = EXCLUDED.operation,
-                            operation_type = EXCLUDED.operation_type,
-                            resource_type = EXCLUDED.resource_type,
-                            table_name = EXCLUDED.table_name,
-                            region = EXCLUDED.region
-                    """
-                    )
-
-                    # Clean up staging table
-                    conn.execute(f"DROP TABLE {staging_table_name}")
-
-                    # Commit transaction (required for connection pooling)
-                    conn.commit()
-
-                    execution_time = time.time() - start_time
-                    logger.debug(
-                        f"Bulk upserted metrics using DuckDB staging table approach",
-                        record_count=record_count,
-                        execution_time_ms=round(execution_time * 1000, 2),
-                        throughput_records_per_sec=round(
-                            record_count / execution_time, 2
-                        ),
-                    )
-
-                finally:
-                    # Clean up temporary file
-                    try:
-                        os.unlink(temp_file_path)
-                    except Exception:
-                        pass
-
-            except Exception as e:
-                # Update failure metrics
-                with self._lock:
-                    self._performance_metrics.batch_failures += 1
-
-                execution_time = time.time() - start_time
-                logger.error(
-                    f"Bulk upsert failed for metrics",
-                    record_count=record_count,
-                    execution_time_ms=round(execution_time * 1000, 2),
-                    error=str(e),
-                )
-                raise DatabaseError(f"Bulk upsert failed: {e}")
-
     def get_table_info(self, table_name: str) -> Dict[str, Any]:
         """Get information about a table."""
         query = f"DESCRIBE {table_name}"
@@ -1250,7 +974,6 @@ class DatabaseManager:
         try:
             # Get table row counts and sizes
             tables = [
-                "metrics",
                 "table_metadata",
                 "gsi_metadata",
                 "cost_analyses",
@@ -1268,6 +991,26 @@ class DatabaseManager:
                     total_rows += count
                 except Exception:
                     stats[f"{table}_count"] = 0
+
+            # `metrics` is no longer a DuckDB table -- metrics now live in the Parquet
+            # lake (see database/lake.py). Count rows via a glob over the lake instead.
+            try:
+                import glob as _glob_mod
+
+                from ..paths import get_lake_dir
+
+                pattern = str(get_lake_dir() / "**" / "*.parquet")
+                if _glob_mod.glob(pattern, recursive=True):
+                    with self.get_connection_context() as conn:
+                        metrics_count = conn.execute(
+                            f"SELECT COUNT(*) FROM read_parquet('{pattern}', union_by_name=true)"
+                        ).fetchone()[0]
+                else:
+                    metrics_count = 0
+            except Exception:
+                metrics_count = 0
+            stats["metrics_count"] = metrics_count
+            total_rows += metrics_count
 
             stats["total_rows"] = total_rows
 

--- a/tools/dynamodb-optima/src/dynamodb_optima/database/lake.py
+++ b/tools/dynamodb-optima/src/dynamodb_optima/database/lake.py
@@ -91,6 +91,9 @@ def read_metrics(account_id: str, region: str, table_name: str, start, end):
 
     db = get_database_manager()
     with db.get_connection_context() as conn:
+        # TIMESTAMPTZ renders in the session tz; force UTC so reads are deterministic
+        # across machines/timezones (pooled connections may carry a non-UTC tz).
+        conn.execute("SET TimeZone='UTC'")
         return conn.execute(
             f"""
             SELECT * FROM read_parquet('{pattern}', union_by_name=true)
@@ -116,6 +119,8 @@ def latest_timestamps(account_id: str, region: str, table_name: str) -> dict:
 
     db = get_database_manager()
     with db.get_connection_context() as conn:
+        # Force UTC so timestamps are deterministic across machines/session tz.
+        conn.execute("SET TimeZone='UTC'")
         # Use .df() rather than .fetchall(): DuckDB's native TIMESTAMPTZ ->
         # Python datetime conversion in fetchall() requires the optional
         # 'pytz' package, which is not a project dependency. Pandas performs

--- a/tools/dynamodb-optima/src/dynamodb_optima/database/lake.py
+++ b/tools/dynamodb-optima/src/dynamodb_optima/database/lake.py
@@ -46,6 +46,7 @@ def write_metrics(rows: list[dict], run_id: str) -> None:
         groups.setdefault(key, []).append(r)
 
     import pandas as pd
+    import uuid
 
     db = get_database_manager()
     with db.get_connection_context() as conn:
@@ -63,15 +64,20 @@ def write_metrics(rows: list[dict], run_id: str) -> None:
                     lambda d: _json.dumps(d) if isinstance(d, dict) else d
                 )
 
+            # Unique per-write view name: pooled connections may be shared across
+            # concurrent writers, and a fixed name would let one writer's DataFrame
+            # clobber another's mid-COPY (data loss). uuid makes each registration
+            # collision-proof.
+            view = f"_lake_write_{uuid.uuid4().hex}"
             try:
-                conn.register("_lake_write_df", df)
+                conn.register(view, df)
                 conn.execute(
-                    f"COPY (SELECT * FROM _lake_write_df) TO '{tmp}' "
+                    f"COPY (SELECT * FROM {view}) TO '{tmp}' "
                     "(FORMAT PARQUET, COMPRESSION ZSTD)"
                 )
                 os.replace(tmp, final)
             finally:
-                conn.unregister("_lake_write_df")
+                conn.unregister(view)
                 if os.path.exists(tmp):
                     os.remove(tmp)
 

--- a/tools/dynamodb-optima/src/dynamodb_optima/database/lake.py
+++ b/tools/dynamodb-optima/src/dynamodb_optima/database/lake.py
@@ -148,6 +148,77 @@ def read_metrics(account_id: str, region: str, table_name: str, start, end):
         ).df()
 
 
+def compact_partition(account_id: str, region: str, table_name: str) -> None:
+    """Merge landing files for one partition into month-sharded served files.
+
+    Safe under concurrency: ignores in-flight *.tmp; per-partition lock (skip if held);
+    merges+dedups into served month shards via atomic rename; deletes ONLY the landing
+    files it snapshotted (files appearing mid-run are left for the next call).
+    """
+    import glob as _glob_mod
+    import pandas as pd
+    import uuid
+
+    landing = _landing_dir(account_id, region, table_name)
+    served = _served_dir(account_id, region, table_name)
+    os.makedirs(served, exist_ok=True)  # lock lives here
+
+    lock_path = served / ".compact.lock"
+    try:
+        fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        os.close(fd)
+    except FileExistsError:
+        logger.info(f"compact: {account_id}/{region}/{table_name} locked, skipping")
+        return
+
+    try:
+        snapshot = sorted(_glob_mod.glob(str(landing / "*.parquet")))
+        if not snapshot:
+            return
+
+        files_sql = ", ".join(f"'{f}'" for f in snapshot)
+        db = get_database_manager()
+        with db.get_connection_context() as conn:
+            conn.execute("SET TimeZone='UTC'")
+            land_df = conn.execute(
+                f"SELECT * FROM read_parquet([{files_sql}], union_by_name=true)"
+            ).df()
+            if land_df.empty:
+                for f in snapshot:
+                    if os.path.exists(f):
+                        os.remove(f)
+                return
+            months = sorted({t.strftime("%Y-%m")
+                             for t in pd.to_datetime(land_df["timestamp"], utc=True)})
+
+            for month in months:
+                shard = served / f"{month}.parquet"
+                shard_tmp = served / f"{month}.parquet.{uuid.uuid4().hex}.tmp"
+                sources = [f"'{f}'" for f in snapshot]
+                if shard.exists():
+                    sources.append(f"'{shard}'")
+                src_sql = ", ".join(sources)
+                conn.execute(
+                    f"""
+                    COPY (
+                        SELECT * FROM read_parquet([{src_sql}], union_by_name=true)
+                        WHERE strftime(timestamp, '%Y-%m') = '{month}'
+                        QUALIFY ROW_NUMBER() OVER (
+                            PARTITION BY {_DEDUP_KEY} ORDER BY ingest_time DESC
+                        ) = 1
+                    ) TO '{shard_tmp}' (FORMAT PARQUET, COMPRESSION ZSTD)
+                    """
+                )
+                os.replace(str(shard_tmp), str(shard))
+
+        for f in snapshot:
+            if os.path.exists(f):
+                os.remove(f)
+    finally:
+        if os.path.exists(lock_path):
+            os.remove(lock_path)
+
+
 def latest_timestamps(account_id: str, region: str, table_name: str) -> dict:
     """Return {"metric:statistic:period": max_timestamp} for gap-detection.
 

--- a/tools/dynamodb-optima/src/dynamodb_optima/database/lake.py
+++ b/tools/dynamodb-optima/src/dynamodb_optima/database/lake.py
@@ -219,6 +219,39 @@ def compact_partition(account_id: str, region: str, table_name: str) -> None:
             os.remove(lock_path)
 
 
+def compact_pending(partitions: list[tuple] | None = None) -> None:
+    """Compact landing files into served.
+
+    If ``partitions`` is given (list of (account, region, table)), compact those.
+    If None, first run the flat->landing migration, then scan the whole landing/ zone
+    and compact every partition with files. Per-partition failures are logged and
+    skipped (self-healing; one bad partition never aborts the batch).
+    """
+    import glob as _glob_mod
+
+    if partitions is None:
+        _migrate_flat_to_landing()
+        partitions = []
+        landing_root = get_lake_dir() / "landing"
+        pattern = str(landing_root / "account=*" / "region=*" / "table=*")
+        seen = set()
+        for d in _glob_mod.glob(pattern):
+            parts = {p.split("=", 1)[0]: p.split("=", 1)[1]
+                     for p in Path(d).parts if "=" in p}
+            key = (parts["account"], parts["region"], parts["table"])
+            if key not in seen:
+                seen.add(key)
+                partitions.append(key)
+
+    for account_id, region, table_name in partitions:
+        try:
+            compact_partition(account_id, region, table_name)
+        except Exception as e:
+            logger.warning(
+                f"compact: partition {account_id}/{region}/{table_name} failed: {e}"
+            )
+
+
 def latest_timestamps(account_id: str, region: str, table_name: str) -> dict:
     """Return {"metric:statistic:period": max_timestamp} for gap-detection.
 

--- a/tools/dynamodb-optima/src/dynamodb_optima/database/lake.py
+++ b/tools/dynamodb-optima/src/dynamodb_optima/database/lake.py
@@ -100,3 +100,42 @@ def read_metrics(account_id: str, region: str, table_name: str, start, end):
             """,
             [start, end],
         ).df()
+
+
+def latest_timestamps(account_id: str, region: str, table_name: str) -> dict:
+    """Return {"metric:statistic:period": max_timestamp} for gap-detection.
+
+    Empty dict if no data (caller collects the full window). Timezone-aware UTC.
+    """
+    import glob as _glob_mod
+
+    pattern = _glob(account_id, region, table_name)
+    if not _glob_mod.glob(pattern):
+        return {}
+
+    db = get_database_manager()
+    with db.get_connection_context() as conn:
+        # Use .df() rather than .fetchall(): DuckDB's native TIMESTAMPTZ ->
+        # Python datetime conversion in fetchall() requires the optional
+        # 'pytz' package, which is not a project dependency. Pandas performs
+        # its own tz-aware conversion in .df() without that dependency.
+        df = conn.execute(
+            f"""
+            SELECT metric_name, statistic, period_seconds,
+                   MAX(timestamp) AS latest
+            FROM read_parquet('{pattern}', union_by_name=true)
+            GROUP BY metric_name, statistic, period_seconds
+            """
+        ).df()
+
+    coverage = {}
+    for row in df.itertuples(index=False):
+        latest = row.latest
+        if latest is not None and hasattr(latest, "to_pydatetime"):
+            latest = latest.to_pydatetime()
+        if latest is not None and getattr(latest, "tzinfo", None) is None:
+            latest = latest.replace(tzinfo=timezone.utc)
+        else:
+            latest = latest.astimezone(timezone.utc) if latest is not None else None
+        coverage[f"{row.metric_name}:{row.statistic}:{row.period_seconds}"] = latest
+    return coverage

--- a/tools/dynamodb-optima/src/dynamodb_optima/database/lake.py
+++ b/tools/dynamodb-optima/src/dynamodb_optima/database/lake.py
@@ -1,0 +1,102 @@
+"""
+Metrics Parquet lake — region-partitioned, append-only, DuckDB-native.
+
+Sole owner of metrics lake I/O. Region-correctness is structural: region is in the
+partition path and the dedup key, so replicas cannot overwrite each other.
+
+Layout:
+    <lake_dir>/account=<id>/region=<r>/table=<t>/ingest_<run_id>.parquet   (landing)
+Readers union landing + served (served added in a later change).
+"""
+
+import os
+from datetime import datetime, timezone
+
+from ..logging import get_logger
+from ..paths import get_lake_dir
+from .connection import get_database_manager
+
+logger = get_logger("dynamodb_optima.database.lake")
+
+_DEDUP_KEY = (
+    "account_id, region, table_name, metric_name, timestamp, statistic, period_seconds"
+)
+
+
+def _partition_dir(account_id: str, region: str, table_name: str):
+    return (
+        get_lake_dir()
+        / f"account={account_id}"
+        / f"region={region}"
+        / f"table={table_name}"
+    )
+
+
+def write_metrics(rows: list[dict], run_id: str) -> None:
+    """Write metric rows to the lake as region-partitioned Parquet (atomic per file)."""
+    if not rows:
+        return
+
+    ingest_time = datetime.now(timezone.utc)
+
+    groups: dict[tuple, list[dict]] = {}
+    for r in rows:
+        key = (r["account_id"], r["region"], r["table_name"])
+        groups.setdefault(key, []).append(r)
+
+    import pandas as pd
+
+    db = get_database_manager()
+    with db.get_connection_context() as conn:
+        for (account_id, region, table_name), grp in groups.items():
+            part = _partition_dir(account_id, region, table_name)
+            os.makedirs(part, exist_ok=True)
+            final = part / f"ingest_{run_id}.parquet"
+            tmp = part / f"ingest_{run_id}.parquet.tmp"
+
+            df = pd.DataFrame(grp)
+            df["ingest_time"] = ingest_time
+            if "dimensions" in df.columns:
+                import json as _json
+                df["dimensions"] = df["dimensions"].apply(
+                    lambda d: _json.dumps(d) if isinstance(d, dict) else d
+                )
+
+            try:
+                conn.register("_lake_write_df", df)
+                conn.execute(
+                    f"COPY (SELECT * FROM _lake_write_df) TO '{tmp}' "
+                    "(FORMAT PARQUET, COMPRESSION ZSTD)"
+                )
+                os.replace(tmp, final)
+            finally:
+                conn.unregister("_lake_write_df")
+                if os.path.exists(tmp):
+                    os.remove(tmp)
+
+
+def _glob(account_id: str, region: str, table_name: str) -> str:
+    return str(_partition_dir(account_id, region, table_name) / "*.parquet")
+
+
+def read_metrics(account_id: str, region: str, table_name: str, start, end):
+    """Return a deduped pandas DataFrame of metrics for a resource + time range."""
+    import glob as _glob_mod
+
+    pattern = _glob(account_id, region, table_name)
+    if not _glob_mod.glob(pattern):
+        import pandas as pd
+        return pd.DataFrame()
+
+    db = get_database_manager()
+    with db.get_connection_context() as conn:
+        return conn.execute(
+            f"""
+            SELECT * FROM read_parquet('{pattern}', union_by_name=true)
+            WHERE timestamp BETWEEN ? AND ?
+            QUALIFY ROW_NUMBER() OVER (
+                PARTITION BY {_DEDUP_KEY} ORDER BY ingest_time DESC
+            ) = 1
+            """,
+            [start, end],
+        ).df()

--- a/tools/dynamodb-optima/src/dynamodb_optima/database/lake.py
+++ b/tools/dynamodb-optima/src/dynamodb_optima/database/lake.py
@@ -11,6 +11,7 @@ Readers union landing + served (served added in a later change).
 
 import os
 from datetime import datetime, timezone
+from pathlib import Path
 
 from ..logging import get_logger
 from ..paths import get_lake_dir
@@ -24,9 +25,20 @@ _DEDUP_KEY = (
 )
 
 
-def _partition_dir(account_id: str, region: str, table_name: str):
+def _landing_dir(account_id: str, region: str, table_name: str):
     return (
         get_lake_dir()
+        / "landing"
+        / f"account={account_id}"
+        / f"region={region}"
+        / f"table={table_name}"
+    )
+
+
+def _served_dir(account_id: str, region: str, table_name: str):
+    return (
+        get_lake_dir()
+        / "served"
         / f"account={account_id}"
         / f"region={region}"
         / f"table={table_name}"
@@ -51,7 +63,7 @@ def write_metrics(rows: list[dict], run_id: str) -> None:
     db = get_database_manager()
     with db.get_connection_context() as conn:
         for (account_id, region, table_name), grp in groups.items():
-            part = _partition_dir(account_id, region, table_name)
+            part = _landing_dir(account_id, region, table_name)
             os.makedirs(part, exist_ok=True)
             final = part / f"ingest_{run_id}.parquet"
             tmp = part / f"ingest_{run_id}.parquet.tmp"
@@ -82,18 +94,42 @@ def write_metrics(rows: list[dict], run_id: str) -> None:
                     os.remove(tmp)
 
 
-def _glob(account_id: str, region: str, table_name: str) -> str:
-    return str(_partition_dir(account_id, region, table_name) / "*.parquet")
+def _read_globs(account_id: str, region: str, table_name: str) -> list[str]:
+    return [
+        str(_landing_dir(account_id, region, table_name) / "*.parquet"),
+        str(_served_dir(account_id, region, table_name) / "*.parquet"),
+    ]
+
+
+def _migrate_flat_to_landing() -> None:
+    """One-time move of pre-CHANGE-2 flat files
+    (<lake>/account=.../region=.../table=.../ingest_*.parquet) into the landing/ zone.
+    Idempotent: no-op once nothing flat remains. landing/ and served/ dirs are NOT
+    named account=... so they are naturally excluded from the flat glob."""
+    import glob as _glob_mod
+    import shutil
+
+    lake = get_lake_dir()
+    flat_pattern = str(lake / "account=*" / "region=*" / "table=*" / "*.parquet")
+    for src in _glob_mod.glob(flat_pattern):
+        src_path = Path(src)
+        parts = {p.split("=", 1)[0]: p.split("=", 1)[1] for p in src_path.parts if "=" in p}
+        dest_dir = _landing_dir(parts["account"], parts["region"], parts["table"])
+        os.makedirs(dest_dir, exist_ok=True)
+        shutil.move(src, str(dest_dir / src_path.name))
 
 
 def read_metrics(account_id: str, region: str, table_name: str, start, end):
     """Return a deduped pandas DataFrame of metrics for a resource + time range."""
     import glob as _glob_mod
 
-    pattern = _glob(account_id, region, table_name)
-    if not _glob_mod.glob(pattern):
+    globs = _read_globs(account_id, region, table_name)
+    existing = [g for g in globs if _glob_mod.glob(g)]
+    if not existing:
         import pandas as pd
         return pd.DataFrame()
+
+    files_sql = ", ".join(f"'{g}'" for g in existing)
 
     db = get_database_manager()
     with db.get_connection_context() as conn:
@@ -102,7 +138,7 @@ def read_metrics(account_id: str, region: str, table_name: str, start, end):
         conn.execute("SET TimeZone='UTC'")
         return conn.execute(
             f"""
-            SELECT * FROM read_parquet('{pattern}', union_by_name=true)
+            SELECT * FROM read_parquet([{files_sql}], union_by_name=true)
             WHERE timestamp BETWEEN ? AND ?
             QUALIFY ROW_NUMBER() OVER (
                 PARTITION BY {_DEDUP_KEY} ORDER BY ingest_time DESC
@@ -119,9 +155,12 @@ def latest_timestamps(account_id: str, region: str, table_name: str) -> dict:
     """
     import glob as _glob_mod
 
-    pattern = _glob(account_id, region, table_name)
-    if not _glob_mod.glob(pattern):
+    globs = _read_globs(account_id, region, table_name)
+    existing = [g for g in globs if _glob_mod.glob(g)]
+    if not existing:
         return {}
+
+    files_sql = ", ".join(f"'{g}'" for g in existing)
 
     db = get_database_manager()
     with db.get_connection_context() as conn:
@@ -135,7 +174,7 @@ def latest_timestamps(account_id: str, region: str, table_name: str) -> dict:
             f"""
             SELECT metric_name, statistic, period_seconds,
                    MAX(timestamp) AS latest
-            FROM read_parquet('{pattern}', union_by_name=true)
+            FROM read_parquet([{files_sql}], union_by_name=true)
             GROUP BY metric_name, statistic, period_seconds
             """
         ).df()

--- a/tools/dynamodb-optima/src/dynamodb_optima/database/lake.py
+++ b/tools/dynamodb-optima/src/dynamodb_optima/database/lake.py
@@ -19,7 +19,8 @@ from .connection import get_database_manager
 logger = get_logger("dynamodb_optima.database.lake")
 
 _DEDUP_KEY = (
-    "account_id, region, table_name, metric_name, timestamp, statistic, period_seconds"
+    "account_id, region, table_name, resource_name, metric_name, timestamp, "
+    "statistic, period_seconds"
 )
 
 

--- a/tools/dynamodb-optima/src/dynamodb_optima/database/schema.py
+++ b/tools/dynamodb-optima/src/dynamodb_optima/database/schema.py
@@ -127,35 +127,6 @@ CREATE INDEX IF NOT EXISTS idx_pricing_operation ON pricing_data(operation);
 CREATE INDEX IF NOT EXISTS idx_pricing_collected ON pricing_data(collected_at);
 """
 
-# CloudWatch metrics schema (metrics is the actual table name used by collector)
-CLOUDWATCH_METRICS_SCHEMA = """
-CREATE TABLE IF NOT EXISTS metrics (
-    account_id VARCHAR NOT NULL,
-    table_name VARCHAR,
-    resource_name VARCHAR,
-    resource_type VARCHAR,
-    metric_name VARCHAR,
-    operation VARCHAR,
-    operation_type VARCHAR,
-    statistic VARCHAR,
-    period_seconds INTEGER,
-    timestamp TIMESTAMP,
-    value DOUBLE,
-    unit VARCHAR,
-    region VARCHAR,
-    dimensions JSON,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    PRIMARY KEY (account_id, resource_name, metric_name, timestamp, statistic, period_seconds)
-);
-
--- Optimized indexes for analytical queries
--- Note: Primary key (account_id, resource_name, metric_name, timestamp, statistic, period_seconds)
--- already provides efficient gap detection queries via MAX(timestamp)
-CREATE INDEX IF NOT EXISTS idx_metrics_account_table_time ON metrics(account_id, table_name, timestamp);
-CREATE INDEX IF NOT EXISTS idx_metrics_type_time ON metrics(resource_type, timestamp);
-CREATE INDEX IF NOT EXISTS idx_metrics_operation ON metrics(metric_name, operation, timestamp);
-"""
-
 # Capacity mode recommendations schema
 CAPACITY_MODE_RECOMMENDATIONS_SCHEMA = """
 CREATE TABLE IF NOT EXISTS capacity_mode_recommendations (
@@ -396,7 +367,6 @@ ALL_SCHEMAS = [
     GSI_METADATA_SCHEMA,
     AWS_ACCOUNTS_SCHEMA,
     PRICING_DATA_SCHEMA,
-    CLOUDWATCH_METRICS_SCHEMA,
     CAPACITY_MODE_RECOMMENDATIONS_SCHEMA,
     TABLE_CLASS_RECOMMENDATIONS_SCHEMA,
     UTILIZATION_RECOMMENDATIONS_SCHEMA,
@@ -421,7 +391,6 @@ def get_table_schemas() -> dict[str, str]:
         "gsi_metadata": GSI_METADATA_SCHEMA,
         "aws_accounts": AWS_ACCOUNTS_SCHEMA,
         "pricing_data": PRICING_DATA_SCHEMA,
-        "metrics": CLOUDWATCH_METRICS_SCHEMA,
         "capacity_mode_recommendations": CAPACITY_MODE_RECOMMENDATIONS_SCHEMA,
         "table_class_recommendations": TABLE_CLASS_RECOMMENDATIONS_SCHEMA,
         "utilization_recommendations": UTILIZATION_RECOMMENDATIONS_SCHEMA,

--- a/tools/dynamodb-optima/src/dynamodb_optima/database/view_manager.py
+++ b/tools/dynamodb-optima/src/dynamodb_optima/database/view_manager.py
@@ -158,7 +158,7 @@ class ViewManager:
         missing_deps = {}
 
         # Check if base tables exist
-        required_tables = ["metrics", "table_metadata", "gsi_metadata"]
+        required_tables = ["table_metadata", "gsi_metadata"]
 
         for table in required_tables:
             try:

--- a/tools/dynamodb-optima/src/dynamodb_optima/paths.py
+++ b/tools/dynamodb-optima/src/dynamodb_optima/paths.py
@@ -71,6 +71,16 @@ def get_checkpoints_dir() -> Path:
     return get_project_root() / "checkpoints"
 
 
+def get_lake_dir() -> Path:
+    """
+    Get the metrics Parquet lake directory.
+
+    Returns:
+        Path: <project_root>/data/metrics_lake
+    """
+    return get_data_dir() / "metrics_lake"
+
+
 def get_database_path() -> str:
     """
     Get default database file path.

--- a/tools/dynamodb-optima/tests/database/test_lake.py
+++ b/tools/dynamodb-optima/tests/database/test_lake.py
@@ -327,3 +327,26 @@ def test_compact_pending_continues_past_failing_partition(tmp_path, monkeypatch)
     (locked_served / ".compact.lock").write_bytes(b"")   # locked -> skipped
     lake.compact_pending()
     assert len(_served_files("a", "us-east-1", "good")) == 1  # good one still compacted
+
+
+def test_get_database_manager_concurrent_init_no_race(tmp_path, monkeypatch):
+    """Concurrent first-time get_database_manager() must not race on schema init
+    (DuckDB 'Catalog write-write conflict'). Regression for the --workers>1 collect failure."""
+    import threading
+    from dynamodb_optima import paths
+    monkeypatch.setattr(paths, "_project_root_override", tmp_path)
+    import dynamodb_optima.database.connection as conn
+    # force cold singleton
+    monkeypatch.setattr(conn, "_db_manager", None)
+
+    errs = []
+    def go():
+        try:
+            conn.get_database_manager()
+        except Exception as e:  # pragma: no cover
+            errs.append(repr(e))
+    threads = [threading.Thread(target=go) for _ in range(8)]
+    for t in threads: t.start()
+    for t in threads: t.join()
+    assert errs == [], f"concurrent init raced: {errs[:2]}"
+    assert conn._db_manager is not None

--- a/tools/dynamodb-optima/tests/database/test_lake.py
+++ b/tools/dynamodb-optima/tests/database/test_lake.py
@@ -121,3 +121,22 @@ def test_latest_timestamps_shape(tmp_path, monkeypatch):
 def test_latest_timestamps_empty(tmp_path, monkeypatch):
     lake = _lake(tmp_path, monkeypatch)
     assert lake.latest_timestamps("nope", "us-east-1", "t") == {}
+
+
+def test_read_metrics_returns_utc_regardless_of_session_tz(tmp_path, monkeypatch):
+    """Timestamps must come back in UTC even if the DuckDB session tz is local."""
+    lake = _lake(tmp_path, monkeypatch)
+    ts = datetime(2026, 6, 1, 9, 17, tzinfo=timezone.utc)
+    lake.write_metrics([_row("a", "us-east-1", "t", "m", ts, 1.0)], run_id="r1")
+
+    # Poison the pooled connection's session tz to a non-UTC zone before reading.
+    from dynamodb_optima.database.connection import get_database_manager
+    with get_database_manager().get_connection_context() as conn:
+        conn.execute("SET TimeZone='America/New_York'")
+
+    df = lake.read_metrics("a", "us-east-1", "t", ts, ts)
+    got = df["timestamp"].iloc[0]
+    # Underlying instant correct AND rendered in UTC (offset 0 / 'UTC').
+    assert got.tzinfo is not None
+    assert got.utcoffset().total_seconds() == 0
+    assert got.tz_convert("UTC").strftime("%Y-%m-%d %H:%M") == "2026-06-01 09:17"

--- a/tools/dynamodb-optima/tests/database/test_lake.py
+++ b/tools/dynamodb-optima/tests/database/test_lake.py
@@ -267,3 +267,63 @@ def test_compact_idempotent(tmp_path, monkeypatch):
     lake.compact_partition("a", "us-east-1", "t")
     lake.compact_partition("a", "us-east-1", "t")
     assert len(_served_files("a", "us-east-1", "t")) == 1
+
+
+def test_compact_pending_scans_all_partitions(tmp_path, monkeypatch):
+    lake = _lake(tmp_path, monkeypatch)
+    ts = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    lake.write_metrics([_row("a", "us-east-1", "t1", "m", ts, 1.0)], run_id="r1")
+    lake.write_metrics([_row("a", "us-west-2", "t2", "m", ts, 2.0)], run_id="r2")
+    lake.compact_pending()  # no args -> scan all landing partitions
+    assert len(_served_files("a", "us-east-1", "t1")) == 1
+    assert len(_served_files("a", "us-west-2", "t2")) == 1
+
+
+def test_compact_partition_skips_when_locked(tmp_path, monkeypatch):
+    lake = _lake(tmp_path, monkeypatch)
+    ts = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    lake.write_metrics([_row("a", "us-east-1", "t", "m", ts, 1.0)], run_id="r1")
+    from dynamodb_optima import paths
+    served = paths.get_lake_dir() / "served" / "account=a" / "region=us-east-1" / "table=t"
+    served.mkdir(parents=True, exist_ok=True)
+    (served / ".compact.lock").write_bytes(b"")   # pre-hold the lock
+    lake.compact_partition("a", "us-east-1", "t")  # must skip
+    landing = paths.get_lake_dir() / "landing" / "account=a" / "region=us-east-1" / "table=t"
+    import glob as g
+    assert g.glob(str(landing / "*.parquet"))   # landing untouched
+
+
+def test_compact_deletes_only_snapshotted_landing(tmp_path, monkeypatch):
+    """A landing file appearing AFTER the snapshot must survive (deleted set = snapshot only).
+    Hook os.remove (called only during the delete phase, after the snapshot) to drop a new
+    landing file once; that new file was never snapshotted so it must NOT be deleted."""
+    lake = _lake(tmp_path, monkeypatch)
+    from dynamodb_optima import paths
+    ts = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    lake.write_metrics([_row("a", "us-east-1", "t", "m", ts, 1.0)], run_id="r1")
+    landing = paths.get_lake_dir() / "landing" / "account=a" / "region=us-east-1" / "table=t"
+
+    created = {"done": False}
+    real_remove = lake.os.remove
+    def hooked_remove(path):
+        if not created["done"]:
+            (landing / "ingest_late.parquet").write_bytes(b"late")
+            created["done"] = True
+        real_remove(path)
+    monkeypatch.setattr(lake.os, "remove", hooked_remove)
+    lake.compact_partition("a", "us-east-1", "t")
+    monkeypatch.undo()
+    assert (landing / "ingest_late.parquet").exists()
+
+
+def test_compact_pending_continues_past_failing_partition(tmp_path, monkeypatch):
+    lake = _lake(tmp_path, monkeypatch)
+    ts = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    lake.write_metrics([_row("a", "us-east-1", "good", "m", ts, 1.0)], run_id="r1")
+    lake.write_metrics([_row("a", "us-east-1", "locked", "m", ts, 1.0)], run_id="r2")
+    from dynamodb_optima import paths
+    locked_served = paths.get_lake_dir() / "served" / "account=a" / "region=us-east-1" / "table=locked"
+    locked_served.mkdir(parents=True, exist_ok=True)
+    (locked_served / ".compact.lock").write_bytes(b"")   # locked -> skipped
+    lake.compact_pending()
+    assert len(_served_files("a", "us-east-1", "good")) == 1  # good one still compacted

--- a/tools/dynamodb-optima/tests/database/test_lake.py
+++ b/tools/dynamodb-optima/tests/database/test_lake.py
@@ -57,6 +57,20 @@ def test_read_metrics_dedups_latest_ingest(tmp_path, monkeypatch):
     assert df["value"].tolist() == [175.0]
 
 
+def test_read_metrics_dedup_key_distinguishes_resource_name(tmp_path, monkeypatch):
+    """A TABLE row and its GSI's row can share account/region/table/metric/timestamp/
+    statistic/period (only resource_name differs). Dedup must not collapse them."""
+    lake = _lake(tmp_path, monkeypatch)
+    ts = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    table_row = _row("a", "us-east-1", "t", "ConsumedReadCapacityUnits", ts, 60.0)
+    gsi_row = dict(table_row, resource_name="t#gsi1", resource_type="GSI", value=999.0)
+    lake.write_metrics([table_row], run_id="run_table")
+    lake.write_metrics([gsi_row], run_id="run_gsi")
+
+    df = lake.read_metrics("a", "us-east-1", "t", ts, ts)
+    assert sorted(df["value"].tolist()) == [60.0, 999.0]
+
+
 def test_read_metrics_empty_partition_returns_empty(tmp_path, monkeypatch):
     lake = _lake(tmp_path, monkeypatch)
     ts = datetime(2026, 6, 1, tzinfo=timezone.utc)

--- a/tools/dynamodb-optima/tests/database/test_lake.py
+++ b/tools/dynamodb-optima/tests/database/test_lake.py
@@ -140,3 +140,41 @@ def test_read_metrics_returns_utc_regardless_of_session_tz(tmp_path, monkeypatch
     assert got.tzinfo is not None
     assert got.utcoffset().total_seconds() == 0
     assert got.tz_convert("UTC").strftime("%Y-%m-%d %H:%M") == "2026-06-01 09:17"
+
+
+def test_write_metrics_concurrent_no_data_loss(tmp_path, monkeypatch):
+    """Concurrent writers must not clobber each other via a shared registered view name."""
+    lake = _lake(tmp_path, monkeypatch)
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+    from datetime import timedelta
+    base = datetime(2026, 6, 1, tzinfo=timezone.utc)
+
+    # Warm the DB once so first-access init isn't the thing under test.
+    from dynamodb_optima.database.connection import get_database_manager
+    with get_database_manager().get_connection_context() as c:
+        c.execute("SELECT 1")
+
+    def work(i):
+        region = ["us-east-1", "us-west-2", "eu-central-1", "eu-west-1"][i % 4]
+        # DISTINCT timestamp per row, else the dedup key collapses them and this
+        # would test dedup, not concurrency.
+        rows = [_row("acct", region, f"table{i}", "m", base + timedelta(minutes=j), float(j))
+                for j in range(50)]
+        lake.write_metrics(rows, run_id=f"run{i}")
+
+    errs = []
+    with ThreadPoolExecutor(max_workers=4) as ex:
+        futs = {ex.submit(work, i): i for i in range(16)}
+        for f in as_completed(futs):
+            try:
+                f.result()
+            except Exception as e:  # pragma: no cover
+                errs.append(repr(e))
+    assert errs == []
+
+    s = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    e = datetime(2027, 1, 1, tzinfo=timezone.utc)
+    for i in range(16):
+        region = ["us-east-1", "us-west-2", "eu-central-1", "eu-west-1"][i % 4]
+        df = lake.read_metrics("acct", region, f"table{i}", s, e)
+        assert len(df) == 50, f"table{i} lost data: got {len(df)} rows (view-name collision?)"

--- a/tools/dynamodb-optima/tests/database/test_lake.py
+++ b/tools/dynamodb-optima/tests/database/test_lake.py
@@ -1,0 +1,5 @@
+def test_get_lake_dir_under_data(tmp_path, monkeypatch):
+    from dynamodb_optima import paths
+    monkeypatch.setattr(paths, "_project_root_override", tmp_path)
+    lake = paths.get_lake_dir()
+    assert lake == tmp_path / "data" / "metrics_lake"

--- a/tools/dynamodb-optima/tests/database/test_lake.py
+++ b/tools/dynamodb-optima/tests/database/test_lake.py
@@ -37,7 +37,7 @@ def test_write_metrics_partitions_by_region_no_overwrite(tmp_path, monkeypatch):
     lake.write_metrics(rows_w, run_id="run1")
 
     from dynamodb_optima import paths
-    base = paths.get_lake_dir() / "account=111122223333"
+    base = paths.get_lake_dir() / "landing" / "account=111122223333"
     east = list((base / "region=us-east-1" / "table=t").glob("*.parquet"))
     west = list((base / "region=us-west-2" / "table=t").glob("*.parquet"))
     assert len(east) == 1 and len(west) == 1
@@ -101,7 +101,7 @@ def test_write_failure_leaves_no_partial_parquet(tmp_path, monkeypatch):
         lake.write_metrics(rows, run_id="rboom")
 
     from dynamodb_optima import paths
-    part = paths.get_lake_dir() / "account=a" / "region=us-east-1" / "table=t"
+    part = paths.get_lake_dir() / "landing" / "account=a" / "region=us-east-1" / "table=t"
     assert list(part.glob("*.parquet")) == []
     assert list(part.glob("*.tmp")) == []
 
@@ -178,3 +178,25 @@ def test_write_metrics_concurrent_no_data_loss(tmp_path, monkeypatch):
         region = ["us-east-1", "us-west-2", "eu-central-1", "eu-west-1"][i % 4]
         df = lake.read_metrics("acct", region, f"table{i}", s, e)
         assert len(df) == 50, f"table{i} lost data: got {len(df)} rows (view-name collision?)"
+
+
+def test_write_goes_to_landing_zone(tmp_path, monkeypatch):
+    lake = _lake(tmp_path, monkeypatch)
+    ts = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    lake.write_metrics([_row("a", "us-east-1", "t", "m", ts, 1.0)], run_id="r1")
+    from dynamodb_optima import paths
+    landing = paths.get_lake_dir() / "landing" / "account=a" / "region=us-east-1" / "table=t"
+    assert list(landing.glob("*.parquet"))  # write lands in landing/
+
+
+def test_migrate_flat_to_landing_moves_files(tmp_path, monkeypatch):
+    lake = _lake(tmp_path, monkeypatch)
+    from dynamodb_optima import paths
+    flat = paths.get_lake_dir() / "account=a" / "region=us-east-1" / "table=t"
+    flat.mkdir(parents=True)
+    (flat / "ingest_old.parquet").write_bytes(b"stub")
+    lake._migrate_flat_to_landing()
+    moved = paths.get_lake_dir() / "landing" / "account=a" / "region=us-east-1" / "table=t" / "ingest_old.parquet"
+    assert moved.exists()
+    assert not (flat / "ingest_old.parquet").exists()
+    lake._migrate_flat_to_landing()  # idempotent, no error

--- a/tools/dynamodb-optima/tests/database/test_lake.py
+++ b/tools/dynamodb-optima/tests/database/test_lake.py
@@ -200,3 +200,70 @@ def test_migrate_flat_to_landing_moves_files(tmp_path, monkeypatch):
     assert moved.exists()
     assert not (flat / "ingest_old.parquet").exists()
     lake._migrate_flat_to_landing()  # idempotent, no error
+
+
+def _served_files(account, region, table):
+    from dynamodb_optima import paths
+    d = paths.get_lake_dir() / "served" / f"account={account}" / f"region={region}" / f"table={table}"
+    import glob as g
+    return sorted(g.glob(str(d / "*.parquet")))
+
+
+def test_compact_basic_merges_landing_to_served(tmp_path, monkeypatch):
+    lake = _lake(tmp_path, monkeypatch)
+    from datetime import timedelta
+    base = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    for i in range(3):
+        lake.write_metrics([_row("a", "us-east-1", "t", "m", base + timedelta(minutes=i), float(i))], run_id=f"r{i}")
+    lake.compact_partition("a", "us-east-1", "t")
+    assert len(_served_files("a", "us-east-1", "t")) == 1
+    from dynamodb_optima import paths
+    landing = paths.get_lake_dir() / "landing" / "account=a" / "region=us-east-1" / "table=t"
+    import glob as g
+    assert g.glob(str(landing / "*.parquet")) == []
+    df = lake.read_metrics("a", "us-east-1", "t", base, base + timedelta(hours=1))
+    assert len(df) == 3
+
+
+def test_compact_multi_month_creates_two_shards(tmp_path, monkeypatch):
+    lake = _lake(tmp_path, monkeypatch)
+    may = datetime(2026, 5, 15, tzinfo=timezone.utc)
+    jun = datetime(2026, 6, 15, tzinfo=timezone.utc)
+    lake.write_metrics([_row("a", "us-east-1", "t", "m", may, 1.0),
+                        _row("a", "us-east-1", "t", "m", jun, 2.0)], run_id="r1")
+    lake.compact_partition("a", "us-east-1", "t")
+    files = _served_files("a", "us-east-1", "t")
+    assert len(files) == 2
+    assert any("2026-05" in f for f in files) and any("2026-06" in f for f in files)
+
+
+def test_compact_dedup_keeps_latest_ingest_vs_existing_served(tmp_path, monkeypatch):
+    lake = _lake(tmp_path, monkeypatch)
+    ts = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    lake.write_metrics([_row("a", "us-east-1", "t", "m", ts, 100.0)], run_id="r1")
+    lake.compact_partition("a", "us-east-1", "t")
+    lake.write_metrics([_row("a", "us-east-1", "t", "m", ts, 175.0)], run_id="r2")
+    lake.compact_partition("a", "us-east-1", "t")
+    df = lake.read_metrics("a", "us-east-1", "t", ts, ts)
+    assert df["value"].tolist() == [175.0]
+    assert len(_served_files("a", "us-east-1", "t")) == 1
+
+
+def test_compact_ignores_tmp_files(tmp_path, monkeypatch):
+    lake = _lake(tmp_path, monkeypatch)
+    ts = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    lake.write_metrics([_row("a", "us-east-1", "t", "m", ts, 1.0)], run_id="r1")
+    from dynamodb_optima import paths
+    landing = paths.get_lake_dir() / "landing" / "account=a" / "region=us-east-1" / "table=t"
+    (landing / "ingest_inflight.parquet.tmp").write_bytes(b"partial")
+    lake.compact_partition("a", "us-east-1", "t")
+    assert (landing / "ingest_inflight.parquet.tmp").exists()
+
+
+def test_compact_idempotent(tmp_path, monkeypatch):
+    lake = _lake(tmp_path, monkeypatch)
+    ts = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    lake.write_metrics([_row("a", "us-east-1", "t", "m", ts, 1.0)], run_id="r1")
+    lake.compact_partition("a", "us-east-1", "t")
+    lake.compact_partition("a", "us-east-1", "t")
+    assert len(_served_files("a", "us-east-1", "t")) == 1

--- a/tools/dynamodb-optima/tests/database/test_lake.py
+++ b/tools/dynamodb-optima/tests/database/test_lake.py
@@ -46,3 +46,47 @@ def test_write_metrics_partitions_by_region_no_overwrite(tmp_path, monkeypatch):
     w = lake.read_metrics("111122223333", "us-west-2", "t", ts, ts)
     assert e["value"].tolist() == [100.0]
     assert w["value"].tolist() == [200.0]
+
+
+def test_read_metrics_dedups_latest_ingest(tmp_path, monkeypatch):
+    lake = _lake(tmp_path, monkeypatch)
+    ts = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    lake.write_metrics([_row("a", "us-east-1", "t", "m", ts, 100.0)], run_id="run1")
+    lake.write_metrics([_row("a", "us-east-1", "t", "m", ts, 175.0)], run_id="run2")
+    df = lake.read_metrics("a", "us-east-1", "t", ts, ts)
+    assert df["value"].tolist() == [175.0]
+
+
+def test_read_metrics_empty_partition_returns_empty(tmp_path, monkeypatch):
+    lake = _lake(tmp_path, monkeypatch)
+    ts = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    df = lake.read_metrics("nope", "us-east-1", "t", ts, ts)
+    assert df.empty
+
+
+def test_write_failure_leaves_no_partial_parquet(tmp_path, monkeypatch):
+    """A failed COPY must never leave a readable .parquet (only .tmp, cleaned up)."""
+    lake = _lake(tmp_path, monkeypatch)
+    ts = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    rows = [_row("a", "us-east-1", "t", "m", ts, 1.0)]
+
+    class _BoomConn:
+        def register(self, *a, **k): pass
+        def unregister(self, *a, **k): pass
+        def execute(self, sql, *a, **k):
+            raise RuntimeError("boom")
+    class _Ctx:
+        def __enter__(self): return _BoomConn()
+        def __exit__(self, *a): return False
+    class _DB:
+        def get_connection_context(self): return _Ctx()
+
+    monkeypatch.setattr(lake, "get_database_manager", lambda: _DB())
+    import pytest
+    with pytest.raises(RuntimeError):
+        lake.write_metrics(rows, run_id="rboom")
+
+    from dynamodb_optima import paths
+    part = paths.get_lake_dir() / "account=a" / "region=us-east-1" / "table=t"
+    assert list(part.glob("*.parquet")) == []
+    assert list(part.glob("*.tmp")) == []

--- a/tools/dynamodb-optima/tests/database/test_lake.py
+++ b/tools/dynamodb-optima/tests/database/test_lake.py
@@ -90,3 +90,20 @@ def test_write_failure_leaves_no_partial_parquet(tmp_path, monkeypatch):
     part = paths.get_lake_dir() / "account=a" / "region=us-east-1" / "table=t"
     assert list(part.glob("*.parquet")) == []
     assert list(part.glob("*.tmp")) == []
+
+
+def test_latest_timestamps_shape(tmp_path, monkeypatch):
+    lake = _lake(tmp_path, monkeypatch)
+    t1 = datetime(2026, 6, 1, 0, 0, tzinfo=timezone.utc)
+    t2 = datetime(2026, 6, 1, 0, 1, tzinfo=timezone.utc)
+    lake.write_metrics([
+        _row("a", "us-east-1", "t", "ConsumedWriteCapacityUnits", t1, 1.0, stat="Sum", period=60),
+        _row("a", "us-east-1", "t", "ConsumedWriteCapacityUnits", t2, 2.0, stat="Sum", period=60),
+    ], run_id="r1")
+    cov = lake.latest_timestamps("a", "us-east-1", "t")
+    assert cov["ConsumedWriteCapacityUnits:Sum:60"] == t2
+
+
+def test_latest_timestamps_empty(tmp_path, monkeypatch):
+    lake = _lake(tmp_path, monkeypatch)
+    assert lake.latest_timestamps("nope", "us-east-1", "t") == {}

--- a/tools/dynamodb-optima/tests/database/test_lake.py
+++ b/tools/dynamodb-optima/tests/database/test_lake.py
@@ -3,3 +3,46 @@ def test_get_lake_dir_under_data(tmp_path, monkeypatch):
     monkeypatch.setattr(paths, "_project_root_override", tmp_path)
     lake = paths.get_lake_dir()
     assert lake == tmp_path / "data" / "metrics_lake"
+
+
+from datetime import datetime, timezone
+
+
+def _row(account, region, table, metric, ts, value, stat="Sum", period=60):
+    return {
+        "account_id": account, "region": region, "table_name": table,
+        "resource_name": table, "resource_type": "TABLE",
+        "metric_name": metric, "operation": None, "operation_type": None,
+        "statistic": stat, "period_seconds": period,
+        "timestamp": ts, "value": value, "unit": "Count",
+        "dimensions": {"TableName": table},
+    }
+
+
+def _lake(tmp_path, monkeypatch):
+    from dynamodb_optima import paths
+    monkeypatch.setattr(paths, "_project_root_override", tmp_path)
+    import importlib
+    from dynamodb_optima.database import lake as lake_mod
+    importlib.reload(lake_mod)
+    return lake_mod
+
+
+def test_write_metrics_partitions_by_region_no_overwrite(tmp_path, monkeypatch):
+    lake = _lake(tmp_path, monkeypatch)
+    ts = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    rows_e = [_row("111122223333", "us-east-1", "t", "ConsumedWriteCapacityUnits", ts, 100.0)]
+    rows_w = [_row("111122223333", "us-west-2", "t", "ConsumedWriteCapacityUnits", ts, 200.0)]
+    lake.write_metrics(rows_e, run_id="run1")
+    lake.write_metrics(rows_w, run_id="run1")
+
+    from dynamodb_optima import paths
+    base = paths.get_lake_dir() / "account=111122223333"
+    east = list((base / "region=us-east-1" / "table=t").glob("*.parquet"))
+    west = list((base / "region=us-west-2" / "table=t").glob("*.parquet"))
+    assert len(east) == 1 and len(west) == 1
+
+    e = lake.read_metrics("111122223333", "us-east-1", "t", ts, ts)
+    w = lake.read_metrics("111122223333", "us-west-2", "t", ts, ts)
+    assert e["value"].tolist() == [100.0]
+    assert w["value"].tolist() == [200.0]


### PR DESCRIPTION
Replaces the DuckDB `metrics` table with a region-partitioned Parquet **lake**, fixing a correctness bug where Global Table replicas overwrote each other, and adds automatic compaction so metric files don't accumulate unbounded. Also hardens concurrent collection.

## This is a Breaking change !!
- The DuckDB **`metrics` table is removed**; metrics now live in a Parquet lake under `<data>/metrics_lake/{landing,served}/account=/region=/table=/…`. `SCHEMA_VERSION` → **1.1.0**.
- **Any consumer that queried `metrics` via SQL must switch** to the lake read API (`dynamodb_optima.database.lake.read_metrics(...)`) to get a deduped pandas DataFrame.
- The small relational tables (`table_metadata`, `gsi_metadata`, `pricing_data`, recommendations) are **unchanged** and stay in DuckDB (For now!!)
- Existing `.db` files: a one-time migration that runs automatically on first `collect`/`maintain`; historical metrics can also just be re-collected.

As described on #244 and #245, the metrics primary key omitted `region`, so a table replicated across N regions (Global Tables) collided on write, we discovered only the last used (or collected? explored?) region's consumed-capacity data survived (verified: 4 of 5 regions came back near-empty). 

On a different note one of the things that was bothering me the most was the incredible large size for the generated DuckDB. The store had grown to ~6.8 GB for 6 tables × 5 regions, of which **~85% was index/PK overhead, not data** (~400 MB of actual metrics). DuckDB's columnar scan is fast without those indexes (~7 ms over 53M rows).

## Changes
- **Parquet lake (`database/lake.py`):** `write_metrics` / `read_metrics` / `latest_timestamps`, region-correct by construction (region in the partition path + dedup key), DuckDB-native `COPY`/`read_parquet`, atomic `.tmp`→rename writes, UTC-normalized reads.
- **Compaction:** `landing/` (per-run files) → `served/` (`YYYY-MM.parquet` month shards) with per-partition locking, dedup-on-merge, snapshot-delete safety, and self-healing lake-wide scan. This process will run at the end of a `collect`; the change also includes a manual `dynamodb-optima maintain` command. Reads never depend on compaction having run.
- **Scoped discovery:** `discover --tables t1,t2` describes only named tables (DescribeTable per name), skipping the account-wide scan.
- **Concurrency fixes:** thread-safe `get_database_manager()` (was a check-then-act race causing `Catalog write-write conflict` under parallel workers); unique per-write Parquet view names.
- Collectors (`aws/collector.py`) and analyzers (`capacity_mode`, `utilization`) read/write the lake.

## Testing
21 lake unit tests (region-correctness, dedup, compaction, concurrency, migration). Verified end-to-end on a real 6-table × 5-region account: all replicas keep different data; `--workers 4` collection completes with zero failures; incremental re-collection appends new data and compaction merges without loss.

## Not included
No tiering/downsampling of old data yet (compaction is file-merge only). This will get us 1m metrics for longer! Which is always nice for a more in depth analysis, however it risk of having holes on your data, lets say you collect on May 15th, you will get the 1m metrics up to may 1st, Now if you re-run the collection on June 15th, you will have all the days from may 15th onwards with 5 minute metrics. The queries actually include the period to avoid any kind of weird calculations. But it is important to understand this in case there are disconnected collection periods. Compaction locking is local-filesystem; S3 backends would need a different mechanism. 

I have tested for the best of my capacity to avoid deploying errors, however merging this is indeed a breaking change. 